### PR TITLE
21 Coders : Added Dropout Tutorial Notebook

### DIFF
--- a/notebooks/examples/dropout_tutorial.ipynb
+++ b/notebooks/examples/dropout_tutorial.ipynb
@@ -1,0 +1,608 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "bc1aee1c",
+   "metadata": {},
+   "source": [
+    "# An Introduction To Dropout As A Bayesian Aproximation With Probly\n",
+    "\n",
+    "This Notebook aims to be a short introduction into Dropout and its use for uncertainty quantification in neural networks."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a8df74b8",
+   "metadata": {},
+   "source": [
+    "## 0. Motivation and Intuition\n",
+    "\n",
+    "When training a neural network, we often face a problem called \"Overfitting\". This is where the model becomes so good at memorizing the training data, that it performs poorly on new data. This happens because the network learns to rely too much on specific neurons or patterns that don't generalize.\n",
+    "This is where the dropout operation comes in handy. \n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a23255ad",
+   "metadata": {},
+   "source": [
+    "## 1. What is Dropout?\n",
+    "\n",
+    "The idea is to insert layers into a model, that have a certain chance to \"drop out\" or disable neurons in that layer, thus creating a slightly different output every time the network makes a prediction.\n",
+    "For our purposes we can use dropout, to evaluate how certain a model is about its inference."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b0a91cc9",
+   "metadata": {},
+   "source": [
+    "![Dropout Image](https://www.baeldung.com/wp-content/uploads/sites/4/2020/05/2-1-2048x745-1.jpg)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7ef4fcdd",
+   "metadata": {},
+   "source": [
+    "As shown above, some of the neurons in the dropout layer have been deactivated, therefore we have a sub-model that will give us a different output than the original model for the same input.  \n",
+    "Which neurons get deactivated will be decided by chance, every time we generate an output. That chance is called the dropout-rate and can be configured manually."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5b3378b6",
+   "metadata": {},
+   "source": [
+    "## 2. Dropout and Model Confidence\n",
+    "\n",
+    "Usually dropout would not be used in inference but only in the training process, if you want to deal with overfitting. But we want to keep it active in the inference process, to calculate uncertainty.  \n",
+    "  \n",
+    "If we give the model the same input for several forward passes, we can look at how much the outputs of the model differ in certain points and with that information, we can make assumptions about the epistemic uncertainty of the model in that specific point. The less variance in the outputs for the same input, the less uncertainty and vice versa. This approach is often referred to as Monte Carlo Dropout.\n",
+    "\n",
+    "This Monte Carlo Dropout is an approximation to the behavior of a bayesian neural network, with the advantage of being significantly more efficient. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d8079621",
+   "metadata": {},
+   "source": [
+    "## 3. How can Probly help?\n",
+    "\n",
+    "The dropout transformation in Probly takes a standard model and transforms it into a dropout-enabled model, that can be used to quantify uncertainty. This is achieved by traversing every layer in the regular model and prepending a dropout layer for every linear layer, except for the model's first layer. This dropout-enabled model can then be extended to a Monte Carlo Dropout as explained above."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5de50db3",
+   "metadata": {},
+   "source": [
+    "## 4. Implementation of Dropout with Probly"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "278ffa97",
+   "metadata": {},
+   "source": [
+    "### 4.1 Using Probly's `dropout` function to transform a model\n",
+    "\n",
+    "Let's implement a simple linear model in PyTorch!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "a8774635",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from torch import nn\n",
+    "\n",
+    "simple_model = nn.Sequential(\n",
+    "        nn.Linear(2, 2),\n",
+    "        nn.Linear(2, 2),\n",
+    "        nn.Linear(2, 2),\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "035be67f",
+   "metadata": {},
+   "source": [
+    "Here we defined a simple model in torch that has three linear layers.  \n",
+    "  \n",
+    "At the moment we can't make any statements about its epistemic uncertainty, but we can use dropout layers to enable us to do so.  \n",
+    "  \n",
+    "With Probly inserting the dropout layers becomes very easy,\n",
+    "all we have to do is import the transformation function `dropout` and apply it to the model. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "7ca11d34",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from probly.transformation import dropout\n",
+    "\n",
+    "dropout_model = dropout(simple_model)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ed7baeef",
+   "metadata": {},
+   "source": [
+    "Now our simple model has been converted to a fully functional dropout model.\n",
+    "  \n",
+    "We would expect that before every linear layer except for the first one a dropout layer has been added to the model, without changing anything else.  \n",
+    "\n",
+    "We can subsequently print out the sturcture of our new Dropout-model to verify this: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "0dddef41",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sequential(\n",
+      "  (0): Linear(in_features=2, out_features=2, bias=True)\n",
+      "  (1_0): Dropout(p=0.25, inplace=False)\n",
+      "  (1_1): Linear(in_features=2, out_features=2, bias=True)\n",
+      "  (2_0): Dropout(p=0.25, inplace=False)\n",
+      "  (2_1): Linear(in_features=2, out_features=2, bias=True)\n",
+      ")\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(dropout_model)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e3030a44",
+   "metadata": {},
+   "source": [
+    "As you can see, probly took care of inserting the dropout layers with one simple function call. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bd62fef3",
+   "metadata": {},
+   "source": [
+    "### 4.2 Specifying the Dropout-rate\n",
+    "\n",
+    "If we don't specify a Dropout-rate when transforming our model, probly will give every dropout layer a standard probability of 0.25.\n",
+    "\n",
+    "To specify the Dropout-rate we can pass it as the second argument to the `dropout` function.\n",
+    "\n",
+    "Now let's transform our model again with a custom probability."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90039919",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sequential(\n",
+      "  (0): Linear(in_features=2, out_features=2, bias=True)\n",
+      "  (1_0): Dropout(p=0.5, inplace=False)\n",
+      "  (1_1): Linear(in_features=2, out_features=2, bias=True)\n",
+      "  (2_0): Dropout(p=0.5, inplace=False)\n",
+      "  (2_1): Linear(in_features=2, out_features=2, bias=True)\n",
+      ")\n"
+     ]
+    }
+   ],
+   "source": [
+    "custom_dropout_rate = 0.5\n",
+    "dropout_model = dropout(simple_model, custom_dropout_rate)\n",
+    "\n",
+    "print(dropout_model)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a51de00a",
+   "metadata": {},
+   "source": [
+    "As expected every dropout layer has the specified dropout-chance of 0.5."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "25e51f5b",
+   "metadata": {},
+   "source": [
+    "### 4.3 Other models...\n",
+    "\n",
+    "Naturally this also works for every other model that a dropout-transformation makes sense for.  \n",
+    "\n",
+    "Let's try it with a convolutional model next."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "b5988554",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sequential(\n",
+      "  (0): Conv2d(3, 5, kernel_size=(5, 5), stride=(1, 1))\n",
+      "  (1): ReLU()\n",
+      "  (2): Flatten(start_dim=1, end_dim=-1)\n",
+      "  (3_0): Dropout(p=0.2, inplace=False)\n",
+      "  (3_1): Linear(in_features=5, out_features=2, bias=True)\n",
+      ")\n"
+     ]
+    }
+   ],
+   "source": [
+    "conv_model = nn.Sequential(\n",
+    "        nn.Conv2d(3, 5, 5),\n",
+    "        nn.ReLU(),\n",
+    "        nn.Flatten(),\n",
+    "        nn.Linear(5, 2),\n",
+    "    )\n",
+    "\n",
+    "dropout_conv_model = dropout(conv_model, 0.2)\n",
+    "\n",
+    "print(dropout_conv_model)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e9b557ba",
+   "metadata": {},
+   "source": [
+    "Like with our simple model, probly inserted the dropout layer into our convolutional model without us even needing to use a different function.\n",
+    "\n",
+    "As expected, the Dropout-layer is only added before the single linear layer."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "80841df0",
+   "metadata": {},
+   "source": [
+    "### 4.4 And other Frameworks?\n",
+    "\n",
+    "That's cool and all, but what if we wanted to use a framework other than torch?  \n",
+    "  \n",
+    "No problem! Probly aims to be unbound by any specific framework or library, so lets see if we can transform some models implemented in flax."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7473aa01",
+   "metadata": {},
+   "source": [
+    "So lets implement a small linear model in flax..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "17b8b158",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from flax import nnx\n",
+    "\n",
+    "flax_rngs = nnx.Rngs(0)\n",
+    "\n",
+    "simple_model_flax = nnx.Sequential(\n",
+    "        nnx.Linear(2, 2, rngs=flax_rngs),\n",
+    "        nnx.Linear(2, 2, rngs=flax_rngs),\n",
+    "        nnx.Linear(2, 2, rngs=flax_rngs),\n",
+    "    )\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f0239f56",
+   "metadata": {},
+   "source": [
+    "As before with torch, we defined a simple linear model with three linear layers in flax.  \n",
+    "Now we can try transforming it with probly's transformation function `dropout`..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "id": "441e2311",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dropout_model_flax = dropout(simple_model_flax)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d4c8ced7",
+   "metadata": {},
+   "source": [
+    "To confirm everything went as expected we create a short function that prints out the layers in a flax model without all the information that is unimportant to us right now.  \n",
+    "It simply goes through the structure of the network and prints out what kind of layers are contained in it:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ce643904",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def print_layers(module, indent=0):\n",
+    "    for name, attr in module.__dict__.items():\n",
+    "        if isinstance(attr, nnx.Module):\n",
+    "            print(\" \" * indent + f\"{name}: {attr.__class__.__name__}\")\n",
+    "            print_layers(attr, indent + 2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7006a5aa",
+   "metadata": {},
+   "source": [
+    "And now we can look at the result of our transformation:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "id": "58d2f9a9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "layers: List\n",
+      "  0: Linear\n",
+      "  1: Dropout\n",
+      "  2: Linear\n",
+      "  3: Dropout\n",
+      "  4: Linear\n"
+     ]
+    }
+   ],
+   "source": [
+    "print_layers(dropout_model_flax)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c56086b1",
+   "metadata": {},
+   "source": [
+    "Now let us try it one more time with a convolutional model implemented in flax.\n",
+    "For that we just define a small convolutional model like we did in torch before: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "id": "05589d73",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "layers: List\n",
+      "  0: Conv\n",
+      "  3: Dropout\n",
+      "  4: Linear\n"
+     ]
+    }
+   ],
+   "source": [
+    "conv_model_flax = nnx.Sequential(\n",
+    "        nnx.Conv(3, 5, (5, 5), rngs=flax_rngs),\n",
+    "        nnx.relu,\n",
+    "        nnx.flatten,\n",
+    "        nnx.Linear(5, 2, rngs=flax_rngs),\n",
+    "    )\n",
+    "\n",
+    "dropout_conv_model_flax = dropout(conv_model_flax)\n",
+    "print_layers(dropout_conv_model_flax)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "659a3c1c",
+   "metadata": {},
+   "source": [
+    "As anticipated, Probly can work with different kinds of models built with different frameworks without the need for seperate functions to handle their differences. \n",
+    "Likewise we can specify the dropout-rate by passing it as the second argument. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0dc5675c",
+   "metadata": {},
+   "source": [
+    "### 4.5 A quick look at some output\n",
+    "\n",
+    "At last we want to look at some output generated by a model implementing dropout as a bayesian aproximation for the quantification of uncertainty.\n",
+    "\n",
+    "Note that these examples are made with untrained models and are only intended to demonstrate what we could do with those transformed models.  \n",
+    "  \n",
+    "For our example we will implement a small model with torch and transform it:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 67,
+   "id": "f6f9a17d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sequential(\n",
+      "  (0): Linear(in_features=2, out_features=2, bias=True)\n",
+      "  (1): ReLU()\n",
+      "  (2_0): Dropout(p=0.3, inplace=False)\n",
+      "  (2_1): Linear(in_features=2, out_features=1, bias=True)\n",
+      ")\n"
+     ]
+    }
+   ],
+   "source": [
+    "demo_model = nn.Sequential(\n",
+    "    nn.Linear(2, 2),\n",
+    "    nn.ReLU(),\n",
+    "    nn.Linear(2, 1)\n",
+    ")\n",
+    "\n",
+    "demo_dropout_model = dropout(demo_model, 0.3)\n",
+    "\n",
+    "print(demo_dropout_model)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0e8c2d0e",
+   "metadata": {},
+   "source": [
+    "Now that we have transformed our model we can proceed with:\n",
+    "1. Generating some random input for the model\n",
+    "2. Setting the model to train since we want to keep the dropout layer active\n",
+    "3. Analysing the output"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "73b15a09",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[0.312858909368515, 0.27893561124801636, 0.27893561124801636, 0.312858909368515, 0.27893561124801636, 0.27893561124801636, 0.27893561124801636, 0.27893561124801636]\n"
+     ]
+    }
+   ],
+   "source": [
+    "from torch import randn, no_grad\n",
+    "\n",
+    "# generates a random input for the model\n",
+    "input = randn(1, 2)\n",
+    "output = []\n",
+    "\n",
+    "demo_dropout_model.eval()\n",
+    "# Set only dropout layers to train to keep them active\n",
+    "for m in demo_dropout_model.modules():\n",
+    "    if isinstance(m, nn.Dropout):\n",
+    "        m.train()\n",
+    "\n",
+    "\n",
+    "# pass the input to the model for a few times\n",
+    "with no_grad():\n",
+    "    for _ in range(8):\n",
+    "        x = demo_dropout_model(input)\n",
+    "        output.append(x.item())\n",
+    "\n",
+    "print(output)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7ce9cb4d",
+   "metadata": {},
+   "source": [
+    "We can see that the output is not always the same if we run this multiple times.  \n",
+    "Now we will calculate the output variance with numpy: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 117,
+   "id": "14faf508",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The output has a variance of 0.0002157731541322927\n"
+     ]
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "variance = np.var(output)\n",
+    "print(f\"The output has a variance of {variance}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10438f53",
+   "metadata": {},
+   "source": [
+    "This variance is what gives us information about input uncertainty in that input point.\n",
+    "\n",
+    "You might ask why the variance in this example is so low. That is caused by the fact that we did not train the model in any shape or form and it is just \"uniformly bad\" at predicting anything.  \n",
+    "\n",
+    "A quick training would probably suffice to generate a bigger variance.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "75e2217e",
+   "metadata": {},
+   "source": [
+    "#### This concludes the introduction to probly's Dropout function.\n",
+    "\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "probly_uv",
+   "language": "python",
+   "name": "probly_uv"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Issue
[Add Tutorial Notebook for Transformation](https://github.com/Cortys/SEP-Probly-WS2526/issues/14)
https://github.com/pwhofman/probly/pull/180

## Motivation and Context
This PR addresses the Dropout Tutorial (issue #[14](https://github.com/Cortys/SEP-Probly-WS2526/issues/14)) for the Transformation Cortys/SEP-Probly-WS2526 project. 
Following the feedback from the previous PR, this notebook has been revised and prepared as a standalone contribution. 

---

## Public API Changes

-   [x] No Public API changes
-   [ ] Yes, Public API changes (Details below)

---

## How Has This Been Tested?

The notebook was run from start to finish in a Jupyter environment.
All code cells execute without errors.
Output examples and figures were verified to match expected behavior for dropout layers in neural networks.

---

## Checklist

-   [ ] The changes have been tested locally.
-   [ ] Documentation has been updated (if the public API or usage changes).
-   [ ] A entry has been added to [`CHANGELOG.md`](https://github.com/pwhofman/probly/blob/main/CHANGELOG.md) (if relevant for users).
-   [ ] The code follows the project's [style guidelines](https://github.com/pwhofman/probly/blob/main/.github/CONTRIBUTING.md) and passes minimal code style checks.
-   [ ] I have considered the impact of these changes on the public API.

---
