### PR TITLE
Distribution representations QDT

### DIFF
--- a/src/probly/representation/distribution/array_dirichlet.py
+++ b/src/probly/representation/distribution/array_dirichlet.py
@@ -105,7 +105,7 @@ class ArrayDirichlet(
 
         return log_beta + digamma_sum - digamma_individual  # type: ignore[no-any-return]
 
-    def num_sample(
+    def sample(
         self,
         num_samples: int = 1,
         rng: np.random.Generator | None = None,

--- a/src/probly/representation/distribution/array_gaussian.py
+++ b/src/probly/representation/distribution/array_gaussian.py
@@ -13,8 +13,6 @@ from probly.representation.sampling.array_sample import ArraySample
 if TYPE_CHECKING:
     from numpy.typing import ArrayLike, DTypeLike
 
-rng = np.random.default_rng()
-
 
 @dataclass(frozen=True, slots=True, weakref_slot=True)
 class ArrayGaussian(GaussianDistribution):
@@ -67,7 +65,7 @@ class ArrayGaussian(GaussianDistribution):
         return 0.5 * np.log(2 * np.e * np.pi * var)
 
     @override
-    def num_sample(
+    def sample(
         self,
         num_samples: int = 1,
         rng: np.random.Generator | None = None,

--- a/src/probly/representation/distribution/common.py
+++ b/src/probly/representation/distribution/common.py
@@ -24,7 +24,7 @@ class Distribution(ABC):
         """Compute entropy."""
 
     @abstractmethod
-    def num_sample(self, num_samples: int) -> Sample[Any]:
+    def sample(self, num_samples: int) -> Sample[Any]:
         """Draw samples from Distribution."""
 
 

--- a/src/probly/representation/distribution/mixture_dirichlet.py
+++ b/src/probly/representation/distribution/mixture_dirichlet.py
@@ -101,9 +101,9 @@ class ArrayDirichletMixture:
             weights=self.weights,
         )
 
-    def num_sample(
+    def sample(
         self,
-        num_samples: int = 1,
+        num_samples: int,
         rng: np.random.Generator | None = None,
     ) -> ArraySample:
         """Sample from the mixture.

--- a/src/probly/representation/distribution/mixture_gaussian.py
+++ b/src/probly/representation/distribution/mixture_gaussian.py
@@ -17,9 +17,6 @@ if TYPE_CHECKING:
     from probly.representation.distribution.array_gaussian import ArrayGaussian
 
 
-rng = np.random.default_rng()
-
-
 @dataclass(frozen=True, slots=True, weakref_slot=True)
 class ArrayGaussianMixture:
     """Gaussian mixture."""
@@ -86,8 +83,15 @@ class ArrayGaussianMixture:
             weights=self.weights,
         )
 
-    def num_sample(self, num_samples: int) -> ArraySample:
+    def sample(
+        self,
+        num_samples: int,
+        rng: np.random.Generator | None = None,
+    ) -> ArraySample:
         """Draw samples from the Gaussian mixture. Returns an ArraySample."""
+        if rng is None:
+            rng = np.random.default_rng()
+
         k = len(self.components)
         weights = self.weights
 
@@ -104,7 +108,7 @@ class ArrayGaussianMixture:
             if num_samples_for_component == 0:
                 continue
 
-            samples_for_component = component.sample(num_samples_for_component).array
+            samples_for_component = component.sample(num_samples_for_component, rng=rng).array
             result[indices_for_component] = samples_for_component
 
         return ArraySample(array=result, sample_axis=0)

--- a/tests/probly/representation/distribution/test_dirichlet.py
+++ b/tests/probly/representation/distribution/test_dirichlet.py
@@ -162,7 +162,7 @@ def test_sample_function_dirichlet() -> None:
     dist = ArrayDirichlet(np.ones(shape))
 
     n_samples = 4
-    samples = dist.num_sample(n_samples)
+    samples = dist.sample(n_samples)
 
     assert isinstance(samples, ArraySample)
     assert samples.array.shape == (n_samples, *shape)
@@ -174,7 +174,7 @@ def test_sample_simplex_constraints() -> None:
     dist = ArrayDirichlet(np.array([1.0, 2.0, 3.0]))
 
     n_samples = 5000
-    sample_wrapper = dist.num_sample(n_samples)
+    sample_wrapper = dist.sample(n_samples)
     samples = sample_wrapper.array
 
     assert np.all(samples >= 0.0)
@@ -187,7 +187,7 @@ def test_sample_statistics_dirichlet_var() -> None:
     dist = ArrayDirichlet(alphas)
 
     n_samples = 300000
-    sample_wrapper = dist.num_sample(n_samples)
+    sample_wrapper = dist.sample(n_samples)
     samples = sample_wrapper.array
 
     a0 = alphas.sum()

--- a/tests/probly/representation/distribution/test_gaussian.py
+++ b/tests/probly/representation/distribution/test_gaussian.py
@@ -103,7 +103,7 @@ def test_sample_function() -> None:
     dist = ArrayGaussian(np.zeros(shape), np.ones(shape))
 
     n_samples = 4
-    samples = dist.num_sample(n_samples)
+    samples = dist.sample(n_samples)
 
     assert isinstance(samples, ArraySample)
     assert samples.array.shape == (n_samples, *shape)
@@ -117,7 +117,7 @@ def test_sample_statistics() -> None:
     dist = ArrayGaussian(np.array([mean_val]), np.array([var_val]))
 
     n_samples = 100000
-    sample_wrapper = dist.num_sample(n_samples)
+    sample_wrapper = dist.sample(n_samples)
     samples = sample_wrapper.array
 
     assert np.mean(samples) == pytest.approx(mean_val, abs=0.05)


### PR DESCRIPTION
## ✨ NumPy array-based Distribution Representation (Gaussian / Dirichlet / Mixtures)

### Motivation
Following the recent Representation Logic rework in **probly**, we are moving away from custom container objects and toward **plain array-based representations** (NumPy / Torch / JAX).  
This PR modernizes the **Distribution Representation** for the **NumPy backend**, ensuring distribution parameters and returned objects behave like natural NumPy arrays (shape/dtype/indexing/etc.) and remain easy to understand for users.

### Scope
- **NumPy backend only** (Torch/Flax/JAX are explicitly out of scope for this PR)
- Array-first semantics aligned with `ArraySample`

---

## What’s included

### ✅ GaussianDistribution (NumPy)
- Stores `mean` and `variance` as plain `np.ndarray`
- Validates:
  - shape compatibility between `mean` and `variance`
  - strictly positive variances
- Provides NumPy interoperability:
  - NumPy-like `shape`/`dtype` behavior
  - `np.asarray(dist)` returns the mean (consistent with `ArraySample`)
- Indexing / slicing returns valid `Distribution` objects (not raw arrays)

### ✅ DirichletDistribution (NumPy)
- Implemented as a specialization of `ArrayDistribution`
- Stores parameters as plain `np.ndarray` (`alpha`)
- Validates:
  - `alpha` is a numpy ndarray
  - `alpha` values are strictly positive
  - `alpha.ndim >= 1`
- Statistical methods:
  - `mean()`
  - `var()` (element-wise variance, no covariance matrix)
- Indexing:
  - operates over batch dimensions
  - preserves the last axis as the category dimension
- `entropy()` raises `NotImplementedError` (by design)

### ✅ Mixture distributions (Gaussian + Dirichlet)
- Implements mixture distributions with:
  - component distributions (Gaussian or Dirichlet)
  - mixing weights that sum to 1
- Supports:
  - batch operations
  - indexing
  - **sampling** (required for mixtures)

### ✅ Sampling integration
- Implements `sample()` in:
  - `array_gaussian`
  - `array_dirichlet`
- Ensures `Distribution.sample()` returns `ArraySample`

---

## Tests

### ✅ GaussianDistribution tests
- Construction with valid numpy arrays
- Validation errors:
  - shape mismatch between means and variances
  - non-positive variances
- Correctness of:
  - `mean()`
  - `var()`
  - `entropy()`
- Indexing / slicing behavior
- Immutability (object remains unchanged after operations)
- `np.asarray(dist)` conversion returns the mean

### ✅ DirichletDistribution tests
- Construction with valid alpha arrays
- Validation errors:
  - non-positive alpha values
  - invalid dimensions
- Correctness of:
  - `mean()`
  - `var()` (element-wise)
- Indexing over batch dimensions:
  - preserves the category axis
- `entropy()` raises `NotImplementedError`

---

## Design notes
- **No custom containers**: parameters are plain NumPy arrays
- **Array semantics first**: shape/dtype/indexing behave like NumPy
- **Consistency**: implementation aligns stylistically with `ArraySample`

---

## Non-goals
- Posterior updates / conjugacy logic
- Categorical distributions
- Log-probability computation
- Full entropy implementation for Dirichlet
- Torch / JAX backend support and tests

---

## How to test
- `pytest`
- or selectively: `pytest -k "gaussian or dirichlet or mixture"`