### PR TITLE
Adds Building Releases to CI

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,44 @@
+# This workflow will upload a Python Package using Twine when a release is created
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Publish Release
+
+on:
+  release:
+    types: [published]
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+
+    - name: Build package
+      run: python -m build
+
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@v1.12.4
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
**TODO** for @pwhofman: You need to add a valid [PyPI secrets token to your repository](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication) and call `PYPI_API_TOKEN`.

This pull request introduces a new GitHub Actions workflow to automate the publishing of a Python package upon the creation of a release. The most important changes include setting up the workflow configuration, defining the job steps, and specifying the necessary permissions.

New GitHub Actions workflow:

* [`.github/workflows/publish-release.yml`](diffhunk://#diff-232ead425069ad86b523a739aa18b77f9088cd61a4b40c6a374d9774ff78cfc8R1-R44): Added a new workflow that triggers on release creation, sets up the Python environment, installs dependencies, builds the package, and publishes it to PyPI using Twine.