### PR TITLE
Fix coverage report upload to only trigger for main repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
             -   name: Measure coverage
                 run: uv run --no-sync pytest "tests/probly" --cov=probly --cov-report=xml
             -   name: Upload coverage to codecov
-                if: ${{ github.repository == 'pwhofman/probly' }}
+                if: ${{ github.repository == 'pwhofman/probly' }} # Only upload reports for main repo and not forks
                 uses: codecov/codecov-action@v5
                 with:
                     token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Issue
#192

## Motivation and Context
We were trying to always upload the code report, also in e.g. forks. This fix makes it so that coverage reports are only uploaded for this repo and when the secret exists.
---

## Public API Changes

-   [x] No Public API changes
-   [ ] Yes, Public API changes (Details below)

---

## How Has This Been Tested?

---

## Checklist

-   [x] The changes have been tested locally.
-   [ ] Documentation has been updated (if the public API or usage changes).
-   [ ] A entry has been added to [`CHANGELOG.md`](https://github.com/pwhofman/probly/blob/main/CHANGELOG.md) (if relevant for users).
-   [x] The code follows the project's [style guidelines](https://github.com/pwhofman/probly/blob/main/.github/CONTRIBUTING.md) and passes minimal code style checks.
-   [x] I have considered the impact of these changes on the public API.

---
