### PR TITLE
ProblyWrong: Evidential classification (Cortys/SEP-Probly-WS2526#8)

### DIFF
--- a/tests/probly/transformation/evidential/classification/__init__.py
+++ b/tests/probly/transformation/evidential/classification/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the classification module."""

--- a/tests/probly/transformation/evidential/classification/test_common.py
+++ b/tests/probly/transformation/evidential/classification/test_common.py
@@ -1,0 +1,39 @@
+"""Tests for evidential classification registration and dispatch."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, cast
+
+from probly.transformation.evidential.classification.common import (
+    evidential_classification,
+    register,
+)
+
+
+def test_multiple_types_are_handled_independently() -> None:
+    class ModelA:
+        def __init__(self, mid: str) -> None:
+            self.id = mid
+
+    class ModelB:
+        def __init__(self, mid: str) -> None:
+            self.id = mid
+
+    def appender_a(base: ModelA) -> str:
+        return f"A_Enhanced({base.id})"
+
+    def appender_b(base: ModelB) -> str:
+        return f"B_Enhanced({base.id})"
+
+    register(ModelA, cast(Callable[..., object], appender_a))
+    register(ModelB, cast(Callable[..., object], appender_b))
+
+    a = ModelA("001")
+    b = ModelB("002")
+
+    result_a = evidential_classification(cast(Any, a))
+    result_b = evidential_classification(cast(Any, b))
+
+    assert cast(str, result_a) == "A_Enhanced(001)"
+    assert cast(str, result_b) == "B_Enhanced(002)"

--- a/tests/probly/transformation/evidential/classification/test_torch.py
+++ b/tests/probly/transformation/evidential/classification/test_torch.py
@@ -1,0 +1,65 @@
+"""Test for torch classification models."""
+
+from __future__ import annotations
+
+from torch import nn
+
+from probly.transformation.evidential.classification.common import (
+    evidential_classification,
+)
+from tests.probly.torch_utils import count_layers
+
+
+def test_evidential_classification_appends_softplus_on_linear(torch_model_small_2d_2d: nn.Sequential) -> None:
+    model = evidential_classification(torch_model_small_2d_2d)
+
+    # count number of nn.Linear layers in original model
+    count_linear_original = count_layers(torch_model_small_2d_2d, nn.Linear)
+    # count number of softplus layers in original model
+    count_softplus_original = count_layers(torch_model_small_2d_2d, nn.Softplus)
+    # count number of nn.Sequential layers in original model
+    count_sequential_original = count_layers(torch_model_small_2d_2d, nn.Sequential)
+
+    # count number of nn.Linear layers in modified model
+    count_linear_modified = count_layers(model, nn.Linear)
+    # count number of softplus layers in modified model
+    count_softplus_modified = count_layers(model, nn.Softplus)
+    # count number of nn.Sequential layers in modified model
+    count_sequential_modified = count_layers(model, nn.Sequential)
+
+    # check that the model is not modified except for the softplus layer at the end of the new sequence layer
+    assert model is not None
+    assert isinstance(model, type(torch_model_small_2d_2d))
+    assert count_linear_original == count_linear_modified
+    assert count_softplus_original == (count_softplus_modified - 1)
+    assert count_sequential_original == (count_sequential_modified - 1)
+
+
+def test_evidential_classification_appends_softplus_on_conv(torch_conv_linear_model: nn.Sequential) -> None:
+    model = evidential_classification(torch_conv_linear_model)
+
+    # count number of nn.Linear layers in original model
+    count_linear_original = count_layers(torch_conv_linear_model, nn.Linear)
+    # count number of softplus layers in original model
+    count_softplus_original = count_layers(torch_conv_linear_model, nn.Softplus)
+    # count number of nn.Sequential layers in original model
+    count_sequential_original = count_layers(torch_conv_linear_model, nn.Sequential)
+    # count number of nn.Conv2d layers in original model
+    count_conv_original = count_layers(torch_conv_linear_model, nn.Conv2d)
+
+    # count number of nn.Linear layers in modified model
+    count_linear_modified = count_layers(model, nn.Linear)
+    # count number of softplus layers in modified model
+    count_softplus_modified = count_layers(model, nn.Softplus)
+    # count number of nn.Sequential layers in modified model
+    count_sequential_modified = count_layers(model, nn.Sequential)
+    # count number of nn.Conv2d layers in modified model
+    count_conv_modified = count_layers(model, nn.Conv2d)
+
+    # check that the model is not modified except for the softplus layer at the end of the new sequence layer
+    assert model is not None
+    assert isinstance(model, type(torch_conv_linear_model))
+    assert count_linear_original == count_linear_modified
+    assert count_softplus_original == (count_softplus_modified - 1)
+    assert count_sequential_original == (count_sequential_modified - 1)
+    assert count_conv_original == count_conv_modified


### PR DESCRIPTION
## Issue
Evidential Classification Tests from Issue (https://github.com/Cortys/SEP-Probly-WS2526/issues/8).

## Motivation and Context
This PR addresses and closes Issue 8.

The original work for this feature was part of a larger, closed Pull Request. As requested, this PR isolates the implementation of the Evidential Classification Test to allow for independent merging into probly/main.

This addition ensures that the Evidential Classification functionality is properly tested and verified, improving code quality and stability.

## Public API Changes

-   [ ] No Public API changes
-   [x] Yes, Public API changes (Details below)

---

## How Has This Been Tested?
Tests run via Cl Pipeline

## Checklist

-   [x] The changes have been tested locally.
-   [ ] Documentation has been updated (if the public API or usage changes).
-   [ ] A entry has been added to [`CHANGELOG.md`](https://github.com/pwhofman/probly/blob/main/CHANGELOG.md) (if relevant for users).
-   [x] The code follows the project's [style guidelines](https://github.com/pwhofman/probly/blob/main/.github/CONTRIBUTING.md) and passes minimal code style checks.
-   [x] I have considered the impact of these changes on the public API.

---
