### PR TITLE
removed mypy from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,10 +148,6 @@ jobs:
                uv run ruff check .
                uv run ruff format --check .
 
-        -   name: Run MyPy Static Type Check
-            run: |
-               uv run mypy src/
-
         -   name: Execute Unit Tests and Measure Coverage
             run: |
                uv run pytest --cov=src/probly --cov-report=xml


### PR DESCRIPTION
## Issue
N/A

## Motivation and Context

due to a large number of mypy warnings on main including the failing mypy checks in the CI pipeline is not longer helpful for ensuring code quality.

type checks will be re-added to CI once the migration to ty has been completed (see #272)

---

## Public API Changes

-   [x] No Public API changes
-   [ ] Yes, Public API changes (Details below)

---

## How Has This Been Tested?
See CI of this PR

---

## Checklist

-   [ ] The changes have been tested locally.
-   [ ] Documentation has been updated (if the public API or usage changes).
-   [ ] A entry has been added to [`CHANGELOG.md`](https://github.com/pwhofman/probly/blob/main/CHANGELOG.md) (if relevant for users).
-   [x] The code follows the project's [style guidelines](https://github.com/pwhofman/probly/blob/main/.github/CONTRIBUTING.md) and passes minimal code style checks.
-   [x] I have considered the impact of these changes on the public API.

---
