### PR TITLE
adds a new github workflow checking if the install works

### DIFF
--- a/.github/workflows/install-import.yml
+++ b/.github/workflows/install-import.yml
@@ -24,4 +24,4 @@ jobs:
         run: uv pip install .
 
       - name: Test import
-        run: uv run python -c "import importlib.metadata; import probly; print(importlib.metadata.version("probly")); print('✅ probly imported successfully')"
+        run: uv run python -c "import probly; print('✅ probly imported successfully')"


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the installation and import testing of the `probly` package. The workflow is triggered on pushes and pull requests to the `main` branch.

Key changes include:

* Added a new GitHub Actions workflow file `.github/workflows/install-import.yml` to handle the installation and import testing of the `probly` package.
* The workflow uses `ubuntu-latest` as the runner and includes steps to checkout the code, install `uv` and Python 3.11, install the package using `uv`, and run a test import to verify successful installation and import of `probly`.

Changes in the future. We should actually import something from `probly` and run something to see that it actually works.