### PR TITLE
[Problym-Löser]Add notebook: transformations comparison

### DIFF
--- a/docs/source/notebooks/examples/index.rst
+++ b/docs/source/notebooks/examples/index.rst
@@ -23,3 +23,4 @@ Notebook Examples
    train_bnn_classification
    train_evidential_classification
    train_evidential_regression
+   transformations_comparison

--- a/docs/source/notebooks/examples/transformations_comparison.ipynb
+++ b/docs/source/notebooks/examples/transformations_comparison.ipynb
@@ -1,0 +1,1085 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a9954231",
+   "metadata": {},
+   "source": [
+    "# Transformation Comparison: Dropout vs DropConnect vs Ensemble vs Bayesian vs Evidential (PyTorch)\n",
+    "\n",
+    "*Date:* 2026-01-29\n",
+    "\n",
+    "**Audience:** Users who already looked at the individual transformation notebooks  \n",
+    "**Framework:** PyTorch  \n",
+    "**Goal:** Compare predictive uncertainty behavior on the same 1D regression setup.\n",
+    "\n",
+    "## What this notebook does\n",
+    "- trains the same base MLP under different `probly.transformation` methods\n",
+    "- compares RMSE (against noise-free ground truth)\n",
+    "- compares NLL in-domain vs OOD\n",
+    "- plots predictive mean ± 2 std\n",
+    "- for evidential: decomposes aleatoric vs epistemic\n",
+    "\n",
+    "## What this notebook does NOT do\n",
+    "- does not claim best hyperparameters or best performance\n",
+    "- is not a benchmark, just a reproducible sanity-check style comparison\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "b5b3e739",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import math\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import torch\n",
+    "\n",
+    "from probly.transformation.bayesian import bayesian\n",
+    "from probly.transformation.dropconnect import dropconnect\n",
+    "from probly.transformation.dropout import dropout\n",
+    "from probly.transformation.ensemble import ensemble\n",
+    "from probly.transformation.evidential.regression import evidential_regression"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "8249d4c8",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "device(type='cpu')"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "torch.manual_seed(0)\n",
+    "np.random.seed(0)\n",
+    "\n",
+    "device = torch.device(\"cpu\")\n",
+    "device"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "8166adb1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "CFG = {\n",
+    "    \"seed\": 0,\n",
+    "    \"epochs\": 500,\n",
+    "    \"mc_samples\": 75,\n",
+    "    \"ensemble_members\": 3,\n",
+    "    \"ensemble_epochs\": 500,\n",
+    "    \"evidential_epochs\": 800,\n",
+    "    \"verbose_every\": 0,\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "0c5a1586",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Using base model factory: make_torch_regression_model_1d\n"
+     ]
+    }
+   ],
+   "source": [
+    "from collections.abc import Callable\n",
+    "\n",
+    "from torch import nn\n",
+    "\n",
+    "\n",
+    "def make_torch_regression_model_1d() -> nn.Module:\n",
+    "    \"\"\"Small 1D regression MLP used as the base model in this tutorial.\"\"\"\n",
+    "    return nn.Sequential(\n",
+    "        nn.Linear(2, 2),\n",
+    "        nn.ReLU(),\n",
+    "        nn.Linear(2, 1),\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "def fallback_regression_model_1d() -> nn.Module:\n",
+    "    \"\"\"Fallback model when fixtures are unavailable.\n",
+    "\n",
+    "    Must match make_torch_regression_model_1d for consistent results.\n",
+    "    \"\"\"\n",
+    "    return make_torch_regression_model_1d()\n",
+    "\n",
+    "\n",
+    "MAKE_BASE: Callable[[], nn.Module] = make_torch_regression_model_1d\n",
+    "print(\"Using base model factory: make_torch_regression_model_1d\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "e8cc245a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1.7320508075688772"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "def make_dataset(\n",
+    "    n_train: int = 256,\n",
+    "    n_test: int = 400,\n",
+    "    train_range: float = 4.0,\n",
+    "    test_range: float = 6.0,\n",
+    "    noise_var: float = 3.0,\n",
+    ") -> tuple[\n",
+    "    tuple[torch.Tensor, torch.Tensor, torch.Tensor],\n",
+    "    tuple[torch.Tensor, torch.Tensor, torch.Tensor],\n",
+    "    float,\n",
+    "]:\n",
+    "    \"\"\"Generate a simple 1D regression dataset with 2D features [x, x^2].\"\"\"\n",
+    "    noise_std = math.sqrt(noise_var)\n",
+    "\n",
+    "    x_train = torch.rand(n_train, 1) * 2 * train_range - train_range\n",
+    "    x_test = torch.linspace(-test_range, test_range, n_test).unsqueeze(1)\n",
+    "\n",
+    "    x_train_2d = torch.cat([x_train, x_train**2], dim=1)\n",
+    "    x_test_2d = torch.cat([x_test, x_test**2], dim=1)\n",
+    "\n",
+    "    y_train = x_train**3 + noise_std * torch.randn_like(x_train)\n",
+    "    y_test_true = x_test**3  # noise-free \"true function\" for plotting\n",
+    "\n",
+    "    return (x_train_2d, y_train, x_train), (x_test_2d, y_test_true, x_test), noise_std\n",
+    "\n",
+    "\n",
+    "(train_x, train_y, train_x1), (test_x, test_y_true, test_x1), noise_std = make_dataset()\n",
+    "train_x, train_y, test_x, test_y_true = [t.to(device) for t in [train_x, train_y, test_x, test_y_true]]\n",
+    "\n",
+    "train_x1 = train_x1.to(device)\n",
+    "test_x1 = test_x1.to(device)\n",
+    "\n",
+    "test_y = test_y_true + noise_std * torch.randn_like(test_y_true)\n",
+    "\n",
+    "x_min, x_max = train_x1.min(), train_x1.max()\n",
+    "in_mask = (test_x1 >= x_min) & (test_x1 <= x_max)\n",
+    "ood_mask = ~in_mask\n",
+    "\n",
+    "known_noise_std = noise_std\n",
+    "\n",
+    "noise_std"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b10050b0",
+   "metadata": {},
+   "source": [
+    "## Dataset design\n",
+    "\n",
+    "We use a simple 1D regression with **known noise**:\n",
+    "\n",
+    "- True function: **y = x³**\n",
+    "- Training inputs: x ∈ [-4, 4]\n",
+    "- Test inputs: x ∈ [-6, 6] (includes extrapolation regions)\n",
+    "- Observation noise: ε ~ Normal(0, σ²)\n",
+    "\n",
+    "Why this setup:\n",
+    "- Inside [-4,4], models should fit well and uncertainty should be moderate.\n",
+    "- Outside [-4,4], epistemic uncertainty should usually increase (less evidence).\n",
+    "- Because we know σ, we can separate:\n",
+    "  - **epistemic** (model uncertainty estimated via sampling/disagreement)\n",
+    "  - **aleatoric** (data noise, fixed by construction)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "9b8aba12",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAioAAAF2CAYAAABAlLOiAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvc2/+5QAAAAlwSFlzAAAPYQAAD2EBqD+naQAAYUFJREFUeJzt3Qd8U9X7P/AnTZruAXQwWkbZe6OAKAgCDhQHKi5w4AK/bgQHbnHjFtHf3z1QcaKoiAsBkY1M2ZTRAd27Te7/9TnlxjQkbVqaJk0+b1+RJM04ubm597nnPOe5Bk3TNCEiIiLyQUHebgARERGRKwxUiIiIyGcxUCEiIiKfxUCFiIiIfBYDFSIiIvJZDFSIiIjIZzFQISIiIp/FQIWIiIh8FgMVIiIi8lkMVMjmt99+E4PBoP4lqi/vvPOOWq/27t3b4O998803yxlnnNFg7zd58mRp27atz/4m8R3g9fTL559/Lr5i/fr1Ptu2EzV8+HB1qc/1zHBsOfXo0UN8yfjx4522bcuWLWIymWTTpk2NP1CxX1Gru3BnSr6urKxMTj/9dLW+nnfeeWKxWFw+9vbbb5d+/fpJ06ZNJTw8XLp27SoPPfSQFBQUNGib/cmePXvkrbfeknvvvdd236FDh9RyxU4xkF1//fXy/vvvy6BBg2r93ClTpqh1+pxzzqnTeyNwxPOnTZtW5f42bdqoNtl/X7VVVFSkvl9P7x++//579T7eFBcXp5bXk08+6fZz8vPzZfr06dKuXTsJCQmRVq1ayUUXXaSWmzvS09PlhhtuUM8LDQ1VQfm111573LYM7erSpUuV+7t16yZnn322zJo1S2rLJD4GH9Dee++9J4sXLz7ufmzIqX6deuqpUlxcLGaz2dtNafRwCq2rr75afv31V/Xj/Oabb+R///ufvPrqq04fv2rVKhk2bJh6DjYA69atUxugn3/+Wf744w8JCvK5Ywq3XXnllXLppZeqDWNDevHFF9UGecSIEVUClYcfflhtYPv06VPv7/nmm2+K1Wr1+d/k4MGD5Yorrqj181avXq16yLCO1sUXX3whK1ascPq3Jk2aqDYhyHjiiSfq9PrY4eL7hfrswXAWqOC37G6w8tNPP9V7GyIiImr1Hebm5sppp50mBw4cUIFqhw4dJDMzU5YuXSqlpaXqAKk6qampMnToUHX9xhtvVMEKfk9///13lcfhPQAHCUeOHKnyNzzvrLPOkl27dkn79u0bb6DiuOD/+usvFajU5UdV3zuekpISCQsLa5D3KywsVCtiQ8LOsK4bIKpq5syZ8vHHH6uNGYYfHnvsMXnggQekdevWcs899xz3+D///PO4+/BDvuuuu9SG4OSTT67V+2MDih2KN4ZbHBmNRnVpSOXl5fLhhx+qDeOJwI6vpg24veDgYPHX3yS2gQi2r7rqKlmyZEmtn4/t55133qnW/7ocVTdmvnDwN3PmTNm3b5+sXbtWBfA6Z9sjZ9CTgqEbHFQ1a9asTm0YNWqUCkjfffddeeSRR9x+XqM8TMNOHCt8cnKyOkrr3LmzPPvss+qHZB/V9e7d2+nz8fgxY8ZU+x444kLX5o8//igDBgxQAcobb7yh/paTkyO33Xab7f0RmT711FPHHUkdPXpUHU1GR0dLbGysTJo0STZs2KC6PbETsR9vjIyMVFEmos2oqCi5/PLL1d/wmi+88IJ0795dbbASExPVCpOdnX3ckQ4+E7oD0VasiNdcc02Vx3zyySfSv39/9fpoU8+ePdVRZ03j4Z999pl6Hl4Xr4+g8eDBg1Ueo38G3I8xSlyPj49XO1rHIY/Dhw/Ltm3b1M7EFXyX+A4wZOJsgxcTE6OWQ0P45Zdf1A7DceP60UcfqeX1+uuvV7n/tddek6efflr9iyAF7r//fhWs6AGMO/RcB6xvDUXPYcDvad68eSpYwjo+cOBAtYFytmzQE4SgGus4vq+tW7fWmKPizvrq7rrvDAI/HM1hw6jDeo3PAei50oeR9d8ijsAxpr5mzRrVk4EARR+G+Prrr1XPWMuWLdXywHJ59NFHj1u3HXNUars8HTn7TertxJg/eovQThzdYp3zJPRqI7/g8ccfr9Pz0T58p9gmeAKWNbY5gF4V/fu17/XAdgdDHRhixTqFbTt6O+1hu4Tnd+zYUT0GO+VTTjlFHTDr37HeM2qfjlCbHBX9e/3000/V8kxKSlLvNXLkSNm5c6fUt5ycHHn77bdVTwp+axiWRi+Ku7DcFi1aJHfffbdaHtgGV7f9ri6Qx3LA76lWNB83depURB+221arVTv99NM1g8GgXXfdddorr7yijRs3Tj3mtttusz3uzTffVPf9888/VV7v77//Vve/99571b5vmzZttA4dOmhNmjTRZsyYoc2dO1f79ddftcLCQq1Xr15as2bNtHvvvVfdf9VVV6n23HrrrbbnWywWbfDgwZrRaNSmTZum2nnGGWdovXv3Vu//9ttv2x47adIkLSQkRGvfvr26jtfU24fPaDKZtClTpqj777nnHi0iIkIbOHCgVlZWph6Tnp6u2tmpUyftmWeeUZ/9vvvu07p27Wp7j59++km978iRI7VXX31VXdCuCRMm2B6Dz4fH4F8d2on78H5z5sxRyyIsLExr27atlp2dXeUzhIaGat27d9euueYa7fXXX9cuvPBC9dzXXnutyrLFY3H/nj17qv0O8BmCg4O1o0ePVrn/008/Vc//448/qn1+Tk6OlpmZWeMlPz9fc2c9xPewZs0adfvQoUNa06ZNtVGjRql1Uvf111+rx73xxhtOX+eJJ57QzGaz9ssvvxz3t/LyctWegwcPaj/++KPWpUsXLSoq6rjP744HH3xQrcO1he8Ey7Zv375q/X/qqae0p59+WouLi9OSkpJs6xwsXrxYfVasd3jMww8/rB6HddH+u9XXIf0+d9ZXd9d9Vx577DH1m8zNzbXdl5aWpj3yyCOqLddff732/vvvq8uuXbvU30877TStefPmWnx8vHbLLbeo7/Crr75Sfxs/frx28cUXq/Zi3cbvBq9z1113Hbdu2y/32ixPZ5z9JtHOli1basnJyWqbg98Xtol43Pfff1/t6+ntsd/+uCMvL08tm9mzZ6vb+Ixnn32228/ft2+f2m58/PHH6jbagN9UdZ/5s88+q1UbCwoK1HeD555//vm273fDhg3q75s2bdJiYmK0bt26qe8B2+RTTz1VrSdffPGF7XWwXcd9WO+wbj733HPaxIkTtSeffFL9ffny5WpbjvfR3wOX6uA7w8XxM2K96N+/v9q2PvTQQ1p4eLg2aNCgGj/rJIf1rCbffvuter958+ap7TL2S/iMQ4YM0datW1fj819++WX1/AULFtjWNbzG2LFjXW7H8XmxP3D22wwKCqry26xJowtUsOHAbXxYexdddJFa8Dt37rTtpLDjxMbN3v/+9z+1scNKXR2sBHifH374ocr9jz76qHr+v//+W+V+7MDxxe3fv1/dxheK57/wwgtVghf9S3YMVHAfXsPe0qVL1f0ffvhhlfvRJvv7v/zyS3V71apVLj8PNmjR0dFaRUWF2xtFbEQTEhK0Hj16aMXFxbbHLVy4UD1u1qxZx30G7Ajs6T/EugQq27dvV4/DxsfeueeeqwIl+wDB1Q8Fz6/pgvbUBAEqdjT44ZWUlKiNNJYnNsD1ZcWKFVXa1blz5yo7qIYMVBCIZ2VlVQnAcD82eLo+ffqo9cM+kMJOARshBO+uAhV31ld3131XrrjiCvUZHOE9Xe2o9fUFQZGjoqKi4+674YYb1I4F60NNgYo7y7M2gYrjwVZpaakKJLAT8kSggoCsXbt2ts9a20AF22fsFHWeCFQAgT6ei/XfEQ7SevbsWeX7wjYE7erYsaPtPhxM1vTZHPdLNXEVqCA4x3ene/HFF50eYJ9ooPL888/b1kMEQvj9IMBNTExUBw048KoO9pv68xGczJ8/XwXtkZGR6gAb20d3A5WPPvpIvdbKlSvdbn+jG/pBEhPGuzFWag9DQVj/0T0FGBpANzS62fUhIXTTzp8/Xw1NuJP/gS4yxyEiDIOgqxvjbOha1i/oYsbrI/ERfvjhB9XNhQx5HYYPpk6d6vL9brrppuPeC58DWfL274VhGAytIFET0OUOCxcudNkdh8dgyEzvvnQHuuczMjLU8IX9ODm6wJHR/d133x33HMecACyr3bt3V7kPXe360E51OnXqJCeddJLKNdBlZWWp7xhDYzV1tz733HPq89Z0QRZ8TdC9jnZjWAPDAvjsc+bMUTkn9QVZ8WjPV199pdqEddTdWT/26wcuyK1AN7vj/e52915yySVqHbf/HkH/LjF8h5kz6AZHN7quV69ean3F79QVd9ZXd9d9VzDsat9+d2FYBsNCjuxz0zBzAm3BMsFyRrf4iS7P2sIysM/bQw4EZvDU9fWq8++//6oh4meeeaZOCdH4rhYsWKCG8bwF2w0MU1588cW27w8XrCfYxu/YscM2nI31c/Pmzeo+T8O6Zp+/cqLrhSv6dgTbTOQXXXbZZWp/g20NhlJdJfk7Pr958+Zq24fliCE8JI8jZQHD4O7SfweOibaNKpm2JkgGwjgx8iyczQLC33VI+kJggqxm7FwwgwLTq5A34g77hCMdVt6NGzfaxkIdYceut6NFixbHJeIhn8UZJClhnNLxvZCpnZCQUO17IR/nwgsvVOOq2HliDBDBGFZGfcOCYAPjoWeeeaYazx49erRa2caOHevy8+vLEjk9jhCoOCaAIphxXC5YKd3JKXAF3yGmMaItmL6IHRh2bu58h9ip1SdkvOPHjR81Nm6OORUnCnlDek4Fgmz8+PEvkt9c5VvpXK2PjvdjnBrBRU0cAzB946J/l9WtG/gtIrfLVUK4O+uru+t+dexz1tyF34azxEfsuJBnhJ1dXl5elb+hnSe6PGsL2wrHQB2viW1TXSBnATtzx3UHB4W33nqrDBkyRH1ntVVRUaEOKvF71fODvAF5H1gfkNCOi6t1Ct8/kjzxu8OBEnKBsI1E+xGE17f6Xi+ysrLUd2kfYCPg1wPtcePGqSBXhyR97OeWL19e7evqz8c+w34G4oQJE9SywfOvu+46t9qo/y5rOtBs1IFKbWBnggS8Dz74QAUq+BcRoX2CXXWczfDBUSqO8lwdhWPlrgtsoB2noOK9sKG271FwthPSiyNhhtS3336rdhLYiaJHAfdhxcTr4AgYf0OPBC7YaSEQQAZ2ffDEzA5Ma8W8fCwDJDbiO0QCnLMdZE0/Wlf0H3NN0BuhJzXiKKK2M0Jq64ILLlAbASRB1xSoOPaUYVo/pkRiedlDYuqJfJd12fk7cmd9dXfddwUJf3XZ2Dv7zSMREcEVAknsxJAQi6AcASRmTLgzHbm+l2d9vx52NPbTuPU6NDiyR+8wphXbJ0MjAMG0adyHHjUsG2ewHm7fvl1NRHCcgYaeDdyH79mTvyPQvyP0AriaSKEfRGJfgd83Ej7xG8I0WwTUc+fOdXtn7K3v8YILLpDff//ddhsTONATjIN7wP7QEZZ/Tb8VV89H+2v7W9Mfi0R6vw1UcFSNnhGs5Pa9Knr3K/5uvxBxlIYvCrNy0M2FoZgT2aFiI4VusJqCHbQDXZ6OO7PaZHTjvfBZcSTvzrRoRMe4IIscR+MYHsFOTv9x4UgRETUu+OGilwUbEBxhOOvp0ZclNjQoXGYP99kva0/BRhBDTdhh4fMsW7bM7S5kxx+tK/qPuSYPPvigGvrBDA7soGbMmCEvvfSSeAoCI3xP7hyxO66P6O3CztTdoLy27NcNR/gtYiNU0/Bqdetrbdd9Zz1+WGew7OyD0NocxekQnGKIADtr7MTsd+T+AoGwY7CLgzo9MMdvyRGGSnA0jp04ZkE6s3//ftUDqtffcAxicPnyyy9Vj1p9cPX9pqSkqH8xHO/ObwLbHQzL4ILtPb53zB7St6V1WY8awnPPPVclaNADDL132XG2JqAWimNxNkeuno8DQQzh1HTgYA+/GxyU1+agvtHlqGD6LnJBXnnllSr348eClQdDG/ZwRIovDtMascKdaD0WdH2hYBGOAp0deeFIAxC14weKMTwddjo1jQU6vhc+K6ZBOsL76NNW8fkcI3C9mJWek4ANrT2sKHpXpqu8BfRcINrGkYT9Y9Abgx02Aoi6cGd6suN3iKmYmBqHIBO9LO6ozxyVlStXqgAFG2TkQ6EtWAfdCYRqgu/R2bLAkZz+PfgaDGtiHUNvnP30aUxfxVEofqeuuLO+urvuV1fQDO+Bqcb29OCpNlO+9QMb+zZjA43p5/4CQw7YgdtfEOjiAAWBhOMFOyasl7iOAx9X8Ft19nzAOoLryEOrL/pBoeP3i+0YhhhxYIbtjyMUPtM5bivRw4cDOfttYF3Wo4bQv3//Kt8h8t4APdAIRtFLZJ8bgt8qCrnVdJoJLDu9hxNTk3U4wMPvtDanqcBvEj277vRiN9oeFfwo0EV53333qW5DLHwsbHwB2Ik4Vrvr27evGmdEbgPGzlGm/ERgB4V596ixgrF+rBgYi//nn39UdzbahKNJHCEguQ07NfSiIGLF8/RxYHcicnQ3I8CaPXu2GrZBXgmOCDB+j8+DBDfUBMDOAhvN888/X31+9DYhQEJ3rL7DwJEA3hsbHoxvI8fg5ZdfVjsIV1V+8V7oicJRBdoyceJEleOD90UiLIZk6gK1RNBmRNbunBcFARG6F/GZEYi6ylvwVI4KfpjodUFdBb2GBPIrMGyBZYPv/kSK8+GoFeP4+C7xHtgJIq8KR/DYGXi72KErSK7E94GgAGW0MRSAdQoboOoqdrqzvrq77ruCuhdYZ9ArY98biPdDsiSCb/TI4nvDjtJZPpoO+RnYkWMdwPeE3y5qitTHMJivQw6Fs4RxbGsxDODYE4Jtov1vG9s9V0frWObu9qTgN4LtPno1q1u30PuGnTNyE3HEjp4RbP9xwUEi1gvUj0LPOnpZsD3DgSeqtaLGFeD52DFj+4HnY1IBtu32Jf/1bQvWBxyU1uYAylvmzJmjAgosA/y20Nv4/PPPq+VkP5ED+zB8N/Y9zUhNwO8d96F3CQeP6C3D7xAJwM563JzBARkO7vT6Um7TfJyzaWCoe3H77berWgKos4GpZZgq5Wq6KuoW4DVQw8Jd1U2/w/vPnDlTTVdFTQzURMAUt2effbZKXQRMlbvssstULQzM3588ebK2bNky1ZZPPvmkylQzTHl2BXPfMcUXdQjwWphiN336dNuUsrVr16p5/q1bt1b1WDBl9JxzztFWr15te43PP/9cGz16tPob2ozHYnrl4cOHq50KCZiKhmnGeG3UDrn88su1AwcOVHmMq8+AaYKO35+705Pt3Xzzzeo5mNrW0LCuYeq543Q6LF/U+bjppptO6PUxpR7TeVNSUtR3rNejwbKraRq9p6Yn4/fkyNm0z59//lkbOnSoajema6Om0ZYtW6o8xnF6sjvrq7vrfk1TKvEbdYSpwailge/Ofqquq+mUgN/tySefrNqB7Q7agFo3jr8XV9OT3V2e7k5PdtZOd6as1nV6srvbR0yPxjKyr7HkTG2nJ+t1QJxNHXeEOidYZ7Cdc1zGqJmD3xqmcmPf0apVK7XuYfuoQ+kLTOGNjY1VnwX1jB5//PEq23aUeUCtHdTcQVmMmnalrqYnO07Bdvf7mVTL6cn2tY+wHmMbg235lVdeWWUfAJga7axcBqAODqZv43eLqc2oxYUaO844W08XLVqkXnvHjh21arfPByr1AbVMsDLVZ82LutJrSPz555/ebkqjgmJ+2FE5m69P5Ax2StgZIZiiqjtCFPDCgZR9DY/6gKDTsQieu7DzR5v0Wln2O/G7775bFcizr4ESyCZNmqQK/mF51RQU1haKgeKgEwUS6wKBC9qFg3fHQOW8885TxRNry+8DFfSy4Chs+PDhDf7ejkWi8ENEwTcceTorIEXOodgceq3QI0VUGzfeeKOqHkxVAxX9Upeiaq6g8isOJrCTqgtUSHXVtgEDBris9hyIJh3rlcbFVS9gXaE4H0YM6grBiLO2oacVPdM1FbNzxoD/iR9C3ghyQjDzBuPfyGE599xzG7QNyAvBuD3G8JGIhZwDTAPEmUGRp0HVQ10D5BhgfBgztjAd1BNnvCUKFMi3sq9/hIR6d3O+PA2THTA93Rfb5mu2bNmiZuvoyb61PWmpJ6GWj17nqL7a5reBip4QhMQ5JO7U9URaJwJTLjHzBMm02EAgcxxJS/ZJWVRzAh02VphCzeVGRBR4/DZQISIiosav0dVRISIiosDBQIWIiIh8VqMr+FYXqAiLxCMUePLV0sdERES+SNM0VZgRJfkdz0nXEAIiUEGQkpyc7O1mEBERNVqpqamqsnlDC4hART95IRayq7N8EhER0fHy8vLUwb79iYAbUkAEKvpwD4IUBipERES1563UCSbTEhERkc9ioEJEREQ+i4EKERER+ayAyFFxdwpzWVmZt5tBPsxsNntlah4RUSBjoCKiApQ9e/aoYIXIFQQpOH8UAhYiImoYAR+ooJDN4cOHxWg0qulXPGKm6ooGYl1p3bo1CwcSETWQgA9UKioqpKioSFXcCw8P93ZzyIfFx8erYAXrTHBwsLebQ0QUEAK++8Bisah/2Z1PNdHXEX2dISIizwv4QEXHrnyqCdcRIqKGx0CFiIjIT5Rb/G9SCAMVUtq2bSsvvPCCt5shkydPlvHjx3u7GUREjc6mg7ky9Mlf5L0Ve8WfBHwybWM1fPhw6dOnT70FF6tWrZKIiAjxthdffFHNxCIiotqZs/hfycgvlbX7suWqwW3FXzBQ8WPY4SPx02QyuTWjxRfExMR4uwlERI3O2v3ZsmRbhhiDDHLrqE7iTzj00whheOT3339XvQ9I8MRl79698ttvv6nrixYtkv79+0tISIj8+eefsmvXLjnvvPMkMTFRIiMjZeDAgfLzzz9XO/SD13nrrbfk/PPPV9O2O3bsKN9880217cJrPPHEE3LNNdeo04Gj3si8efOqPOaff/6R008/XcLCwqRZs2Zy/fXXS0FBgcuhn88//1x69uxpe/yoUaOksLBQ/vjjDzVFOC0trcrr33bbbTJs2LA6L1siosbamwIX9msl7eK83ztenxio1KPDucWy5VCe+teTEKAMHjxYpkyZogqQ4YJidboZM2bIk08+KVu3bpVevXqpQOCss86SJUuWyLp162Ts2LEybtw42b9/f7Xv8/DDD8vFF18sGzduVM+//PLLJSsrq9rnPPfcczJgwAD1PjfffLPcdNNNsn37dvU3BBhjxoyRJk2aqKGmzz77TAVM06ZNc/pa+FwTJ05UgQ8+CwKxCy64QPUUnXrqqZKSkiLvv/++7fHl5eXy4YcfqscTEQWKlbuPytIdRyTYaJBbTu8ofkcLALm5uUh6UP86Ki4u1rZs2aL+PRF//Juh3f3Zeu2m91erf3Hbk0477TTt1ltvrXLfr7/+qj7nV199VePzu3fvrr388su2223atNHmzJlju43Xuf/++223CwoK1H2LFi1y+Zp4jSuuuMJ222q1agkJCdrrr7+ubs+bN09r0qSJei3dd999pwUFBWlpaWnq9qRJk7TzzjtPXV+zZo16z7179zp9v6eeekrr2rWr7faCBQu0yMjIKq9fn+prXSEiqi9Wq1Wb8Ppyrc09C7X7vtzY4PvQhsAelXqAHpRvNxwS7N5T4iPVv7jt6Z4VV9CjYQ89KnfddZd07dpVYmNj1fAPeihq6lFBb4wOibbR0dGSkZHh9nMwfNS8eXPbc/CevXv3rpK0O3ToUFWeXu91sYfHjhw5Ug39TJgwQd58803Jzs6uMky0c+dO+euvv9Ttd955R/UA+UJSMBFRQ/hz5xH5e2+WmE1BMm2EH/ameHroZ/bs2SofAvkKCQkJKvfAcYdUUlIiU6dOVfkH2IFeeOGFkp6eXuUx2KGeffbZKlcCr3P33XerMua+IruwXApKKiQxOlQlMuFf3Mb93uC4o0aQ8uWXX6r8kaVLl8r69evVzr+ms0U7lolH4FHTiRvr8hxXcP6lxYsXq5ybbt26ycsvvyydO3dWJ5AErAsYwnr77bfVOoPHcdiHiAKFpmny3E+VuSmXn9RamseEij/yaKCChE8EITjixQ4HOQSjR49WuQq622+/Xb799luVr4DH41wqyEPQYdYKghTsVJcvXy7vvvuuOnKeNWuW+IomEcESGWqS9LwSsVg19S9u435PlnN3t5T7smXLVO8DEmMRoKCXA8m3DQ09Ohs2bKjy/aNtOBEkAhBnEOig1wX5Msh7wedG0KW77rrrZP78+Sppt3379uqxRESB4JdtGbI+NUfCgo1y0/D24q88Gqj88MMPagfZvXt31Y2PAAO9I2vWrFF/z83Nlf/7v/+T559/Xs0EwUwVHB0jING783/66SfZsmWLfPDBB6puyJlnnimPPvqovPrqqzX2CDSUFjFhMq53S0GF9d2ZBepf3Mb9noIZNitXrlQBx5EjR6rttcCMnS+++EL1pCBQuOyyy+rcy3EikIwbGhoqkyZNkk2bNsmvv/4qt9xyi1x55ZVqRpIjfD70Aq1evVqtN/gMmZmZKuDRITkXQ1KPPfaYXH311Q38iYiIvMNq1eTZY70pVw1pIwlR/tmbAg2ao4LABJo2bar+RcCCXhZMOdV16dJFTWtdsWKFuo1/0QtgvyPDzikvL082b94svmJYx3i5/YxOMu30jupf3PYkDOdgaARDIqiBUl2+CQJBzLQZMmSIGirB8uvXr580NAzd/fjjj2rmEIYEL7roIpWD8sorrzh9PAIQTEPGjKNOnTrJ/fffr2YVIVjVoTcGwTB6l6666qoG/DRERN7z9YaDsvVwnkSFmuTGU/23N6VBC77hCB41LtA136NHD3UfamCgKx8JnvYQlOj1MfCv49G2ftuxhoautLRUXXQIahoCelA82YtiDztuPZiz72VxVtUV9//yyy9V7sOQnD3HoSBnr5OTk1Ntm5wNJ6EXxx6CTse22EOvmw49J+iVq8nBgwdVMNOiRYsaH0tE1NiVVlhsuSkY8mkSUXlmd3/VYIEKdozo7kcBMk9DEi9yGsi/oYcOBeQ++uijGovRERH5iw//2i8HsoslMTpErh7STvxdgwz9oKDXwoULVU5CUlKS7X4kdSLPxPFIHTM48Df9MY6zgPTb+mMczZw5U+3E9EtqaqoHPhV5G6rtIjn7xhtvlDPOOMPbzSEi8rj8knJ55ded6vptozpJmNko/s6jgQqGDxCkYJYGuvvbtasa+SF5FtNZUTFVh+nLyLdA5VXAvzhqtq/fgRlEyF9AfoYzKB2Pv9tfyP+gUm1RUZHMmTPH200hImoQb/6xW7IKyyQlPkIm9P/vwN+fmTw93INu+a+//lrVUtFzSnDiOZy7Bf9ee+21cscdd6gEWwQUmAWC4OTkk09Wj8URMwISzAx5+umn1WsgqRKvjYCEiIgoEGTkl8ibSyvrSE0f01lMxsCo2erRQOX1119X/w4fPrzK/ZiCjJkagKNhzNxAoTckwGJGymuvvWZ7LGa2YNgI54xBAINiZpje+sgjj3iy6URERD7l5SU7pbjcIn2SY2VMd+epD/7Io4GKs5kjjlBXAzVRcHGlTZs28v3339dz64iIiBqHPUcK5eO/K8tQzDiziyqGGSgCo9+IiIioEXv2p+1SYdVkROd4OTmlmQQSBipEREQ+bO3+bPlu42FV9Xz62C4SaBioEBER+ShN0+TRhVvUdczy6doi8GaxMlChOsPUYCRBY7YWxktrqlzr6anK3m4DEVF9+2bDIVm3P0fCzUa5a7Tzk7f6OwYqjRRmUuGUBN6EM1kvXbpUnUTy8OHDarq5tz47zmPUkG0gIvK04jKLPLVom7p+8/D2khDtvyce9IkS+uSdLkOcrM9k8szXvGvXLnU+Hv3cTd6Ec0a5qlRMRNQYvbV0txzKLZFWsWFy3bAUCVTsUWmEUIPm999/lxdffFENd+CCEwLqwx+LFi1SVX9REA/nVsLjx48fX+U10CNhX98GJ43EOZJQPRjF+Hr37i2ff/65yzbguTiTMc5ujPfUXwvXv/rqqyqPxUkn9ZMNop14zBdffCEjRoxQZ1TGezmeYHHZsmXqNfF3nPkZ9XWys7Nr/Oz2Qz8LFiyQ7t27q+WAEzOivfZw3xNPPCHXXHONKkiIs3bPmzevTt8JEVF9Ss8rkdd/36WuTx/bWUKD/b9UvisMVJz0QhSVVXjl4k7dGcBOGsXvpkyZooY7cElOTrb9fcaMGfLkk0/K1q1bpVevXm69JoKU9957T+bOnSubN2+W22+/Xa644goVFDiDQAPvj3bg/XG7Nu677z6566671NmVcSboiRMnSkVFhfob7hs5cqSqSIwABsHWuHHjVO9QTZ9dt2bNGrn44ovl0ksvVadgeOihh+SBBx6ocnZmQPAyYMAAWbdundx8882qsCBO40BE5E3P/rhdisos0rd1rJzbu6UEMg79OEDVv26zfvTKe295ZIyEm2v+SpCHgaEO9DY4G+5A1d7anKQPFYHRs/Dzzz/bzrGUkpKiAoQ33nhDTjvttOOeg1Me4P3rOuSCIOXss89W13Gma/R87Ny5U7p06aJOlYDgwb5CMf6uq+6z655//nkV7CA4AQRDW7ZskWeeecZWFRnOOussFaDAPffcoyol4+SZnTsHZtIaEXnfpoO58vnaA+r6A+d0C6jibs6wR8UPYSdfGwgQMIMHwU1kZKTtgh4W5KF4gn1PT4sWLdS/+okn9R6VE4HepKFDh1a5D7d37NihemactQMbAwQ/9ifAJCLyxnRkdLCf16el9GvdRAIde1QchAUbVc+Gt967PuB8SPZwLiXHYaXy8nLb9YKCAvXvd999J61ataryuNqe+BE7++reS4ezZts/R8+TAeTINBT7duht0dtBRNTQFm1Kk5V7siTEFBSQxd2cYaDiADsqd4ZfvA3DH/Y9A9WJj4+XTZs2VbkPvRb6Thq5IAhI9u/f73SYpzbwXsgb0aEHA701tYFejiVLlqghobp+dsxGQkKuPdzGEBBOdElE5GuQq/jYseJuN5zWXs32IQYqjRZmrKxcuVLNeMEwDXJGXDn99NNVbgaGcpCD8sEHH6jApW/fvurvmPGCnBEk0KI34ZRTTpHc3Fy1Y0cxN5yt2l14r1deeUW9D4IJ5H049lrUZObMmdKzZ0+VO3LjjTeqwAR5IxMmTJC4uDi3Pvudd94pAwcOlEcffVQuueQSlZSLdtnnvRAR+ZJXftmppiMnNQlTdVOoEnNUGikEFugZQG8IejHQG+IKpvYiqXT69Olq552fny9XXXVVlcdgh47HYPYPeiPGjh2rhoIwXbk2MIsGs3CGDRsml112mWonEl9rA70eP/30k2zYsEEGDRqkgp6vv/7aVg/Gnc/er18/+fTTT+WTTz5RdV5mzZqlkoztE2mJiHzF7swCeXPpbnV91jndAno6siOD5u6c2EYsLy9PzZRBLwF6COyVlJTInj171A45NDQwq/6Re7iuEJEnYDc86e1V8se/mTK8c7y8PXmgT830yatmH9oQ2KNCRETkRT9uTldBitkYJA+N6+5TQYovYKBCRETkxfP56GdHvv7UFGkbV3XWJjFQISIi8prXftspB3OK1QyfqSM6eLs5PomBChERkRfsPVIob/xemUD7wDldJczMBFpnGKgQERF5IYH2ga83SZnFKsM6xsmY7jz7uysMVI4JgMlPdIK4jhBRfflmwyFZuuOImE1B8vC5TKCtTsAXfEMxMqwgmZmZqiYHVxZyFaRgHcH6UdsCdkRE9rILy+SRbysTaP93egdJiY/0dpN8WsAHKigclpSUJAcOHFCVTolcQZCCdYUl+InoRDzx/VY5WlgmnRIj5fpTWYG2JgEfqADKsHfs2NHpyfOIdOhJYZBCRCdi+c4j8tmaA4LO+9kX9FJDP1Q9BirHYAfEnRAREXlKSblF7v3yH3X9ipPaSP82TbzdpEaBoRwREVEDnXRw79EiSYwOkbvHdvZ2cxoNBipEREQetj0tX+b+vktdxyyf6FAm5buLgQoREZEHWayazPhio1RYNTmjWyJrptQSAxUiIiIP+r8/d8u6/TkSGWKSR85jzZTaYqBCRETkITszCuTZn/61lclvERPm7SY1OgxUiIiIPDTkc9dnG6SswiqndYqXiwcke7tJjRIDFSIiIg94c+luWZ+aI1EhJnnywp4c8qkjBipERET1bEd6vjy/+NiQz7huHPI5AQxUiIiI6lGFxWob8hnROV4m9E/ydpMaNQYqRERE9Wje0t2y4UCuRIWaVJl8DvmcGAYqRERE9WRbWp68sHiHuv7guO7SPCbU201q9BioEBER1dO5fG79eL2UWawyqmuCXNivlbeb5BcYqBAREdWDJxdtk+3p+RIXaZYnL+SQT31hoEJERHSCftueIe8s36uuPzOht8RFhni7SX6DgQoREdEJOFpQKnd9tlFdnzS4jYzonODtJvkVBipERER1pGma3LNgoxwpKJWOCZEy86yu3m6S32GgQkREVEcf/b1fft6aIWZjkLx4aV8JDTZ6u0l+h4EKERFRHU84+OjCLer69LGdpVvLaG83yS8xUCEiIqql4jKLTP1wrZSUW+WUDnFyzdB23m6S32KgQkREVEsPfrPp2FTkEHn+4t4SFMSpyJ7CQIWIiKgWFqw5IJ+uPiAok/LipX0kIZrVZz2JgQoREVEtzop8/1eb1PVbR3aUoR3ivN0kv8dAhYiIyA1FZRVy84drpbjcovJSbjm9o7ebFBAYqBAREbnhga82y46MAomPCpE5l/QRI/NSGgQDFSIiohp8ujpVFqw9IIhNXp7YVwUr1DAYqBAREVVj44EcW17KHWd0kpNTmnm7SQGFgQoREZELmfmlcsP7a6SswiojuyTIzcM7eLtJAYeBChERkRPlFqtM/WitHM4tkZT4CJlzaR/WS/ECBipEREROPLZwi/y9J0siQ0wy78oBEh0a7O0mBSSPBip//PGHjBs3Tlq2bCkGg0G++uqr4846OWvWLGnRooWEhYXJqFGjZMeOHVUek5WVJZdffrlER0dLbGysXHvttVJQUODJZhMRUYBD8uy7K/ap65jh0yEh0ttNClgeDVQKCwuld+/e8uqrrzr9+9NPPy0vvfSSzJ07V1auXCkREREyZswYKSkpsT0GQcrmzZtl8eLFsnDhQhX8XH/99Z5sNhERBbB1+7Pl/i8rk2dvH9VJzuiW6O0mBTSDhm6Nhngjg0G+/PJLGT9+vLqNt0VPy5133il33XWXui83N1cSExPlnXfekUsvvVS2bt0q3bp1k1WrVsmAAQPUY3744Qc566yz5MCBA+r57sjLy5OYmBj1+uiZISIiciYtt0TOe/VPSc8rldHdEmXuFf0DPi8lz8v7UK/lqOzZs0fS0tLUcI8OC+Kkk06SFStWqNv4F8M9epACeHxQUJDqgXGltLRULVj7CxERUXUKSyvk2ndXqSAFQz3P8WSDPsFrgQqCFEAPij3c1v+GfxMSEqr83WQySdOmTW2PcWb27Nkq6NEvycnJHvkMRETkHyxWTW79ZJ1sPpQnzSLM8vbkgRLF5Fmf4JezfmbOnKm6qPRLamqqt5tEREQ+7PHvtsrPWzPEbAqSeVcNkOSm4d5uEnk7UGnevLn6Nz09vcr9uK3/Df9mZGRU+XtFRYWaCaQ/xpmQkBA1jmZ/ISIicub9FXvl/y3bo64/f3Fv6d+mibebRL4QqLRr104FG0uWLLHdh1wS5J4MHjxY3ca/OTk5smbNGttjfvnlF7FarSqXhYiI6ET8uj1DHvxms7p+95jOck4v9yZpUMMxefLFUe9k586dVRJo169fr3JMWrduLbfddps89thj0rFjRxW4PPDAA2omjz4zqGvXrjJ27FiZMmWKmsJcXl4u06ZNUzOC3J3xQ0RE5MzmQ7ky7cO1YtVELuqfJDcPb+/tJlFDByqrV6+WESNG2G7fcccd6t9JkyapKcjTp09XtVZQFwU9J6eccoqafhwaGmp7zocffqiCk5EjR6rZPhdeeKGqvUJERFRX+44WyqT/t0oKyywyOKWZPHF+T1VGgwK4jkogzwEnIiLfkZFXIhfNXSH7s4qka4tomX/DySyP78P7UL+c9UNERORMbnG5THp7lQpSWjcNl3evGcggxccxUCEiooBQUm6RKe+tlq2H8yQuMkTev3aQJET9l2pAvomBChER+b0Ki1Vu+XidOhtyVIhJ9aS0aRbh7WaRGxioEBGRX7NaNblnwT+yeEu6Kuj25qQB0r1ljLebRW5ioEJERH4dpNz75T+yYO0BMQYZ5OWJfeXklGbebhbVAgMVIiLyS5jUOuubTfLJqlTBuQXnXNJHxnR3XdWcfBMDFSIi8ssg5eFvt8gHf+0XlEfBmZDP7c1CoY0RAxUiIvK7IOWJ77fKO8v3qttPXdhLzu+b5O1mUR0xUCEiIr8KUp76Ybu8ubTyJIOoOHvxgGRvN4t8tYQ+ERFRQybOPrJwi60n5ZHzustlJ7X2drPoBDFQISKiRs9i1WTmFxvl09UH1O1Hz+suVw5u6+1mUT1goEJERI1aucUqt89fLws3Hlaze56+qLc6GzL5BwYqRETUqMviT/torfy8NUOCjQZ58dK+clbPFt5uFtUjBipERNQoFZRWyA3vr5ZlO49KiClI5l7ZX0Z0TvB2s6ieMVAhIqJG43BusWQXlotFs8qMBf/I5kN5EmE2yluTBsrg9qw4648YqBARUaOwdEemfLvhkKTllMjq/dlSVGaRZhFm+X+TB0rv5FhvN488hIEKERE1ip4UBCmpWUWyZl+OlFmsEhlikrlX9mOQ4ucYqBARkc8P9RzJL5U1e7Nk95Ei0UQkLDhIOsSHS4Q52NtNJA9joEJERD4ZoCzZmiF/7T4iFosmOzMKZdeRIvW3mDCTuuQWV0i5xeLtppKHMVAhIiKfy0X5dFWqrNufLUFBBrFaRQ7kFKu/xYSaJC7CLGZTkESGBkuw0ejt5pKHMVAhIiKfy0UpKbeK0SCSnl+qrhuO9aT0aBktSU0ipKCsXMLNJmkSwaEff8dAhYiIfAbyUTLzS6WwtEIO5JSIRRNVbbZvcqxEhBglJswseSXlEhlqknG9W0qLmDBvN5k8jIEKERF5JUEWvSGOgcaOjHxZsy9L8koqc09UT0qoSVrEhsolA1tLh4RIl88l/8RAhYiIGrwWSkFJhQQFiXRrESM9WsZIx+aRqhz+sz9utwUppiCR4KAgadUkTKYMS5HeyU3U/QxQAgsDFSIiatD8E01DEGKQlXuOqpk9EWaTtIwNVfko6Xml6rGJ0SHSLCJYCksqJDbczKTZAMZAhYiIGgSGbNCTkhAVKqv2HlXTi8sqrFJhLZcjB8vUY3BiwaYRZmkSbhZN08QQZFDXmTQbuIK83QAiIgoMCDYw3LN0Z4YcyimRkgqrWEWkHBmzx4KUKcPaSefESCkoKZf8kgpp0yxCLh6YzOGeAMYeFSIiahA7MwrUZc+RIrFWxiY2ZiN6ToLl5HZxcuXgtrIjrUDEoEnHxCgGKQGOgQoRETVIfsq7y/eqUvhGg0GsSFSx69rH1OPOzaNUUi0CEwYnpGOgQkREHp+GjKTZtfuz1W09REFBN0w/jggxSb/WTWTy0HYMUOg4DFSIiKj+z9OzJUPN6rFYNSmtsMjGA7mSVVhuewyClMrE2RC54qTWcn7/JAYp5BQDFSIiqtc6Ke8u2ysbD+ZIiNEosREm2XK4QAUsYDBU5qOgW6VtXKTcNLy9nNenlbebTT6MgQoREdVbT8pbS3fLtsN5kltUpsrfp+b893cEKMFGkdBgk3SIj5R7z+5qK+JG5AoDFSIiqpc8lB3p+bLpYK4UlVmktLK4rIJz9YSbgyQ4yChlFqsYgwwyrncrBinkFgYqRER0wuXwcZLAYINIdlH5cVOPg1G0Lcws5mCjFJdZpGuLKBnZLcFbzaZGhoEKERHVuRx+UVmFIOHkzx2Zcii3svy93osSHCRiMgZJUpNwdTbk0nKLdEiI4OweqhUGKkREVGsY7tmdWSC7jxRWmc2D6cZmEwIVgxgMBunZKlZmntVFcovLRTSDrU4KkbsYqBARUa3yUWLDTfLX7iOy4UCurfy9DsM/OIFgVKhJnXzwnF4tmYtCJ4SBChER1ejr9Qflu42HJDO/TFKzi+RIQeVJBPVhHpNB1CwfoylIIkNM0qZphMRFmZmLQieMgQoREVXpMSm3WFSvCGbyYJjm6/UH5PHvtklOUbmataMHJ0lNwqSkzCKFZRZ1u8JqFYP6TyQ+KoQnE6R6wUCFiIhsM3j2HCmUtNxiiQ4Jlrbx4ZISHyXvLN+rzmSsw3l5erWKkbN7tZSfNh+WzYfy1GyeiJBg6RAfIef0biUjuyYwSKF6wUCFiCjAe1AO5xbJ/FUHxGK1qiAlM79U0vJKZHtGgVRY022PDzEFSZjJIGUWTYKNQSoYwQVnOs4qKpWmEWae7ZjqHQMVIqIA7kHZfjhPUrOLpazCKpEhRsksqKwoW6nyCqYZx0WESJnVqh4HJ7VrZgtIGJiQJzFQISIKkMqxekCh10D5Ny1PtqflS8mxyKSgzK6cLPJQjv0bZjaK0WiQyOBgKTdZJblpqFzQn+fnoYbBQIWIyM97TTCUg5MCnpzSVM7vl6QCF5yPB0FKqcP0Yp0RF6NBJck2jwmT5tEhYrWKxEYEyyUDW7MXhRoMAxUiIj+0ITVb3l+xV50c8FBOiRrSWbn7qHy2+oCakbPpUN5xpe4xxRj3mYwGdT4ek8Eg4SFG6ZwYJdcNa1dlJhBRQ2GgQkTkRzCs8+XaA/Lz1gzZe7RQla0vKbOKPqiz52iRugCmEYN27HqwKUjaNAuXMJNRDuYWi9FgkE7No9Q0YxZtI29hoEJE5CdQ7+StP/bIjowC0TRNVY2tTH2tCkFJdKhJ2jQLk/S8UskpLlfVT7o0j5I7RneWDgmRaiaPGDTO4iGvY6BCRNTIk2P1yrFPLdouGfklgppszjNP/gtUmkWaVe5Js8hQNS355JQ4Ob9fK87kIZ/DQIWIqJEmxw5s21S6t4qWFbuOyvxVqZJnV5StOsYgVJUNl6kjOjDvhHweAxUiIh/qIbG/DXpJe5x9+NPVqZKaVSi7MoukqNQif+w4ctzrGQ0IRAxSYdFUrwpm7eBSbv1vynFsuFku7N+KeSfUKDBQIaIGGZoINO4sB72HpKCkQiJDTdK2WbjsPVqkekyO5JeKVUOBNU2yCsukQtNUGXvHmToYxomLNEuL2FCVBHs4r0Q9F8FJYnSIqoFyJL9cCssqJNhokNZNw2XKqe3lvD6sg0KNAwMVIqo3jjvecb1byrCO8RJowcmOjHxZtvNItcsBj/10VaqUlFslqUmopOeVqOnEGIo5UlAqRXoXiAsIUBCzhJoM0rZZhJzXt5VsPJAj4SEIeCJU5Vi9KJutxH14iHRsHhnQASQ1PgxUiOiEekLsz7iLIEXTRFLiI9WOF7cxg8Tx9VxVS3Uc8vBkr0xN7+fO8rB/zN97jsqCNQfVEE1WYakKFjC0sm5/ljz+3VY5s0eWXHysUFpBaYW8t2Kf/PFvplg0TeWblFZYj+stsQ9KQlHHXtOkuEKrMsyjiUHCzP+dd8dZmxmYUGPWaAKVV199VZ555hlJS0uT3r17y8svvyyDBg3ydrOIGiXHnTB6QnB0n11UJqHBRumb3ER6JkUfNzXV2fP0HhTsfI8WlMqgdk1VjkRidKjszixQj7d/DWe9LqDfh2GOMotFYsLMqjCZq94I/WR6xWUo6R5Wq3wLzJBZsCZVnfEXbTWbgsQYFKSGRnBGYJxcz7GNaspuer6IZlC9EjszCmyJregB2Xu0QMorEEtoKvgoLK2Qf9PzJSO/TPV8bEvLl9d/262GYrKLyl22zb62if19uESGBYulCFOJRSqORTU4P8+F/ZM5W4f8VqMIVObPny933HGHzJ07V0466SR54YUXZMyYMbJ9+3ZJSEjwdvOIGhUECvNX7Zf03BK10xzZNVF+2ZYh+44WSlFphQoAftuWIU0izNKtZbRc0C9JOiZEyaq9R2TZziwpt1hVANG9RZQs25UlZpNBgk0G2X2gQAUZWYXl0ql5pJiCDOqx/6bnVUkUxc69qKxCVT/FjvypRdskNjxYYsKCJbuoVDYeyFXtTIgKkYy8EnU2X9T80AMRPdBZvz9bVVxFcIHk0L6tY6RTIoKrSImLDJHUrOLjAhi8/7vL98gnf6eqHowgA5JOraq3Ij4qVIrLLbL1cL60jA2R1k0jVc/QniMFMmfxdtVThKAEgQhyP4KCgtRrZOaVSmZBqd2J/CplFR0/A6ekwqougByS4KAgMRhEBTZIfm3XLFQyC8tVoixeTz/XTlCQqLMVJzcJl4QoixwpKFPLtmVMmFx3ajvmm5BfM2j41fk4BCcDBw6UV155Rd22Wq2SnJwst9xyi8yYMaPG5+fl5UlMTIzk5uZKdHR0A7SY6MRhp7pyV5YUlJZLz6SYWs/QcDW8cs/nG+Sfg7mqJwLzQkJMQWonHBYcJEcKym0FwlBOHX+LCTerHfnh3BIxGw0qSEGvCwIS7CxjwkyqsFi42aiKhxWVWVRdDoPBoHauESFGNRV20pA20iTcLE/9sF2yC0skM7/MNhOlsgCZUUorUKTMqoIctK3CImpHjh30xQOTZGiHOPlw5X7Vc7N6b7bqVQg1BUlhWbmUVlROu1VtD8LMlhAJCzbK2B6Jck6vVvLXrkxZsPaQyh/B++Kh6EnRzwbcJDxY9Z4cLSwTq6ZJq9gwlbyaV1wuxXiMVtkWV8MzNdFzSlrGhMjVQ9vJu8v3SlSoScwmo2QVlMqRwjIZ2LaJWrYodZ9falFBGJYZzrOTEB2qphPjXxZjo4bk7X2ozwcqZWVlEh4eLp9//rmMHz/edv+kSZMkJydHvv766+OeU1paqi72CxmBDQMVaizQa/DUoq2yO7NQ7RixQxveOV7G9WpVJRnSPj/Evh6Gq6TWP7Znyo0frJKicq1OO1n8i2AAWw2TMUgFFMivQHCBnT4CFvwdM1Uchy5Ur8CxXoi6bnSw4658LYOUliMYqmyL5uYQSn3S2xFmClKBDJZDdY/V29InOUYePre7PL/4X9WLhTL16FGJCg1W5etx4j8MRyEAS88vVdddDYERBUKg4vNDP0eOHBGLxSKJiYlV7sftbdu2OX3O7Nmz5eGHH26gFhKdeK/JwZwiadUkTAUkh3NK5Kv1B2XPkSIVDGhWqxwtKJMFaw/Kb9szpWuLKJWTcCCrWFbuOaoSN3OKyiUixKR6NZBfsT+rSAU4GE7IKS6ThRsPq94R9BDouQ21odn9e6wDQiwVVvnvcECk+Fj3iP53x+ejWip6Wk4EAqHKN6/8t7rDrNp8SgQSGIrCMgoxGdXQFIIgvB+GaPA+xmNX4qJC1X3ogTlaWK56XyIsVknPL6uxLRHmINWbgt6x64al2PKC0GuC8+kgD8ZVTRX2nFCg8vlApS5mzpypcloce1SIvMlxlsmSrRny/vI9sudIoWAihzpCN1TO7sCUVewckShZiNkgqvtT1P0r92TLsl1H1ZF3bXbGGJJxBe9bm/gFbcVwBIYekJeSW1ymdvAYkkEMUVyGgOi/XhhVeOxYMKByMqya04AGs1jwd6d/E5EYlctiloRosxzOKVbDR1g6GPY57jPhOcbK3I4IM4anLJJfYhGzUWyPRw8N8nBOTmmqiqihZwiPz1azdiJlzf5stWwKSsqlzKJJSblFPaZTYqSqRYLP/t3GQyrYQGIuLmLXfnzeZuEmiQgJlqiwYLl6aFtbPgl6RxwDE3CcrcMAhQKdzwcqcXFxYjQaJT09vcr9uN28eXOnzwkJCVEXIk9y92gXj1uyJUP1fmAHjR4QzJBBIih6QrBjxs4cO3hcrDjT7bGgIafkv+ACd+U72yMfg9dAjwCGIypPSGdVvQCqMqkY1BBQctNwNRMHpdYRCOkJm0iM3Z6eL+UW58GP3qug79xbxoRKj6QYFSw1jwm1zYpB8PXrtnRZn5pT2Xtz7KR4CECQcGs2BqkcDAQy+aXHRyMYSlJ5INbKoSP7tgSbRPUY9WgVLdcNa6eGujDrZ0d6gbz+207JtVtW+vLC50+KDVMzeo4WlkiIqfJ1zSZN2jSLkHP7tJILjp3fxn4YDXkw+Lw9WkbLxoO5qmcL79uvTaz0aBlbZfgNs5wwGwg5J9vT8tVjKywWNcTVOTFa7h7b2WWZegYiRH4QqJjNZunfv78sWbLElqOCZFrcnjZtmrebRwHKncJmKkA5tuOu3IEZJCrEpM5si4AFPRhqV+0QGTjOHtHpPS74u54rop5uFTEEiQoCWsaGquRMJLiu2ZejHhdhNqkT0OEoP9RklHN7t5Il29JVIIG9cfPYMDWckXlsJklpeYUUlVXmmkSGmFT+BDJDKqxWtROODg2W20d3kkHtmh0XqF1xchtVywOB2W/bM2RXZoHq+Qg1G9XMHey80WPRrkWMHMguVlN4i5Exq4ImzTaDJ6lpmOzMKFSBHIIufO7IkGBpnxCphkj0xGL0hnRrWSxr92er891gBg9ai7Zj5s9ZPVuo5Ng9mQVSUo52hqtlc1JKnC1AcRY0IJDD94thMgQoOGEfPpezoEJ/HpKH3/xjl8orwjfUrWWMGt5hmXoiPw9UAMM4SJ4dMGCAqp2C6cmFhYVy9dVXe7tpFIAQgGB6L5I5kaeAnTVyDewLm+l1Sdbtz1bDBdhBIzjZV17s1nCNnnzZNMIk5RWaCnIKSi3qucHHzuWCXhLs5NEDgQAiJNiodqzdEyNVTwZ21MgJQd6LwRAkFqtFYiOC5Ybh7dVZcvXpu5hFoldT/XlLuhrGgN5JsTK6e6LsPVoo321Mk/yScvVaqDOiD1+42nFfMbiNjOxWWXzMflozAh9UTEWNFvRaIFDBZ8lG7ZQKi1jFoHoxosPM0rV5tGw6lCfDO8VLq9hwaRoZ7HSWC26jTehZwfRizPRJiA5RPSZXDWmrHuMs4bg6roZl3HkOZ+QQBdisHx2mJusF3/r06SMvvfSSmrbcGDKWyb98sGKfvPLrDjWttbTCIhHBRjEHG+XG4R3UUfeavdny9rI9aqoughpXPST6cIqzwl4QHWZS9UXCgk2qpwS9NyoqEU0O5RSrWhp4fseESLloQCsxGoy24SX9vDEr92TJrowC9Xop8REqr6K6mSOuhrNONKnT2fMde6Uw9Rhl5/GZUCwOlW3xcW8/o5Nb7/n1+gMqoNLrvHCWDFH98PY+tNEEKo15IZN/wM4WR8tzft4umw/lqeRKwAgMaoVEmI1SWG6tHFKpBpI5UY+kwmpQRc6Gtm8m/2YUqOJriVEhquIphh6ws0UND5xwrl18ZJUKrig8hoAESaDn90tyWfZdtdmumqqvHeFXV+m2LucK4iwZIv/bhzJQIXKDvgPdk1moEkXLa5gig+RRPESzzy9RCaEGiY8MUc9HVdQbTmsnk4akOO1dQDVYZ8MV/r4z9vfPR9TY5LGOCpFvceyFAD2IOJhT7DJICTEZZHBKM7Vz/XVbhmTkl6rhHQxfhBiDxGg0qITQpKbhx+V61CYnwt9nivj75yOi2mGgQgHN2dDDW0t32/I64iKCVYInhmZQw6S6HpROCVHqfDEqjDFUFvcKPVa/o6Rck5iQYLnhtBQZ2LYZp6oSEbmJgQoFpA2p2fLT5sppw5VnzjVI1+ZRsjY1R52ErsxiVWe4PZBT4lZhtKQmoerkcMt2HlVJoJh5gtwS5JHgdcLN+jBPu4b7kEREfoCBCgVc78m3Gw6okvKoaooAJblpqKooit4UVG/Vk2Ttob6HxaKpGSl6pVWdOUjkmlNS5Lw+SbbaIjsy8lTQgqTX5KYRcnav5urvRERUOwxUKCDoyaqpWUXyz4Fc1YuCmTfoOdmeVqgCFsdz4NiXfkexMpz3BRVHUZAMvSToLQkPNsrEk5JtPSX68A0KkTkriEZERLXDQIUCoicFQQp6Q6LDgqXcapXSEovYp5zoQQoSYnHmX7APW/B3BCbNIkLkofO6qynIuPRKinFZeZQ5J0REJ46BCvl1Hgqqr6JKK4ZgEiJDJPVooZQeC0QcYQineXSoZBWVSZTZJEXqBHSVJ6LDJTYsWCae1FpGdnV+jikiIqp/DFTIL3tQ3vhtlyzZlqGqlOL8L8hBKbPiRH3HBylBx4qwYXYP/t69RbSk5ZWqk/t1aR4tHRMipGWT8Gp7T4iIyDMYqJBfBShfrj2gZvNsS8tXM3TCQ4xyVJ3YrmruSbBRxHJs6AdnHI4KDVbnh0mICpEQk1HiokKqPREdERE1DAYq5DfJss//9K9sPZyrTuJnORaQFNklorSMCVX/ZhWWqTPo5pdWqBMLWjVN2sWFy9TTO9b6RHRERORZDFTIL3pSXvllhwpSSuzyT/RrpiCDmuEztH2cpOUVqzMKo3x9dGiwxMWZ5ayeLaqcL4cBChGR72CgQo02OFm5K0sKSstVsiwKt7lKko0MMUpSkzApLKuQFrFhctGAZGkSHuyzJ+ojIqL/MFChRufd5XvkzaW7JTOvVN3G4I6rJNmQ4CCZMixFLuifxCEdIqJGiIEKNaqqsh+v3CufrTkoJRXHn3fHsWIsTvzXNMIsp3SMY00TIqJGioEK+XyAsmRrhvy1+4gcLSiT1XuzqhRqg6BjEUp8lFmVwC8stUhQkEhEiEkmDEjilGIiokaMgQr59EyeT1elyrr92aq7BGcodnYCY8QpIWajmrGT3CRCUnOKxGrV5Lph7VicjYiokWOgQj5d9r6kHAXbLJJdbJFSJ8M9erLs6O7NxWAwSF5JubSKDZNxvVvKsI7xDd5uIiKqXwxUyCchHwVl7wtKyiWjoFwczheozsmD4R4kxz5+fk/Vc6LnsTBhlojIfzBQIZ+0+VCOrNmXLXklFbb7Qk0GNa0YeSjNo8MkqWmYTB7aztZzwoRZIiL/w0CFfIJ9b8jWw3ny6MKttiAFuSlmk0F6t4qVuOgQMYhBJvRPZg0UIqIAwECFfCJpFvko+7MK5UBWsRzMKVHTjI1BBmkWYRaDVJ5M0GQMknCzifknREQBhIEKebX3BBCkrNqTJfuyimy5KCh73yImRBKiQ+VoQamYrZpcNCBJTkppxl4UIqIAwkCFvNJ7ciC7SJ3RuE9SjPy544gcyi2xPQZDPehFMQYFSW5RuYQFm9TMnk6J0QxSiIgCDAMVavApx1sO5UpqVpEUl1lk5Z4sWy8KCrepIMWAGT2aSpzt3Dxa8kvKVfE2vQeGiIgCBwMVajA70vPVyQP3HClUOSdl1qpF2wzH8lJQrC0qLFiVv88rLpfI0Mq8FPamEBEFHgYq1GBl8H/dli67Mwuk0D5C0SvLmgwSZDCIxaqJ2WSUiwckyVVD2rEuChFRgGOgQg1SBn8VztFTYZXicovTICUqNFhaxoZJuNkoY7snyqShKervDFCIiAIbAxXyWC/KjrQC+WxNqhzIxiyfUimtGqMoxiBRJe+7toyWiwckS8fEKAYnRERkw0CFPDaz51B2sezMLJCSMkuVIAW9KGajqNk8waYgFaRcMrA1a6MQEdFxGKiQR2b2YOpxh4QoWZeaI4VlVbtSMLsHeSi9kmNldLfmMrJbAntRiIjIKQYq5JGTCSZEhsjqfVlVghRMPQ42GiQ6LFi6NI+SO0d3kt7JTbzaXiIi8m0MVKhe7cjIlz2ZBao+Ck4eCJHmIAkLNqqgBTVTkpqEyZRT2zNIISKiGjFQoXod9vl1W4bkFFfYgpQQo0G6t4qRbi2iZWdGgSrmxp4UIiJyFwMVqjf/phXIz1szpKC0Qp2rZ0j7ZpJTVCYxYWZJzyuVFrFhqnAbgxQiInIXAxWqF9vS8uTOz9arICU0OEjO7d1SJdQ2jwmVy09qLcFGIwu3ERFRrTFQoRO2dn+2XP32KsktLlc1Ufokx0hBSYWt9D17UIiIqK4YqNAJWbbziEx5b7XKSenXOlbenjxIisorWPqeiIjqBQMVqrMfN6fJLR+tkzKLVYZ1jJM3ruwv4WaTxAgDFCIiqh8MVKhOFqw5INMXbFQnERzbvbm8OLGPhJiM3m4WERH5GQYqVGvv/7VPHvhqk7p+Uf8kefKCnmLCSXuIiIjqGQMVqpUP7IKUyUPayqxzukkQauITERF5AAMVctuHK/fJ/ceClCnD2sm9Z3VVBdyIiIg8hf315JaP/94v931ZGaRcewqDFCIiahgMVKhG81ftl5lf/KOuXzO0ndx/NoMUIiJqGAxUqFqfrk6VGceCFOSkPHAOgxQiImo4DFTIpe//OSwzFmxUpfAnDW4jD47rxiCFiIgaFAMVcmrpjky59ZN1YtVEJg5KlofO7c4ghYiIGhwDFXJ67p7r31sj5RZNzu7ZQh4b35NBChEReQUDFapie1q+OsFgcblFlcV//pLeYmSdFCIi8hIGKmSTmlUkV/7fSnUW5L6tY2XuFf1ZFp+IiLyKgQopRwpK5Yr/WykZ+aXSOTFK3p48UCJCWA+QiIi8i4EKSXGZRa57d7XsO1okyU3D5L1rB0lsuNnbzSIiImKgEuhw9uPb5q+T9ak5EhseLO9ePUgSo0O93SwiIiLPBiqPP/64DBkyRMLDwyU2NtbpY/bv3y9nn322ekxCQoLcfffdUlFRUeUxv/32m/Tr109CQkKkQ4cO8s4773iqyQFp9vdb5cfN6WI2Bsm8KwdISnykt5tERETk+UClrKxMJkyYIDfddJPTv1ssFhWk4HHLly+Xd999VwUhs2bNsj1mz5496jEjRoyQ9evXy2233SbXXXed/Pjjj55qdkB5b8VeeevPPer6MxN6yaB2Tb3dJCIioioMmoa6o56D4AMBRk5OTpX7Fy1aJOecc44cOnRIEhMT1X1z586Ve+65RzIzM8VsNqvr3333nWzaVHkyPLj00kvVa/3www9utyEvL09iYmIkNzdXoqOj6/HTNV5LtqbLlPdWq4Jud4/pLFNHdPB2k4iIyAfleXkf6rUclRUrVkjPnj1tQQqMGTNGLZDNmzfbHjNq1Kgqz8NjcH91SktL1evYX+g/mw7myrSPKqvOXjowWW4e3t7bTSIiIvKtQCUtLa1KkAL6bfytuscg8CguLnb52rNnz1bRn35JTk72yGdojDLzS1VPil7Q7dHxPVh1loiI/CNQmTFjhtqpVXfZtm2beNvMmTNVF5V+SU1N9XaTfEJZhVVu/nCNHM4tkZT4CHn18n4SbOTELyIi8l21quh15513yuTJk6t9TEpKiluv1bx5c/n777+r3Jeenm77m/6vfp/9YzBGFhYW5vK1MUMIF6rqoW83y6q92RIVYpI3rxog0aHB3m4SERFR/QUq8fHx6lIfBg8erKYwZ2RkqKnJsHjxYhWEdOvWzfaY77//vsrz8BjcT7XzwV/75KOV+wWjPC9N7CvtOQ2ZiIgaAY/1+6NGCqYU419MRcZ1XAoKCtTfR48erQKSK6+8UjZs2KCmHN9///0ydepUW2/IjTfeKLt375bp06erIaXXXntNPv30U7n99ts91Wy/tHL3UXnom8oE5eljusiILpWBIRERUcBOT8YQEWqjOPr1119l+PDh6vq+fftUnRUUdYuIiJBJkybJk08+KSbTfx09+BsCky1btkhSUpI88MADNQ4/+drUKm86kF0k572yTI4Wlsm43i3lpUv7MHmWiIgazT7U43VUfIG3F7K3lJRb5KK5y2XTwTzp3jJaPr9xiISZeTZkIiJqPPtQTvnwY48s3KKClCbhwTLvqgEMUoiIqNFhoOKnvlx3wJY8+8KlfaVVrOtZUkRERL6KgYof+jc9X+79ovK0A7ec3lFO61Q/M7WIiIgaGgMVP1NYWiE3f7hWVZ49pUOc3Dqyo7ebREREVGcMVPwI8qJnfvGP7MwokMToEHnh0j5iDOIMHyIiarwYqPiRD1bul282HFLBySuX9ZO4SFbnJSKixo2Bip/YfChXHv12i7o+Y2wXGdi2qbebREREdMIYqPiB4jKL/O/jdVJmscqorgly3bB23m4SERFRvWCg4gce+26L7MoslISoEHn6ot6sPEtERH6DgUoj9+PmNPnwWL2UOZf0kaYRZm83iYiIqN4wUGnE0nJL5J4FG9X164elyNAOcd5uEhERUb1ioNJIWa2a3PHpeskpKpceraLlztGdvd0kIiKiesdApZGat3S3LN91VMKCjfLSpX3FbOJXSURE/od7t0bonwO58uyP29X1h8/tLinxkd5uEhERkUcwUGlkSsotasinwqrJWT2by4QBSd5uEhERkccwUGlk5vz8r+zIKFBVZx8f35NTkYmIyK8xUGlE1uzLknl/7FbXZ1/QU5pwKjIREfk5BiqNqPrsXZ9tFE0TubBfkpzRLdHbTSIiIvI4BiqNxFM/bJM9RwqleXSozBrXzdvNISIiahAMVBqB5buOyDvL96rrT13US2LCgr3dJCIiogbBQMXHFZRWyPTPK6vPXnZSazmtU7y3m0RERNRgGKj4uNnfb5UD2cWS1CRM7j2rq7ebQ0RE1KAYqPiwlbuPqhMOwjMX9ZbIEJO3m0RERNSgGKj4cGG3mV/+o65PHNRaBrdv5u0mERERNTgGKj7q1V93yu7MQkmICpEZZ3bxdnOIiIi8goGKD9qWliev/7ZLXX/kvO6c5UNERAGLgYqPsVg1mbHgH3UunzHdE2VsjxbebhIREZHXMFDxMe+t2CvrU3MkKsQkj5zXw9vNISIi8ioGKj7kQHaRPPPjdnV9xlldJDE61NtNIiIi8ioGKj5C0zR54KtNUlRmkUFtm8rEga293SQiIiKvY6DiI37cnCa/bs8UszFInrigpwQFGbzdJCIiIq9joOIDisoq5JFvt6jrN5yWIh0SIr3dJCIiIp/AQMUHvLRkpxzKLVFl8m8e3sHbzSEiIvIZDFS8bGdGvry1dLe6/tC47hJmNnq7SURERD6DgYrXE2g3q5opo7omyKhuid5uEhERkU9hoOJF32w4JCt2H5UQU5A8OK67t5tDRETkcxioeEl+Sbk8/t1WdX3qiA6S3DTc200iIiLyOQxUvOSFn3dIRn6ptG0WLtefmuLt5hAREfkkBipesD0tX95Zvlddf+jc7hIazARaIiIiZxioeCGB9pGFm9XJB3HSweGdE7zdJCIiIp/FQKWB/bw1Q5btPKoq0N5/djdvN4eIiMinMVBpQKUVFnn8u8oKtNcOa8cEWiIiohowUGlA7y7fK3uPFklcZIia6UNERETVY6DSQI4UlMrLS3aq69PHdJbIEJO3m0REROTzGKg0kOd++lfySyukR6touah/krebQ0RE1CgwUGkAWw7lyfxV+9X1Wed0l6Agg7ebRERE1CgwUGmA6ciPLtwiVk3k7J4tZFC7pt5uEhERUaPBQMXDftqSrs7nYzYFyYwzu3i7OURERI0KAxUPKrdY5clF29T1KZyOTEREVGsMVDzok1WpsudIoTSLMMtNwzkdmYiIqLYYqHhIYWmFvPjzDnX9fyM7cjoyERFRHTBQ8ZA3l+5WtVPaNAuXiYNae7s5REREjRIDFQ/IzC+VeX/sVtfvHtNZJdISERFR7XlsD7p371659tprpV27dhIWFibt27eXBx98UMrKyqo8buPGjTJs2DAJDQ2V5ORkefrpp497rc8++0y6dOmiHtOzZ0/5/vvvxZe9tGSHFJVZpHdSjJqSTERERD4WqGzbtk2sVqu88cYbsnnzZpkzZ47MnTtX7r33Xttj8vLyZPTo0dKmTRtZs2aNPPPMM/LQQw/JvHnzbI9Zvny5TJw4UQU969atk/Hjx6vLpk2bxBchefbjvyuLu804s6sYDCzuRkREVFcGDRXJGggCkddff112764cFsH1++67T9LS0sRsNqv7ZsyYIV999ZUKdOCSSy6RwsJCWbhwoe11Tj75ZOnTp48KfNyBgCgmJkZyc3MlOjpaPOnmD9fI9/+kyYjO8fL21YM8+l5ERESe1pD7UGcaNHkCH7Jp0/8qs65YsUJOPfVUW5ACY8aMke3bt0t2drbtMaNGjaryOngM7vc16/ZnqyAFnSj3sLgbERFR4wlUdu7cKS+//LLccMMNtvvQk5KYmFjlcfpt/K26x+h/d6a0tFRFgPYXT0PHlF7c7cJ+SdKlecNHnURERBLogQqGZpB3Ud1FH7bRHTx4UMaOHSsTJkyQKVOmiKfNnj1bdVPpFyTpetqfO4/Iyj1ZaobPHWd08vj7ERERBYJaVyG78847ZfLkydU+JiUlxXb90KFDMmLECBkyZEiVJFlo3ry5pKenV7lPv42/VfcY/e/OzJw5U+644w7bbfSoeDJYQW/Ksz/9q65fcVIbaRkb5rH3IiIiCiS1DlTi4+PVxR3oSUGQ0r9/f3n77bclKKhqB87gwYNVMm15ebkEBwer+xYvXiydO3eWJk2a2B6zZMkSue2222zPw2NwvyshISHq0lCWbM2QDak5EhZslJuGt2+w9yUiIvJ3HstRQZAyfPhwad26tTz77LOSmZmp8krsc0suu+wylUiLqceYwjx//nx58cUXq/SG3HrrrfLDDz/Ic889p4aUMH159erVMm3aNPEFVqsmzy2u7E2ZPLStxEc1XIBERETk7zx2Ahr0eiCBFpekpKQqf9NnRCN/5KeffpKpU6eqXpe4uDiZNWuWXH/99bbHYsjoo48+kvvvv1/VYOnYsaOavtyjRw/xBYs2pcnWw3kSFWKSG079b8iLiIiIGlkdFX+bA26xajJ6zu+yK7NQbhvVUW4bxSRaIiLyL3mBVEfF33y9/qAKUmLDg+XaU9p5uzlERER+h4FKHZVbrPLCzzvU9RtPay9RoZXJwERERFR/GKjU0edrDsj+rCKJiwyRqwa38XZziIiI/BIDlTooKbeoMyTD1BHtJdzssZxkIiKigMZApQ4Wb0mXw7kl0iImVCYOau3t5hAREfktdgXUwTm9WkiTcLMUl1skNNjo7eYQERH5LQYqdYDzGZ3SMc7bzSAiIvJ7HPohIiIin8VAhYiIiHwWAxUiIiLyWQxUiIiIyGcxUCEiIiKfxUCFiIiIfBYDFSIiIvJZDFSIiIjIZzFQISIiIp/FQIWIiIh8VkCU0Nc0Tf2bl5fn7aYQERE1KnnH9p36vrShBUSgkp+fr/5NTk72dlOIiIga7b40Jiamwd/XoHkrRGpAVqtVDh06JFFRUeqEgvUVYSLwSU1Nlejo6Hp5TX/A5eIal41zXC6ucdk4x+XSsMsGYQKClJYtW0pQUMNnjAREjwoWbFJSkkdeGysCfyjH43JxjcvGOS4X17hsnONyabhl442eFB2TaYmIiMhnMVAhIiIin8VApY5CQkLkwQcfVP/Sf7hcXOOycY7LxTUuG+e4XAJr2QREMi0RERE1TuxRISIiIp/FQIWIiIh8FgMVIiIi8lkMVIiIiMhnMVCpJ999952cdNJJEhYWJk2aNJHx48d7u0k+pbS0VPr06aMqA69fv14C2d69e+Xaa6+Vdu3aqfWlffv2Kku/rKxMAtGrr74qbdu2ldDQUPUb+vvvvyWQzZ49WwYOHKgqaSckJKhtyfbt273dLJ/z5JNPqu3Jbbfd5u2m+ISDBw/KFVdcIc2aNVPblZ49e8rq1avFHzBQqQcLFiyQK6+8Uq6++mrZsGGDLFu2TC677DJvN8unTJ8+XZVfJpFt27ap0zq88cYbsnnzZpkzZ47MnTtX7r33Xgk08+fPlzvuuEMFamvXrpXevXvLmDFjJCMjQwLV77//LlOnTpW//vpLFi9eLOXl5TJ69GgpLCz0dtN8xqpVq9Tvp1evXt5uik/Izs6WoUOHSnBwsCxatEi2bNkizz33nDpo9guYnkx1V15errVq1Up76623vN0Un/X9999rXbp00TZv3oyp8Nq6deu83SSf8/TTT2vt2rXTAs2gQYO0qVOn2m5bLBatZcuW2uzZs73aLl+SkZGhfje///67t5viE/Lz87WOHTtqixcv1k477TTt1ltv1QLdPffco51yyimav2KPygnCUSC63HA+ob59+0qLFi3kzDPPlE2bNnm7aT4hPT1dpkyZIu+//76Eh4d7uzk+Kzc3V5o2bSqBBENda9askVGjRtnuw+8It1esWOHVtvkSrBsQaOuHK+htOvvss6usN4Hum2++kQEDBsiECRPUcCH2RW+++ab4CwYqJ2j37t3q34ceekjuv/9+WbhwoepuGz58uGRlZUkgQy3ByZMny4033qh+ROTczp075eWXX5YbbrhBAsmRI0fEYrFIYmJilftxOy0tzWvt8iUYIkQOBrr1e/ToIYHuk08+UQeHyOOhqvuh119/XTp27Cg//vij3HTTTfK///1P3n33XfEHDFRcmDFjhkrUqu6i5xrAfffdJxdeeKH0799f3n77bfX3zz77TAJ52WDni1ODz5w5UwKBu8vFHnrjxo4dq46E0PNE5Nh7gN5Z7KADXWpqqtx6663y4YcfqsRr+g/2Q/369ZMnnnhC9aZcf/31anuC3Dd/YPJ2A3zVnXfeqXoDqpOSkiKHDx9W17t162a7H+dYwN/2798vgbxsfvnlF9WF73jOCfSuXH755X4T7dd2uegOHTokI0aMkCFDhsi8efMk0MTFxYnRaFTDg/Zwu3nz5hLopk2bpnpo//jjD0lKSpJAh2FCJFljh6xDjxyWzyuvvKJmFmJ9CkQtWrSosg+Crl27qoke/oCBigvx8fHqUhP0oGBHjOmDp5xyiroPWfqYgtqmTRsJ5GXz0ksvyWOPPVZlx4wZHZjpgWmogbpc9J4UBCl6DxxyMwKN2WxWn3/JkiW26fw4MsRt7KQDecj0lltukS+//FJ+++03NY2dREaOHCn//PNPlfsw07JLly5yzz33BGyQAhgadJzC/u+///rNPoiBygmKjo5WORiYXpmcnKxWjGeeeUb9Dd35gax169ZVbkdGRqp/UTckkI8QEaQghwnryrPPPiuZmZm2vwVaTwKmJk+aNEn1sg0aNEheeOEFNQ0XO6BAHu756KOP5Ouvv1a1VPR8nZiYGFUfI1BhWTjm6URERKi6IYGev3P77bernlkM/Vx88cWqFhF6af2lp5aBSj1AYGIymVQtleLiYtVbgGEPv5nDTvUKtTGQQIuLY8AWaCczv+SSS1SgNmvWLLVDRlHAH3744bgE20CCpEhAMGsPPW81DS1SYBo4cKDqgUM+4COPPKJ64RD0Y4jdHxgwR9nbjSAiIiJyJvAGxomIiKjRYKBCREREPouBChEREfksBipERETksxioEBERkc9ioEJEREQ+i4EKERER+SwGKkREROSzGKgQERGRz2KgQkRERD6LgQoRERH5LAYqREREJL7q/wNn6kYjCp7REAAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 600x400 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.figure(figsize=(6, 4))\n",
+    "plt.scatter(train_x1.cpu().numpy(), train_y.cpu().numpy(), s=10, alpha=0.5, label=\"train noisy\")\n",
+    "plt.plot(test_x1.cpu().numpy(), test_y_true.cpu().numpy(), label=\"true function\")\n",
+    "plt.title(\"Toy regression: y = x^3 + noise (train in [-4,4], test in [-6,6])\")\n",
+    "plt.legend()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3dcd8e66",
+   "metadata": {},
+   "source": [
+    "### Uncertainty & evaluation setup (important)\n",
+    "\n",
+    "In this notebook, epistemic uncertainty for dropout / dropconnect / ensemble / Bayesian methods is estimated via repeated stochastic forward passes (MC samples). Observation noise is assumed to be **known and homoskedastic Gaussian noise** from the data generation process, denoted as `known_noise_std`.\n",
+    "\n",
+    "Therefore, we form the total predictive uncertainty as:\n",
+    "\n",
+    "`total_std = sqrt(epistemic_std**2 + known_noise_std**2)`\n",
+    "\n",
+    "For evaluation, **RMSE** is computed against the noise-free target `test_y_true` (function approximation quality), while **NLL** is computed against the noisy observations `test_y` (distributional calibration). We additionally report NLL separately for **in-distribution** (within the training x-range) and **OOD** (outside the training x-range).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "3a9f697b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from torch import Tensor\n",
+    "\n",
+    "\n",
+    "@torch.no_grad()\n",
+    "def mc_predict(\n",
+    "    model: nn.Module,\n",
+    "    x: Tensor,\n",
+    "    num_samples: int = 75,\n",
+    "    force_train_mode: bool = False,\n",
+    ") -> tuple[Tensor, Tensor]:\n",
+    "    was_training = model.training\n",
+    "    model.train(mode=force_train_mode)\n",
+    "\n",
+    "    preds: list[Tensor] = []\n",
+    "    for _ in range(num_samples):\n",
+    "        preds.append(model(x))\n",
+    "\n",
+    "    stacked = torch.stack(preds, dim=0)\n",
+    "    mean = stacked.mean(dim=0)\n",
+    "    std = stacked.std(dim=0, unbiased=False)\n",
+    "\n",
+    "    model.train(mode=was_training)\n",
+    "    return mean, std\n",
+    "\n",
+    "\n",
+    "def train_mse(\n",
+    "    model: torch.nn.Module,\n",
+    "    x: torch.Tensor,\n",
+    "    y: torch.Tensor,\n",
+    "    epochs: int = 500,\n",
+    "    lr: float = 1e-2,\n",
+    "    weight_decay: float = 0.0,\n",
+    "    verbose_every: int = 300,\n",
+    ") -> torch.nn.Module:\n",
+    "    \"\"\"Train a model with MSE loss on (x, y).\"\"\"\n",
+    "    model.to(device)\n",
+    "    model.train()\n",
+    "\n",
+    "    opt = torch.optim.Adam(model.parameters(), lr=lr, weight_decay=weight_decay)\n",
+    "    loss_fn = torch.nn.MSELoss()\n",
+    "\n",
+    "    for ep in range(1, epochs + 1):\n",
+    "        opt.zero_grad()\n",
+    "        pred = model(x)\n",
+    "        loss = loss_fn(pred, y)\n",
+    "        loss.backward()\n",
+    "        opt.step()\n",
+    "\n",
+    "        if verbose_every and ep % verbose_every == 0:\n",
+    "            print(f\"epoch {ep:4d} | mse {loss.item():.4f}\")\n",
+    "\n",
+    "    return model\n",
+    "\n",
+    "\n",
+    "def gaussian_nll(\n",
+    "    y: torch.Tensor,\n",
+    "    mean: torch.Tensor,\n",
+    "    std: torch.Tensor,\n",
+    ") -> torch.Tensor:\n",
+    "    \"\"\"Pointwise Gaussian negative log-likelihood.\"\"\"\n",
+    "    var = std**2 + 1e-8\n",
+    "    return 0.5 * torch.log(2 * math.pi * var) + 0.5 * (y - mean) ** 2 / var\n",
+    "\n",
+    "\n",
+    "def mean_nll(\n",
+    "    y: torch.Tensor,\n",
+    "    mean: torch.Tensor,\n",
+    "    std: torch.Tensor,\n",
+    "    mask: torch.Tensor | None = None,\n",
+    ") -> float:\n",
+    "    nll = gaussian_nll(y, mean, std)\n",
+    "    if mask is not None:\n",
+    "        nll = nll[mask]\n",
+    "    return nll.mean().item()\n",
+    "\n",
+    "\n",
+    "@torch.no_grad()\n",
+    "def rmse(y: torch.Tensor, mean: torch.Tensor) -> float:\n",
+    "    \"\"\"Root mean squared error.\"\"\"\n",
+    "    return torch.sqrt(torch.mean((y - mean) ** 2)).item()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "feab6e69",
+   "metadata": {},
+   "source": [
+    "## Predictive uncertainty via sampling\n",
+    "\n",
+    "Some transformations are stochastic at inference:\n",
+    "- **dropout / dropconnect**: randomness comes from masks\n",
+    "- **bayesian**: randomness comes from weight sampling (implementation-dependent)\n",
+    "- **ensemble**: randomness comes from multiple trained members (no repeated sampling needed)\n",
+    "\n",
+    "For these methods we estimate:\n",
+    "- Predictive mean: average over samples/models\n",
+    "- Epistemic std: standard deviation over samples/models\n",
+    "\n",
+    "Because our base models output only a single scalar (no explicit noise head),\n",
+    "we form a **total** predictive std using:\n",
+    "\n",
+    "total_std = sqrt(epistemic_std² + noise_std²)\n",
+    "\n",
+    "This gives a reasonable predictive distribution for NLL evaluation.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "b03534fd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dist = torch.distributions\n",
+    "\n",
+    "\n",
+    "def evidential_studentt_params(\n",
+    "    out_dict: dict[str, torch.Tensor],\n",
+    ") -> tuple[\n",
+    "    torch.Tensor,\n",
+    "    torch.Tensor,\n",
+    "    torch.Tensor,\n",
+    "    torch.Tensor,\n",
+    "    torch.Tensor,\n",
+    "    torch.Tensor,\n",
+    "    torch.Tensor,\n",
+    "]:\n",
+    "    gamma = out_dict[\"gamma\"]\n",
+    "    nu = out_dict[\"nu\"]\n",
+    "    alpha = out_dict[\"alpha\"]\n",
+    "    beta = out_dict[\"beta\"]\n",
+    "\n",
+    "    df = 2.0 * alpha\n",
+    "    loc = gamma\n",
+    "    var = beta * (1.0 + nu) / (nu * alpha)\n",
+    "    scale = torch.sqrt(var + 1e-8)\n",
+    "    return gamma, nu, alpha, beta, df, loc, scale\n",
+    "\n",
+    "\n",
+    "def evidential_loss(\n",
+    "    out_dict: dict[str, torch.Tensor],\n",
+    "    y: torch.Tensor,\n",
+    "    lam: float = 0.01,\n",
+    ") -> tuple[torch.Tensor, float, float]:\n",
+    "    gamma, nu, alpha, beta, df, loc, scale = evidential_studentt_params(out_dict)\n",
+    "    tdist = dist.StudentT(df=df, loc=loc, scale=scale)\n",
+    "\n",
+    "    nll = -tdist.log_prob(y).mean()\n",
+    "    evidence = 2.0 * nu + alpha\n",
+    "    reg = (torch.abs(y - gamma) * evidence).mean()\n",
+    "\n",
+    "    return nll + lam * reg, nll.item(), reg.item()\n",
+    "\n",
+    "\n",
+    "@torch.no_grad()\n",
+    "def evidential_decompose(\n",
+    "    out_dict: dict[str, torch.Tensor],\n",
+    ") -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:\n",
+    "    gamma = out_dict[\"gamma\"]\n",
+    "    nu = out_dict[\"nu\"]\n",
+    "    alpha = out_dict[\"alpha\"]\n",
+    "    beta = out_dict[\"beta\"]\n",
+    "\n",
+    "    ale_var = beta / (alpha - 1.0 + 1e-8)\n",
+    "    epi_var = beta / (nu * (alpha - 1.0 + 1e-8))\n",
+    "\n",
+    "    ale_std = torch.sqrt(ale_var + 1e-8)\n",
+    "    epi_std = torch.sqrt(epi_var + 1e-8)\n",
+    "    total_std = torch.sqrt(ale_var + epi_var + 1e-8)\n",
+    "\n",
+    "    return gamma, ale_std, epi_std, total_std"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ce9d245e",
+   "metadata": {},
+   "source": [
+    "## Train + Evaluate: Dropout\n",
+    "MC sampling at inference (keep train mode during prediction).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7c461608",
+   "metadata": {},
+   "source": [
+    "## Dropout (MC Dropout)\n",
+    "\n",
+    "Training is standard MSE.\n",
+    "At evaluation we keep the model in `train()` mode so dropout stays active, then run\n",
+    "many forward passes. Variation across predictions approximates epistemic uncertainty.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "46fb70e1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dropout | RMSE: 66.88179016113281 | NLL_in: 40.215293884277344 | NLL_ood: 322.47161865234375\n"
+     ]
+    }
+   ],
+   "source": [
+    "base = MAKE_BASE().to(device)\n",
+    "m_dropout = dropout(base, p=0.1).to(device)\n",
+    "\n",
+    "m_dropout = train_mse(m_dropout, train_x, train_y, epochs=CFG[\"epochs\"], lr=1e-2, verbose_every=CFG[\"verbose_every\"])\n",
+    "\n",
+    "# MC sampling (force train mode so dropout is active)\n",
+    "mean_do, std_do = mc_predict(m_dropout, test_x, num_samples=CFG[\"mc_samples\"], force_train_mode=True)\n",
+    "\n",
+    "# Total std: epistemic from MC + known aleatoric (noise_std)\n",
+    "total_std_do = torch.sqrt(std_do**2 + noise_std**2)\n",
+    "\n",
+    "nll_do_in = mean_nll(test_y, mean_do, total_std_do, in_mask)\n",
+    "nll_do_ood = mean_nll(test_y, mean_do, total_std_do, ood_mask)\n",
+    "\n",
+    "rmse_do = rmse(test_y_true, mean_do)\n",
+    "\n",
+    "print(\"Dropout | RMSE:\", rmse_do, \"| NLL_in:\", nll_do_in, \"| NLL_ood:\", nll_do_ood)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2067c259",
+   "metadata": {},
+   "source": [
+    "## Train + Evaluate: DropConnect\n",
+    "MC sampling at inference (keep train mode during prediction).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9ad13ed9",
+   "metadata": {},
+   "source": [
+    "## DropConnect\n",
+    "\n",
+    "Same idea as dropout, but the randomness affects connections/weights rather than activations\n",
+    "(depending on implementation). We again use multiple forward passes to estimate epistemic uncertainty.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "8fd1bd7d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DropConnect | RMSE: 66.45568084716797 | NLL_in: 37.09754180908203 | NLL_ood: 437.0319519042969\n"
+     ]
+    }
+   ],
+   "source": [
+    "base = MAKE_BASE().to(device)\n",
+    "m_dc = dropconnect(base, p=0.1).to(device)\n",
+    "\n",
+    "m_dc = train_mse(m_dc, train_x, train_y, epochs=CFG[\"epochs\"], lr=1e-2, verbose_every=CFG[\"verbose_every\"])\n",
+    "\n",
+    "mean_dc, std_dc = mc_predict(m_dc, test_x, num_samples=CFG[\"mc_samples\"], force_train_mode=True)\n",
+    "total_std_dc = torch.sqrt(std_dc**2 + noise_std**2)\n",
+    "\n",
+    "nll_dc_in = mean_nll(test_y, mean_dc, total_std_dc, in_mask)\n",
+    "nll_dc_ood = mean_nll(test_y, mean_dc, total_std_dc, ood_mask)\n",
+    "\n",
+    "rmse_dc = rmse(test_y_true, mean_dc)\n",
+    "\n",
+    "print(\"DropConnect | RMSE:\", rmse_dc, \"| NLL_in:\", nll_dc_in, \"| NLL_ood:\", nll_dc_ood)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e058a4b7",
+   "metadata": {},
+   "source": [
+    "## Train + Evaluate: Ensemble\n",
+    "No MC sampling: variance comes from member disagreement.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8ec6392a",
+   "metadata": {},
+   "source": [
+    "## Ensemble\n",
+    "\n",
+    "`probly.transformation.ensemble(...)` returns a `torch.nn.ModuleList`, i.e. multiple independent members.\n",
+    "\n",
+    "Key consequence:\n",
+    "- You cannot do `members(X)` because `ModuleList` has no `forward`.\n",
+    "- You must run each member separately, then aggregate.\n",
+    "\n",
+    "Uncertainty comes from **member disagreement**:\n",
+    "- mean over members = predictive mean\n",
+    "- std over members = epistemic uncertainty estimate\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "d42a7e39",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Ensemble | RMSE: 54.49751281738281 | NLL_in: 2.9756195545196533 | NLL_ood: 6.665450572967529\n"
+     ]
+    }
+   ],
+   "source": [
+    "from collections.abc import Sequence\n",
+    "\n",
+    "base = MAKE_BASE().to(device)\n",
+    "members = ensemble(base, num_members=CFG[\"ensemble_members\"], reset_params=True)\n",
+    "\n",
+    "for mm in members:\n",
+    "    mm.to(device)\n",
+    "\n",
+    "opt = torch.optim.Adam([p for mm in members for p in mm.parameters()], lr=1e-2)\n",
+    "loss_fn = torch.nn.MSELoss()\n",
+    "\n",
+    "for ep in range(1, CFG[\"ensemble_epochs\"] + 1):\n",
+    "    opt.zero_grad()\n",
+    "\n",
+    "    member_losses = [loss_fn(mm(train_x), train_y) for mm in members]\n",
+    "    loss = torch.stack(member_losses).mean()\n",
+    "\n",
+    "    loss.backward()\n",
+    "    opt.step()\n",
+    "\n",
+    "    if CFG[\"verbose_every\"] and ep % CFG[\"verbose_every\"] == 0:\n",
+    "        print(f\"epoch {ep:4d} | mse {loss.item():.4f}\")\n",
+    "\n",
+    "\n",
+    "@torch.no_grad()\n",
+    "def ensemble_predict(\n",
+    "    members: Sequence[torch.nn.Module],\n",
+    "    x: torch.Tensor,\n",
+    ") -> tuple[torch.Tensor, torch.Tensor]:\n",
+    "    \"\"\"Predictive mean and std across ensemble members.\"\"\"\n",
+    "    preds: list[torch.Tensor] = []\n",
+    "    for mm in members:\n",
+    "        mm.eval()\n",
+    "        preds.append(mm(x))\n",
+    "    stacked = torch.stack(preds, dim=0)  # [M, N, 1]\n",
+    "    return stacked.mean(dim=0), stacked.std(dim=0, unbiased=False)\n",
+    "\n",
+    "\n",
+    "mean_ens, std_ens = ensemble_predict(members, test_x)\n",
+    "total_std_ens = torch.sqrt(std_ens**2 + noise_std**2)\n",
+    "\n",
+    "nll_ens_in = mean_nll(test_y, mean_ens, total_std_ens, in_mask)\n",
+    "nll_ens_ood = mean_nll(test_y, mean_ens, total_std_ens, ood_mask)\n",
+    "\n",
+    "rmse_ens = rmse(test_y_true, mean_ens)\n",
+    "\n",
+    "print(\"Ensemble | RMSE:\", rmse_ens, \"| NLL_in:\", nll_ens_in, \"| NLL_ood:\", nll_ens_ood)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1d7ae451",
+   "metadata": {},
+   "source": [
+    "## Train + Evaluate: Bayesian\n",
+    "We treat the transformed model as stochastic and MC-sample it at inference.\n",
+    "(Training is plain MSE here, because this notebook is about using the ProBly transformation API.)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d5fe7f3c",
+   "metadata": {},
+   "source": [
+    "## Bayesian transformation (practical note)\n",
+    "\n",
+    "In a “full Bayesian” setup you might train with an ELBO/KL term.\n",
+    "Here we deliberately keep training simple (MSE), because the goal of this notebook is to demonstrate:\n",
+    "- the ProBly API usage\n",
+    "- the stochastic behavior at inference\n",
+    "- uncertainty-aware evaluation\n",
+    "\n",
+    "We still use MC sampling at inference to obtain a predictive distribution.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "86c62a51",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Bayesian | RMSE: 65.43173217773438 | NLL_in: 37.11834716796875 | NLL_ood: 1430.4635009765625\n"
+     ]
+    }
+   ],
+   "source": [
+    "base = MAKE_BASE().to(device)\n",
+    "m_bayes = bayesian(base).to(device)\n",
+    "\n",
+    "m_bayes = train_mse(m_bayes, train_x, train_y, epochs=CFG[\"epochs\"], lr=1e-2, verbose_every=CFG[\"verbose_every\"])\n",
+    "\n",
+    "# MC sampling: even in eval it may be stochastic, but we'll just sample.\n",
+    "mean_b, std_b = mc_predict(m_bayes, test_x, num_samples=CFG[\"mc_samples\"], force_train_mode=False)\n",
+    "total_std_b = torch.sqrt(std_b**2 + noise_std**2)\n",
+    "\n",
+    "nll_b_in = mean_nll(test_y, mean_b, total_std_b, in_mask)\n",
+    "nll_b_ood = mean_nll(test_y, mean_b, total_std_b, ood_mask)\n",
+    "\n",
+    "rmse_b = rmse(test_y_true, mean_b)\n",
+    "\n",
+    "print(\"Bayesian | RMSE:\", rmse_b, \"| NLL_in:\", nll_b_in, \"| NLL_ood:\", nll_b_ood)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "e934bed2",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "bayes sample std mean: 29.752193450927734\n"
+     ]
+    }
+   ],
+   "source": [
+    "with torch.no_grad():\n",
+    "    s = torch.stack([m_bayes(test_x) for _ in range(10)], dim=0).std().mean().item()\n",
+    "print(\"bayes sample std mean:\", s)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ef862953",
+   "metadata": {},
+   "source": [
+    "## Train + Evaluate: Evidential Regression\n",
+    "Single forward gives distribution parameters + analytic decomposition.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2b2d0e96",
+   "metadata": {},
+   "source": [
+    "## Evidential Regression\n",
+    "\n",
+    "Evidential regression returns a dict of distribution parameters:\n",
+    "- gamma: mean-like location\n",
+    "- nu, alpha, beta: evidence/shape parameters\n",
+    "\n",
+    "Unlike sampling-based methods, evidential regression can provide an analytic decomposition:\n",
+    "- **aleatoric uncertainty** ~ beta / (alpha - 1)\n",
+    "- **epistemic uncertainty** ~ beta / (nu * (alpha - 1))\n",
+    "\n",
+    "We compute:\n",
+    "- Student-t NLL (faithful to evidential predictive distribution)\n",
+    "- Optional Gaussian-approx NLL (for easier comparison with other methods)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "10fc1517",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "epoch  400 | loss 5.3736 | nll 5.1058 | reg 26.7803\n",
+      "epoch  800 | loss 4.9962 | nll 4.7552 | reg 24.1011\n",
+      "Evidential | RMSE: 79.96048736572266 | NLL(StudentT)_in: 4.8924336433410645 | NLL(StudentT)_ood: 11.615111351013184 | NLL(Gauss)_in: 19.519474029541016 | NLL(Gauss)_ood: 612.5783081054688\n"
+     ]
+    }
+   ],
+   "source": [
+    "base = MAKE_BASE().to(device)\n",
+    "m_evi = evidential_regression(base).to(device)\n",
+    "\n",
+    "m_evi.train()\n",
+    "opt = torch.optim.Adam(m_evi.parameters(), lr=1e-3)\n",
+    "\n",
+    "for ep in range(1, CFG[\"evidential_epochs\"] + 1):\n",
+    "    opt.zero_grad()\n",
+    "    out = m_evi(train_x)  # dict: gamma, nu, alpha, beta\n",
+    "    loss, nll_val, reg_val = evidential_loss(out, train_y, lam=0.01)\n",
+    "    loss.backward()\n",
+    "    opt.step()\n",
+    "\n",
+    "    if ep % 400 == 0:\n",
+    "        print(f\"epoch {ep:4d} | loss {loss.item():.4f} | nll {nll_val:.4f} | reg {reg_val:.4f}\")\n",
+    "\n",
+    "with torch.no_grad():\n",
+    "    out_test = m_evi(test_x)\n",
+    "    mean_evi, ale_std, epi_std, total_std_evi = evidential_decompose(out_test)\n",
+    "\n",
+    "    # StudentT NLL (more faithful for evidential)\n",
+    "    gamma, nu, alpha, beta, df, loc, scale = evidential_studentt_params(out_test)\n",
+    "    tdist = dist.StudentT(df=df, loc=loc, scale=scale)\n",
+    "    nll_point_studentt = -tdist.log_prob(\n",
+    "        test_y,\n",
+    "    )\n",
+    "    # Note: NLL is evaluated on noisy observations (test_y),\n",
+    "    # not the noise-free test_y_true.\n",
+    "\n",
+    "    nll_evi_studentt_in = nll_point_studentt[in_mask].mean().item()\n",
+    "    nll_evi_studentt_ood = nll_point_studentt[ood_mask].mean().item()\n",
+    "\n",
+    "    # Optional: Gaussian approx NLL (for apples-to-apples)\n",
+    "    nll_evi_gauss_in = mean_nll(test_y, mean_evi, total_std_evi, in_mask)\n",
+    "    nll_evi_gauss_ood = mean_nll(test_y, mean_evi, total_std_evi, ood_mask)\n",
+    "\n",
+    "    rmse_evi = rmse(test_y_true, mean_evi)\n",
+    "\n",
+    "print(\n",
+    "    \"Evidential | RMSE:\",\n",
+    "    rmse_evi,\n",
+    "    \"| NLL(StudentT)_in:\",\n",
+    "    nll_evi_studentt_in,\n",
+    "    \"| NLL(StudentT)_ood:\",\n",
+    "    nll_evi_studentt_ood,\n",
+    "    \"| NLL(Gauss)_in:\",\n",
+    "    nll_evi_gauss_in,\n",
+    "    \"| NLL(Gauss)_ood:\",\n",
+    "    nll_evi_gauss_ood,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d5331721",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>method</th>\n",
+       "      <th>rmse</th>\n",
+       "      <th>nll_in</th>\n",
+       "      <th>nll_ood</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>ensemble</td>\n",
+       "      <td>54.4975</td>\n",
+       "      <td>2.9756</td>\n",
+       "      <td>6.6655</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>evidential(StudentT)</td>\n",
+       "      <td>79.9605</td>\n",
+       "      <td>4.8924</td>\n",
+       "      <td>11.6151</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>dropout</td>\n",
+       "      <td>66.8818</td>\n",
+       "      <td>40.2153</td>\n",
+       "      <td>322.4716</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>dropconnect</td>\n",
+       "      <td>66.4557</td>\n",
+       "      <td>37.0975</td>\n",
+       "      <td>437.0320</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>bayesian</td>\n",
+       "      <td>65.4317</td>\n",
+       "      <td>37.1183</td>\n",
+       "      <td>1430.4635</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                 method     rmse   nll_in    nll_ood\n",
+       "2              ensemble  54.4975   2.9756     6.6655\n",
+       "4  evidential(StudentT)  79.9605   4.8924    11.6151\n",
+       "0               dropout  66.8818  40.2153   322.4716\n",
+       "1           dropconnect  66.4557  37.0975   437.0320\n",
+       "3              bayesian  65.4317  37.1183  1430.4635"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "results = [\n",
+    "    (\"dropout\", rmse_do, nll_do_in, nll_do_ood),\n",
+    "    (\"dropconnect\", rmse_dc, nll_dc_in, nll_dc_ood),\n",
+    "    (\"ensemble\", rmse_ens, nll_ens_in, nll_ens_ood),\n",
+    "    (\"bayesian\", rmse_b, nll_b_in, nll_b_ood),\n",
+    "    (\"evidential(StudentT)\", rmse_evi, nll_evi_studentt_in, nll_evi_studentt_ood),\n",
+    "]\n",
+    "\n",
+    "df = pd.DataFrame(results, columns=[\"method\", \"rmse\", \"nll_in\", \"nll_ood\"]).sort_values(\"nll_ood\")\n",
+    "\n",
+    "for c in [\"rmse\", \"nll_in\", \"nll_ood\"]:\n",
+    "    df[c] = df[c].apply(lambda x: x.item() if hasattr(x, \"item\") else float(x))\n",
+    "\n",
+    "df = df.round({\"rmse\": 4, \"nll_in\": 4, \"nll_ood\": 4})\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a8badaa6",
+   "metadata": {},
+   "source": [
+    "## Interpreting the metrics\n",
+    "\n",
+    "- **RMSE**: accuracy against the true (noise-free) function y = x³.\n",
+    "  Lower is better.\n",
+    "\n",
+    "- **NLL**: evaluates the *full predictive distribution*.\n",
+    "  Lower is better. NLL penalizes:\n",
+    "  - wrong means (poor accuracy)\n",
+    "  - overly small predicted uncertainty (overconfidence)\n",
+    "\n",
+    "Caveat:\n",
+    "- For dropout/dropconnect/ensemble/bayesian we use a Gaussian approximation and inject known noise_std.\n",
+    "- For evidential we report Student-t NLL, which is more faithful to its predictive distribution.\n",
+    "\n",
+    "**Note:** NLL is computed on the **noisy observations** `test_y` (not the noise-free `test_y_true`) and is reported separately for **in-distribution** (within the training x-range) and **OOD** (outside it), so it reflects both calibration and how uncertainty behaves under extrapolation, penalizing both **under-** and **over-confidence**.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "b735d59c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABvkAAAGHCAYAAACapT7WAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvc2/+5QAAAAlwSFlzAAAPYQAAD2EBqD+naQAAli9JREFUeJzt3QeYY2XZ//E7ffps74Wl6FIFlg5SBFkVX0WRVwEVBUEReEH9i4AICL6iICJFKRZAhZdiASmKdFSKVKVIX9jed/pkJuX8r9+TnEySKTu7O7NJZr6f68pkcnJycs5JcufJcz8l4HmeZwAAAAAAAAAAAAAqRrDUOwAAAAAAAAAAAABgw5DkAwAAAAAAAAAAACoMST4AAAAAAAAAAACgwpDkAwAAAAAAAAAAACoMST4AAAAAAAAAAACgwpDkAwAAAAAAAAAAACoMST4AAAAAAAAAAACgwpDkAwAAAAAAAAAAACoMST4AAAAAAAAAAACgwpDkAwAAAMrUFltsYV/4whdytx955BELBALueqhoe+eff/6QbQ8jk94jeq8M1kc+8hE74YQTrNzwfl+/4YgzG2KvvfayM844oyTPDQAAAFQaknwAAABAH2644QZX0e1fqqqq7D3veY+dcsoptmLFCqsk9957L4mNCvLggw/acccd595vNTU1tuWWW9qXvvQlW7Zs2ZA9x/e//3274447bDj84x//sL/+9a/2rW99K7fslVdece/Bd955Z6O3e/PNN9tPfvKTIdrLkWs4X9v1Wbp0qXudX3jhhY3eht43P/3pT2358uVDum8AAADASESSDwAAABjABRdcYL/5zW/sqquusn322ceuvvpq23vvva2jo2Oz78v+++9vnZ2d7npDk3zf/e53+7xP2zvnnHOGaA8xFJTkUC+qT3ziE3bFFVfYZz7zGbvttttsl112GbLEx3Amgi655BI7+OCDbeutty5I8uk9SJJv+G3qa7uxccZP8ul13pQk38c//nFraGiwn/3sZxu9DQAAAGC0IMkHAAAADODDH/6wffazn3U9qdS77/TTT7cFCxbYnXfe2e9j2tvbh2VfgsGg61Go66Gi7YXD4SHbHnqoB6jeMxvqxz/+sb355pv2wx/+0L3vlLS5++67XQ9SJZvL2cqVK+2ee+6x//7v/y71rowqnue5xFy5xpkNff5PfepT9utf/9odFwAAAID+keQDAAAANsAHPvABd61En2jOvLq6OnvrrbfcPGT19fV2zDHHuPvS6bTrebT99tu7SvPJkyfbl7/8ZVu3bl3BNlWR/b3vfc9mzJjhhmc86KCD7OWXXx70XFlPPfWUe+6xY8dabW2t7bTTTnb55Zfn9k9D30n+8KN9zVH2u9/9zt1+9NFHez33tdde6+576aWXcsteffVVVxk/btw4d3y77bab/elPf1rvOVRvLm3rRz/6kds3DUep4z700ENt0aJF7nxceOGF7nxUV1e7nj1r167ttZ0///nP9v73v98ds877YYcd1uu8/fvf/3bnQM+hfZwyZYobCnPNmjV9zjmn5JrWHzNmjDU2NtoXv/jFzd5rUz2oihMsWqbz/J///Ge9j3/jjTfsiCOOcMeqY9Z5VG/A5uZmd7+OU4noG2+8Mfd+yJ/78e9//7vtvvvu7rFbbbWVe+0HSwm+ZDJphxxySG6ZEp1HHnmk+1/vbf8589/H6rWlz0ksFrNp06bZySefbE1NTbn7DzzwQLftd999N/d4zVkp3d3ddu6559q8efPca6b3g94XDz/8sG3KUL3FvQ77+vxpv3bYYQfXU1HHpvfx9OnT7eKLL+613Xg87t5nGoZV53bq1Kn2yU9+0sUO32Bjho79ox/9qN13333uc6fPif8Z7e+11bn76le/au9973vd+uPHj3evy1Adp9bX+0b0ufGfX+fzvPPOs0gkYqtWrep1Xk488UT3edP58X3wgx90+7spPQIBAACA0YAmuwAAAMAG8CvkVUHuU1Jj/vz5tt9++7nElSrARZXzquBWhff//M//uMSgemI9//zzbt4yVXqLEhRK8ilRp8tzzz3nEl5KXqzP/fff7yr7lTA47bTTXGJHiSD1/NJt7YOG0NN6GnZ0IEqSKWGpoSEPOOCAgvtuvfVWl3hQRb8ombbvvvu6iv4zzzzTJVb0uMMPP9x+//vfu6Em1+emm25yx3jqqae6JJ4SBuoBpkSqEgYatlJJtyuvvNL+3//7f/arX/0q91gdy7HHHuvOu3q8KRGnoVT1Guj8+gkgHffbb7/tXgOdG+33dddd566ffPLJgoSn6PnnzJljF110kXsdfvGLX9ikSZPccwxEz99XMrCtrc1Wr16dux0KhVwydkNpO7pMmDBhwPV0PnVOurq63HnVMS9ZssS9H5Q0UxJM5049BPfYYw+XYBEl8+TFF190772JEye6hJTe20rQKNk0GI8//rj7bMyePbsgQan3v4YePfvss23bbbd1y/1rPY+GeFRi8KSTTrLXXnvNvZZPP/107nPy7W9/2yUpFy9ebJdddpl7nN6r0tLS4l6no446yk444QRrbW21X/7yl+48/POf/7Sdd97ZhpMScB/60Idcwk7vHyXL9d7dcccdXU9gSaVS7nOq+RaVcNVnU/up96cS5/75H2zMEJ0nHbMeo+NW8m6g11bnU6+Pnl+JXyX3dJ6VwFPyzo9bG3ucej01vLHimZ5biVbRMMf6XOo+xRHNa5r/ftV2lJRWUtOnhK3omDVMLQAAAIB+eAAAAAB6uf766zVOnPfAAw94q1at8hYtWuTdcsst3vjx473q6mpv8eLFbr1jjz3WrXfmmWcWPP5vf/ubW37TTTcVLP/LX/5SsHzlypVeNBr1DjvsMC+dTufWO/vss9162r7v4Ycfdst0Lclk0pszZ443e/Zsb926dQXPk7+tk08+2T2uL1p+3nnn5W4fddRR3qRJk9y2fcuWLfOCwaB3wQUX5JYdfPDB3o477ujF4/GC59xnn328bbbZZsBzu2DBAve8EydO9JqamnLLzzrrLLf8fe97n5dIJAr2SefIf67W1lZvzJgx3gknnFCw3eXLl3uNjY0Fyzs6Ono9///93/+553nsscdyy3QOtOy4444rWPcTn/iEe83Xx3/8+i56rTbGhRde6B7/4IMPDrje888/79a7/fbbB1yvtra24L3lO/zww72qqirv3XffzS175ZVXvFAo1O97KN9+++3nzZs3r9dy7U/+e9fnv/8PPfRQL5VK5ZZfddVVbv1f/epXuWX6jPR1/vRe7erqKlimz8PkyZN7vZ7F7/eBPvt6n+Yr/vzJAQcc4Jb9+te/zi3TvkyZMsU74ogjcst0HFrvxz/+ca/n8z+rg40ZovOgZbpvsK9tX5+FJ554otf+b8pxPv300249ncNie++9t7fnnnsWLPvDH/7Q5/tC9L446aSTei0HAAAA0IPhOgEAAIABqHeRejXNnDnT9YBR76E//vGPrgdbPvVAynf77be7XlMadk49ufyLeqhoG/5Qgg888ECuN1t+rzLN/bc+6t2jnj5aV8Pd5SvuoTZYn/70p928avlD9amnjYYR1H2iXncPPfSQ682j3kj+sWkITPWe0nCR6j22PhoqUOfIt+eee7przYGYP0+glusc+dtU7yf1SlMvpvxzq15yWjd/mEYNS+jTcIBab6+99nK31VOv2Fe+8pWC2+qNpONSb7GBfP7zn3f7lX+Rb37zmwXL1HtxQz322GOup5vfy3Eg/vnUMI4bOsyoepvpceqNOWvWrNxy9dDS6zoYOlcb0lPRf//rPZw/RKl6pjU0NLghOtdHr3s0GnX/632q96d6IGoYy75e46Gmz7Pesz7ti3rSqQepT71b1QtTn/Ni/md1sDHDpx6ng31dij8LiUTCvVZbb721ix2DOU+DOc71fUY0tHD+8KT6PCi2FvccFr2P8nvBAgAAAOiN4ToBAACAAWjOOM2hpaSThizUkHjF86XpPg1/l0+JLg0vqKEe+6JEmmjeKdlmm20K7ldicX3JEr+y3B9CcyhoOD4lGjSs3sEHH+yW6X8NeajzIBpCU52ivvOd77hLf8dXnAgtlp9Iyk9QqdK/r+X+vGQ6t9JfwkvJIZ8SPkqQ3XLLLblz7vPnqBton/zXQM+dv91imvNPl2Lbbbddwfx0G0rzHmroU73GGpJyfZT4+frXv24//vGPXQJFScqPfexjLjmTn1Dti+ZL6+zs7PVeFL3v77333kHtc6bD3OD4739tP58SSDqf/v3roznoLr30Une+lMDKPx/DTZ/94qS63jeaDzL/s6pjzE9eFxtszNjYY9Nrq2For7/+epcwz3+d+vosbMxxDkSNBJTM1ftSQ3rqOTWM7Ne+9rU+GyVo/za2sQIAAAAwWpDkAwAAAAagnirqETSQWCzWK/GnHkWqrO+v55aSeOVIx6KeXOqt+LOf/cxWrFjh5sX6/ve/X3Bsonny+utJpB5Cg+mBtSHL/aSE//yaf0xzzhXLT6So95vmIVOPOiUq1RtJj1cy09/Ohjz35rRo0SI3P56Sc0qw1dfXD+pxSnZ94QtfsDvvvNP++te/urndlNzRHITFyeihpvn4/GTs5vLb3/7WHa/et3qd9bnT66hjzu81Nlj9JZbU07EvQ/We2dCYkd8zbzDUi1AJPiXa9t57b/e+0rGqh3Jfn4WhPk4lBDUvoZ/kUw9hzR2Z3zswn3rrrm8OSgAAAGC0I8kHAAAADIOtttrKDUW47777DlgZP3v27FwvnvyeYOpVtb5kiZ5DXnrppQF7i21obxj1uFHPqAcffND+85//uEp8f6hO8fczEolsUi+1jeUftxIiAz2/zp+OQT35lFTw+T0By5mGUlSCT0kQHcPUqVM36PE77riju5xzzjkuyan34TXXXGPf+973+n1PKImk92pf5+e1114b1PPOnTvXDU052Peg//7X9vPf/xrCU0PR5r++/W1DySI99g9/+EPBOuedd55tDL/3ppJM+Qbbq7C/96yGqlQvQ31uNiVmrM9A5+nYY491SeD8IWyLj3NTrC/WaMjOj3/84/b000+7ZN8uu+xi22+/fa/11NNQ7wENFQsAAACgf8zJBwAAAAwD9SBTz58LL7yw132aL8yvWFcSQ5X+V155ZUGPmJ/85CfrfY5dd93VDdmndYsr6vO3VVtb664HW5mvfRo3bpwbplMX9WbMHxpQybUDDzzQrr32Wlu2bFmvxytBOZzUe1BDZ6p3Yf7QjMXP7/c8Ku5pNJhzOxT0vOphtqHa29vtIx/5iEt0qAdfX8Nn9kdzB+r9lU/JPvU0VcIw/z1R/H7Q+dK5veOOO2zhwoW55Ur0aq6+wVAPMSVXi+dp6+89qPeahua84oorCl6nX/7yl244x8MOO6xgG30NK9nX66yE2hNPPGGbkkTWXIg+fZavu+4621hHHHGEm1/uqquu6nWfv9+DjRnr09dr65+n4s+C4k5/PRQ3xvpizYc//GHXO++HP/yhPfroo/324nv22Wfd9T777DNk+wYAAACMRPTkAwAAAIbBAQccYF/+8pfdkIEvvPCC65WlZJ56Sd1+++12+eWX26c+9SnXe0rDXmo9DWWn5M7zzz9vf/7zn9c7VJ0SN1dffbX913/9lxuK8otf/KLr8aV5yV5++eVcYmbevHnuWsM2Komjyn4N0dcf7ecnP/lJN4+dEk4/+tGP+pyrcL/99nMJpBNOOMH1pNLQnkqsLF682P71r3/ZcFGCT8f9uc99ziU6dSw6j0pM3XPPPa4nlJIpWm///fe3iy++2CUDNUeghq9UD7GhpnnJBjM3mYYL1bCSAznmmGPsn//8px133HEuwabLYB//0EMP2SmnnGJHHnmkm0NRySENa6rXXIkmn94T6jWmufumTZvmkrh77rmn6/X4l7/8xc3l99WvftU9Xokg9bYazPEpKafhUrXtE088Mbdc70/tg5I7StRpWFjNqaiE8VlnneWeV0Ooav5A9erTULG77757QRJI+6yks+Yc1H06F3rv63OjXnyau1DPr9dXvRY1H2JbW5ttKB3rXnvt5fZLczoq4a3PQnHydEOoB9uvf/1rt+96bXV+9dnSedJ5Vu+2wcaM9envtdV50ntBw3Tq3OizqvU0xOpQUYJ0zJgx7vxreFkl/fTcfiMBHY8+r/p86v1w1FFH9bmd+++/382PqZ5+AAAAAAbgAQAAAOjl+uuvV5cX7+mnnx5wvWOPPdarra3t9/7rrrvOmzdvnlddXe3V19d7O+64o3fGGWd4S5cuza2TSqW87373u97UqVPdegceeKD30ksvebNnz3bb9z388MNun3Sd7+9//7v3wQ9+0G1f+7LTTjt5V155Ze7+ZDLpnXrqqd7EiRO9QCDgtuHT/+edd16v/b7//vvdfVp/0aJFfR7bW2+95X3+85/3pkyZ4kUiEW/69OneRz/6Ue93v/vdgOdswYIFbtuXXHJJwXL/+G6//fZBvRZaf/78+V5jY6NXVVXlbbXVVt4XvvAF75lnnsmts3jxYu8Tn/iEN2bMGLfekUce6c598XHrfy1btWpVn8+tfR6I//j1XfSaro/W2djHv/32295xxx3nzoXOybhx47yDDjrIe+CBBwrWe/XVV73999/fvd+03fz32aOPPures9Fo1Ntyyy29a665Jnd8g/Gxj33MO/jgg3st//nPf+62FwqFer2Pr7rqKm/u3LnufTR58mTvpJNO8tatW1fw+La2Nu/oo492r2X+uUin0973v/99dzsWi3m77LKLd/fdd7tjKj5f/b3f+3pvH3LIIW572p+zzz4795nI3+8DDjjA23777Xs9vq/n7ujo8L797W97c+bMccepz82nPvUp91wbGjO07cMOO6zPfe/vtdX5/OIXv+hNmDDBq6urc58drTuYOLMhx3nnnXd62223nRcOh9129BnK989//tMtP/TQQ/vcf8VDxcJzzjmnz/sBAAAA9Ajoz0BJQAAAAAAAButvf/ubG85VPUo3ZKhRjA7q5auenerZqN64xTRc7NFHH21vvfXWBs9FCQAAAIw2JPkAAAAAAENKc6/NmDHDfv7zn5d6V1BmNJzsjTfeaMuXL8/N4Vc8r6OGM9UwuwAAAAAGRpIPAAAAAAAMq7vuusteeeUV+853vuMSfZozEAAAAMCmIckHAAAAAACG1RZbbGErVqyw+fPn229+8xurr68v9S4BAAAAFS9Y6h0ANrfzzz/fAoFAqXcDACoCMRMAsLm/c1avXj2ohNEXvvCFzbJfGBrvvPOOdXZ2ujn3SPBhtMWsckUsBTAaPfLIIy5+63p9NM+0LpUWp1Xu0jHecMMNw7JfKC8k+YAKtnTpUvfD4oUXXij1rgAANgHxHAAAAACA0efxxx939QFNTU2l3hVUqHCpdwDAplUKf/e733WtOnbeeedS7w4AYCMRzwEAALC5vfbaaxYM0v4fwOiy//77u9EFotGolUuST/UB6rE3ZsyYgvuI0xgM3iFAkXQ6bfF4vNS7AQAVgZgJAAAAVKZYLGaRSKTUuwEAm5WSZlVVVRWRPCNOYzDK/50MbIK///3vtvvuu7vAvdVWW9m1117bax2NT3zKKafYTTfdZNtvv70Lnn/5y1/cfc8//7x9+MMftoaGBqurq7ODDz7YnnzyyYLHa2xjbeOxxx6zL3/5yzZ+/Hi3/uc//3lbt25dr+f72c9+lnueadOm2cknn9yrO3Z/4y3njwOtcaN1bPLFL37R7QNjLQMYaTHzz3/+sx1wwAFu7h6tp/27+eabC9a5/fbbbd68eVZdXW0TJkywz372s7ZkyZKCdRRTtU9afvjhh7v/J06caP/v//0/S6VSvcat/9GPfmTXXXedOw86Rj3v008/3Wv/Xn31VfvUpz5l48aNc+dtt912sz/96U+91lOc/9rXvubiu7Y3Y8YMd8yaw4V4DmBDKZYdd9xxNnnyZBdTFI9/9atf9Zpn5LbbbrP//d//dTFHMUpx+c033yzY1htvvGFHHHGETZkyxa2jdT/zmc9Yc3NzwXq//e1vc7FWMU/rLFq0qGAdlVN32GEH+/e//+1id01NjW299db2u9/9zt3/6KOP2p577um28d73vtceeOCBPo9PsfG///u/XdzX98Rpp502qAYlirWnn366zZw5050XPfcPf/hD1yAFAIbL+mLW9ddfbx/4wAds0qRJLjZtt912dvXVVxds49hjj3Xl2EQi0Wv7hx56qIuZGxqTBxPfi+se1q5d68rHO+64oysv65hUvv/Xv/5VsO0N+Z4BgM1RBl6xYoWFw2HXI66YesMpZl111VUDzsnn1wEotu6xxx72t7/9rc/96OrqsvPOO8+VNbUfKnueccYZbnlf9Seaj1hlZH+f/ToU0TCd3/zmN93/c+bMydUHqG5iU+I0RheG68SI9eKLL7rCsCpxFTCTyaQLwPoiKPbQQw+5wqkCrwrWCqAvv/yyvf/973fBUoFarSZU4a3KC7+CIp8eqy7Vei59eajQ/u677+a+OET36cvmkEMOsZNOOim3niqO//GPf2xQy4xtt93WLrjgAjv33HPtxBNPdPsq++yzzyafOwCjTznGTCW5VIBXIfiss85y6yuRqALx0UcfnVtHiTElyS666CJXsL/88stdTNW6+UNdKJk3f/58ty9K4qly+dJLL3WFeMXkfEoktra2ukSk9ufiiy+2T37yk/b222/nYrWOed9997Xp06fbmWeeabW1te68KIn4+9//3j7xiU+49dra2ty5+c9//uOOZ9ddd3WVQUoGLl68mHgOYIMozu211165SgPFbTWIOP74462lpcUluXw/+MEPXAtlVQSoUlex7JhjjrGnnnrK3d/d3e3ioiokTj31VFcRrMqTu+++2yXMGhsb3XqqwP3Od77jKrG/9KUv2apVq+zKK690Qx0Vx1o12PjoRz/qKpKPPPJIF9/1vxqHaN++8pWvuBh+ySWXuEYSqpRWQ458eh59tyiuq7HIFVdc4bb761//ut/z0tHR4RKL2n/F7lmzZrmhj/T9sWzZMvvJT34yDK8GAKw/ZikOqjz7sY99zFVA33XXXfbVr37VNUBQo1/53Oc+59a/7777XAz1LV++3JW9VS73DSYmDza+F1NZV5XRit+qbNZ3jsr0iq+vvPKKa6icb33fMwCwOcvAilX6TZ4fM+XWW2+1UCjkYlt/fvnLX7oypH6Ha1uKh4rbakihJJ5PsVvL1Uhav9/1e171KZdddpm9/vrrLobm03p/+MMfXNxXmVffEWqAsXDhQtcwRPUMetz//d//uW2ojkV0fEMRpzFKeMAIdfjhh3tVVVXeu+++m1v2yiuveKFQyMt/6+v/YDDovfzyy70eH41Gvbfeeiu3bOnSpV59fb23//7755Zdf/31bhvz5s3zuru7c8svvvhit/zOO+90t1euXOm2d+ihh3qpVCq33lVXXeXW+9WvfpVbNnv2bO/YY4/tdUwHHHCAu/iefvpp91jtAwCMpJjZ1NTkHrvnnnt6nZ2dBc+VTqfdtR4/adIkb4cddihY5+6773bbOvfcc3PLFFO17IILLijY1i677OL2xbdgwQK33vjx4721a9fmlmu/tPyuu+7KLTv44IO9HXfc0YvH4wX7ts8++3jbbLNNbpn2Q4/9wx/+0Ou8+8dCPAcwWMcff7w3depUb/Xq1QXLP/OZz3iNjY1eR0eH9/DDD7uYsu2223pdXV25dS6//HK3/MUXX3S3n3/+eXf79ttv7/f53nnnHfdd8L//+78Fy7WNcDhcsFzlVG3v5ptvzi179dVXc98dTz75ZG75fffd1yvunXfeeW7Zxz72sYLn+upXv+qW/+tf/+q3vHzhhRd6tbW13uuvv17w2DPPPNPt/8KFC/s9RgDYGIONWYrLxebPn+9tueWWuduqI5gxY4b36U9/umC9H//4x14gEPDefvvtDYrJg4nvfcVSlWvz6yv88nEsFisoRw/2ewYANmcZ+Nprr+0zBm233XbeBz7wgV4xTNf5dQs777xzQUy77rrr3Hr5dbG/+c1vXLn2b3/7W8FzXHPNNW7df/zjH7lluq16kjfffDO3TN8NWn7llVfmll1yySVumeLtUMVpv26DOobRgeE6MSKpt4ZawKk3hVrx+tS6Qq3Ziqm1g4bMyH/8X//6V/f4LbfcMrd86tSpruWxWmGolUg+td7I74mnXiFqpXfvvfe62+oxotZ0ag2SP+bzCSec4Hq+3HPPPUN4BgCgsmPm/fff73rSqYechv7J5/f0e+aZZ2zlypWuRVz+OocddpjNnTu3z7iqHiT51GtOLeGKffrTn7axY8cWrCf+uhoiQ62q1YJa+6meebqsWbPGnTMNj+QPGapefe973/tyPfv6OhYAGAzVFSim/Nd//Zf73489uij2qBfFc889l1tfPZ2j0Wi/sczvyaHvAPWE64taHqvFsuJd/vOpV8g222xjDz/8cMH6GjZIPfd8GmJOvUr0nZLfq9v/v68Y7Pds8akXivjfEX3R0M06PsXu/P3UCBr6ntIw0QAwHNYXszTsm09xWrFJ5WnFP3/oTNURqAecRnpQ2dKnXtDqVaLeGhsSkwcT3/uioeT8+grFTpVtFdcVy/O/Xwb7PQMAm7MMrF5xqldQzz3fSy+95Hq46Td+f/y6BdUX5Mc0DZNZ3PNZZU6Va1XnkL8fGpZZisvGKotq9CDfTjvt5OqBNzZObmicxuhAkg8jkoar6OzsdIXcYsVj2YtfYM5/vArCfa2rQK5CdfF498XPpQCrCm5/DGUNQ9fX8+vLQ5Xi/v0AsLmVY8x866233LXGre9Pf3FVVOAujqtKBBYPeaHK4L7mAsxPdvrrib+u5hrRjwsNlaRt5l/8oUH0I8E/loGOAwAGS/FWw6xpvpDi2KOK1vzYM5hYpnj+9a9/3X7xi1+4oYFUSfLTn/60YL4mNVpQvFPcLn5ODUOc/3yieZmKGzCociR/mCN/Wf6+DPQdoYoRVWb43xF90X5qOOfifVTFSvF5AYChtL6YpWHkFYs0tLsaPSg2nX322e6+/Hir+ZpVJv/jH//obmtI+2effdYN5bmhMXkw8b0vKrdruDhtXxXJeqy2rblW+3rs+r5nAGBzloEVszQ3qIbs9Cnhp8SfEoD98esOiuO5GibnN2T247Cm7ijej/e85z25/RgoTg5UDzEYGxqnMTowJx9Q1LKuHPTXs0MtNDSGNACUUrnFzMHakPjZ37qZETcyBWvR/CN99XYUTcINAEPJjz2f/exn7dhjj+1zHbUOVmvlwcQy0dykaqV85513ul7Z//M//5ObV0oJOz2nyqaa86Sv7amRRr7+nnMw+9KfwfR61n5+8IMfdPPC9sWveAGA4ZYfs9TYSxXOaoD24x//2DV4UENf9fJTJa0f10UjZcybN89++9vfuoSfrrWueu35NiQmry++9+X73/++a8SmeaQvvPBCNxeVEpYakSh/X4citgPAUJeBRSNKKPH3wgsv2M477+wSforD/lx3Q7EvO+64o4vpfSlu2DbUcXJD4zRGB5J8GJHUgkGV0GpdUUyt4Qbz+Jqamj7XffXVV13wLA7aeq6DDjood7utrc2WLVtmH/nIR9zt2bNn554/vxWIhvBcsGBBrpWx36JDLVT6almS/1iGeQMwUmOmP5yFhtboL1mWH1f9oTHy99u/fzj4sVgt+/Ljd190LDqOgRDPAQyG4m19fb1r+DVQ7PGTfIOligpdzjnnHHv88cdt3333tWuuuca+973vuRimSgj1CtlciTJ9R+T3GlfvaVVabLHFFv0+Rvup75L1xWQA2Jwx66677rKuri43DGd+b47i4dx8Su6pB57KxTfffLMbhj5/CPkNjckDxfe+/O53v3Nl9F/+8pcFy1U/MVQV5AAwXGVg0TQiX/7yl3NDdr7++ut21llnDfgYv+5A8Ty/biGRSLg6W02/kR+H//Wvf7nE4VD9jt+Q7RCn0ReG68SIpFYS6llxxx132MKFC3PLNXyFxqQfzOMPPfRQ1+Itf1igFStWuIL2fvvt58ZPzqcu4wr+vquvvtqSyaR9+MMfdrf1JaRWeFdccUVBaw0FZXWnVuE9/wtDreuUAPTdfffdvYa703Af0ldCEAAqOWZqeyrEq7VxPB4veKwfQ3fbbTebNGmSq6hQ5YlPLZu17/lxdajpeQ888EC79tprXSVMX8OJ+I444gj3I8AfeqmvYyGeAxgMxVvFFM1J0lfjgfzYMxiaL1WxN58qg9U4w4+rGtpIz/vd7363V4tj3dY8IENNQ8rlu/LKK921/x3RF/V0eeKJJ/r83lJsLT5OANgcMcvvwZEfP/X7//rrr+9zW0cddZSr7D3ttNPcfE3qtZJvsDF5MPG9L9p28XY1/5Q/1zQAlHsZWMMiq35DPfhuueUWVxerxN9AVLegRKLqFvLrYm+44YZev9FV5lRM/PnPf95rOxpyub29fYOPb0PqA4jT6As9+TBiqdCreTk08fNXv/pVV8BVYXv77bd34xSvj1q23X///a5yWo/X+M2qzFWB+OKLL+61vr4E1IpDwV49SH72s5+5x37sYx9z9+vLQi1HtF8f+tCH3HJ/vd13372g8P6lL33JtczQetqehvjQUB35E7WKbuvLS19CqgzXl8Kee+7Za74sAKi0mKmkoIYwUjxUjDz66KNdK2YlyzT/34033uh60f3whz90Q3EccMABrlJEicXLL7/ctZz+2te+ZsNdoaN9VoXJCSec4Hr36flVybx48WK3r/LNb37TxfQjjzzSDamhYZjWrl3rWnQrfqtVIPEcwGD94Ac/cD1AFCMUezS8m2LKc889Zw888ID7f7AeeughO+WUU1x8Uo8Qxf7f/OY3uYoUUXxSjFc5Vg05VEmiOKVWzWq8cOKJJ7qhi4eStq3vA5WFFVNVDtb3QH4r6mKKtYqrH/3oR93wdIq1qmR58cUXXQzWvtO6GcBwGChmaU5oVTD/13/9l+tZoh7HqhhWg7G+Goqp3kDbUYWtyobFjdYGG5MHE9/7ohh6wQUXuPL1Pvvs42LoTTfd1GtOKgAo5zLwpz/9aVfPqnoGJfwUTweiugXFVsVp9eTT4xVX1SCjOP5pnlQlEL/yla+4/VEPafUw1ChGWq4GZ0oabgiVW+Xb3/62G25U+6PvDT/5l484jT55wAj26KOPevPmzfOi0ai35ZZbetdcc4133nnnqblDbh39f/LJJ/f5+Oeee86bP3++V1dX59XU1HgHHXSQ9/jjjxesc/3117tt6LlOPPFEb+zYsW79Y445xluzZk2vbV511VXe3LlzvUgk4k2ePNk76aSTvHXr1vVa79JLL/WmT5/uxWIxb9999/WeeeYZ74ADDnCXfHfeeae33XbbeeFw2O2H9gcARkrM/NOf/uTts88+XnV1tdfQ0ODtscce3v/93/8VrHPrrbd6u+yyi4uX48aNc9tavHhxwTrHHnusV1tb22v7xce3YMECd/uSSy7pta6Wa/18b731lvf5z3/emzJliovritsf/ehHvd/97ncF6+nYTjnlFHe/zu+MGTPcPq1evTq3DvEcwGCtWLHCxeKZM2e62KMYdPDBB3vXXXedu//hhx92ceT2228veJwf4/z48vbbb3vHHXect9VWW3lVVVUuhip2P/DAA72e8/e//7233377uViqi8qz2ofXXnstt47Kqdtvv32vx86ePds77LDDei0v/k7xY/Irr7zifepTn/Lq6+vd94TiZ2dnZ69tKo7ma21t9c466yxv6623drF2woQJ7jvkRz/6kdfd3b0BZxgA1m+wMUvl2Z122snF2S222ML74Q9/6P3qV79yj1VcLnbbbbe5+1RW7s/6YvJg43txLI3H4943vvENb+rUqa78rbqIJ554olddxGC/ZwBgc5aBfS0tLS6GKR799re/7bUdP4bpOt/PfvYzb86cOa5uYbfddvMee+yxPutiVa5ULFe5V+sq9qsu5bvf/a7X3Ny83vqTvsqxF154oasvCAaDBd8PGxunicejS0B/+k7/ARgMdd1W64mnn356g1tqAMBoQ8wEAAAA+qch8NVD77HHHnOjbAAAAAyEOfkAAAAAAACAMqDhPDXsmoaFBwAAWB/m5AMAAAAAAABK6JZbbnFzYd9zzz1ujulAIFDqXQIAABWAJB8AAAAAAABQQkcddZTV1dXZ8ccfb1/96ldLvTsAAKBCMCcfAAAAAAAAAAAAUGGYkw8AAAAAAAAAAACoMAzXaWbpdNqWLl1q9fX1jHkOoCyok3Vra6tNmzbNgsGR3R6DGAyg3BCDAaB0iMEAUDqjJQYTfwGMpPhLks/MBfWZM2eWejcAoJdFixbZjBkzbCQjBgMoV8RgACgdYjAAlM5Ij8HEXwAjKf6S5DNzrTb8E9jQ0FDq3QEAa2lpcQVOPz6NZMRgAOWGGAwApUMMBoDSGS0xmPgLYCTFX5J8Zrlu2QrqBHYA5WQ0DBtBDAZQrojBAFA6xGAAKJ2RHoOJvwBGUvwduYMrAwAAAAAAAAAAACMUST4AAAAAAAAAAACgwpDkAwAAAAAAAAAAACoMST4AAAAAAAAAAACgwpDkAwAAAAAAAAAAACoMST4AAAAAAAAAAACgwpDkAwAAAAAAAAAAACoMST4AAAAAAAAAAACgwpDkAwAAAAAAAAAAACoMST4AAAAAAAAAAACgwpDkAwAAAAAAAAAAACoMST4AAAAAAAAAAACgwpDkAwAAAAAAAAAAACoMST4AAAAAAAAAAACgwpDkAwAAAAAAAAAAACoMST4AAAAAAAAAAACgwpDkAwAAAAAAAACMKolUutS7AACbjCQfAAAAAAAAAGBU6UqS5ANQ+UjyAQAAAAAAAABGlW6SfABGAJJ8AAAAAAAAAIBRJUGSD8AIQJIPAAAAAAAAADCqdKVSpd4FANhkJPkAAAAAAAAAAKMKPfkAjAQk+QAAAAAAAAAAo0oXST4AIwBJPgAAAAAAAADAqOJ5Zt0k+gBUOJJ8AAAAAAAAAIBRpyvJvHwAKhtJPgAAAAAAAADAqMOQnQAqHUk+AAAAAAAAAMCoQ5IPQKUjyQcAAAAAAAAAGHW6EgzXCaCykeQDAAAAAAAAAIw69OQDUOlI8gEAAAAAAAAARp1kyrN02iv1bgDARiPJBwAAAAAAAAAYlejNB6CSkeQDAAAAAAAAAIxKXUnm5QNQuUjyAQAAAAAAAABGpXiCnnwAKhdJPgAAAAAAAADAqERPPgCVbLMl+X7wgx9YIBCw008/PbcsHo/bySefbOPHj7e6ujo74ogjbMWKFQWPW7hwoR122GFWU1NjkyZNsm9+85uWTCYL1nnkkUds1113tVgsZltvvbXdcMMNm+uwAAAAAAAAAAAVip58ACrZZknyPf3003bttdfaTjvtVLD8a1/7mt111112++2326OPPmpLly61T37yk7n7U6mUS/B1d3fb448/bjfeeKNL4J177rm5dRYsWODWOeigg+yFF15wScQvfelLdt99922OQwMAAAAAAAAAVKhEKm2e55V6NwCgPJN8bW1tdswxx9jPf/5zGzt2bG55c3Oz/fKXv7Qf//jH9oEPfMDmzZtn119/vUvmPfnkk26dv/71r/bKK6/Yb3/7W9t5553twx/+sF144YX205/+1CX+5JprrrE5c+bYpZdeattuu62dcsop9qlPfcouu+yy4T40AAAAAAAAAEAFU36vK0lvPgCVadiTfBqOUz3tDjnkkILlzz77rCUSiYLlc+fOtVmzZtkTTzzhbut6xx13tMmTJ+fWmT9/vrW0tNjLL7+cW6d421rH30Zfurq63DbyLwCAzYMYDAClQwwGgNIhBgNA+cbfeIJ5+QBUpmFN8t1yyy323HPP2UUXXdTrvuXLl1s0GrUxY8YULFdCT/f56+Qn+Pz7/fsGWkfBurOzs8/90v40NjbmLjNnztzEIwUADBYxGABKhxgMAKVDDAaA8o2/zMsHoFINW5Jv0aJFdtppp9lNN91kVVVVVk7OOussN1yof9G+AgA2D2IwAJQOMRgASocYDADlG3+7kvTkA1CZwsO1YQ3HuXLlStt1111zy1KplD322GN21VVX2X333efm1WtqairozbdixQqbMmWK+1/X//znPwu2q/v9+/xrf1n+Og0NDVZdXd3nvsViMXcBAGx+xGAAKB1iMACUDjEYAMo3/tKTD0ClGraefAcffLC9+OKL9sILL+Quu+22mx1zzDG5/yORiD344IO5x7z22mu2cOFC23vvvd1tXWsbShb67r//fpfA22677XLr5G/DX8ffBgAAAAAAAAAA/elOpi2d9kq9GwBQPj356uvrbYcddihYVltba+PHj88tP/744+3rX/+6jRs3ziXuTj31VJec22uvvdz9hx56qEvmfe5zn7OLL77Yzb93zjnn2Mknn5xrffGVr3zF9Qw844wz7LjjjrOHHnrIbrvtNrvnnnuG69AAAAAAAAAAACNIPJmymuiwVZcDwLAoadS67LLLLBgM2hFHHGFdXV02f/58+9nPfpa7PxQK2d13320nnXSSS/4pSXjsscfaBRdckFtnzpw5LqH3ta99zS6//HKbMWOG/eIXv3DbAgAAAAAAAABgfTRkZ0201HsBAGWc5HvkkUcKbldVVdlPf/pTd+nP7Nmz7d577x1wuwceeKA9//zzQ7afAAAAAAAAAIDRI55IlXoXAKB85uQDAAAAAAAAAKASdJLkA1CBSPIBAAAAAAAAAEY1evIBqEQk+QAAAAAAAAAAo1o6bdadTJd6NwBgg5DkAwAAAAAAAACMegzZCaDSkOQDAAAAAAAAAIx6DNkJoNKQ5AMAAAAAAAAAjHqd3ST5AFQWknwAAAAAAAAAgFEvniTJB6CykOQDAAAAAAAAAIx6iaRnyVS61LsBAINGkg8AAAAAAAAAAA3Zybx8ACoIST4AAAAAAAAAAJiXD0CFIckHAAAAAAAAAAA9+QBUGJJ8AAAAAAAAAACQ5ANQYUjyAQAAAAAAAABgZomkZ4lUutS7AQCDQpIPAAAAAAAAAIAsevMBqBQk+QAAAAAAAAAAyOrsJskHoDKQ5AMAAAAAAAAAIKuDJB+ACkGSDwAAAAAAAACArI7uZKl3AQAGhSQfAAAAAAAAAABZ6bRZnHn5AFQAknwAAAAAAAAAAORhyE4AlYAkHwAAAAAAAAAAeRiyE0AlIMkHAAAAAAAAAEAeevIBqAQk+QAAAAAAAAAAyNOVSFsq7ZV6NwBgQCT5AAAAAAAAAAAo0s6QnQDKHEk+AAAAAAAAAACKdHQxZCeA8kaSDwAAAAAAAACAIvTkA1DuSPIBAAAAAAAAAFCksztlaeblA1DGSPIBAAAAAAAAAFDE88w6EgzZCaB8keQDAAAAAAAAAKAP7V0M2QmgfJHkAwAAAAAAAACgD20k+QCUMZJ8AAAAAAAAAAD0gXn5AJQzknwAAAAAAAAAAPQzL197N735AJQnknwAAAAAAAAAAPSjvStV6l0AgD6R5AMAAAAAAAAAoB9tXYlS7wIA9IkkHwAAAAAAAAAA/ejsTlsylS71bgBALyT5AAAAAAAAAAAYAEN2AihHJPkAAAAAAAAAABhAK0N2AihDJPkAAAAAAAAAABhAazxZ6l0AgF5I8gEAAAAAAAAAMIBkyrN4giE7AZQXknwAAAAAAAAAAKxHS5whOwGUF5J8AAAAAAAAAACsB0N2Aig3JPkAAAAAAAAAAFiPjq6UJVPpUu8GAOSQ5AMAAAAAAAAAYBDozQegnJDkAwAAAAAAAABgEJiXD0A5IckHAAAAAAAAAMAge/Kl016pdwMAHJJ8AAAAAAAAAAAMgueZtXYxZCeA8kCSDwAAAAAAAACAQWrpZMhOAKMgyXfRRRfZ7rvvbvX19TZp0iQ7/PDD7bXXXitYJx6P28knn2zjx4+3uro6O+KII2zFihUF6yxcuNAOO+wwq6mpcdv55je/aclkYWuJRx55xHbddVeLxWK29dZb2w033DCchwYAAAAAAAAAGKXz8jFkJ4ARn+R79NFHXQLvySeftPvvv98SiYQdeuih1t7enlvna1/7mt111112++23u/WXLl1qn/zkJ3P3p1Ipl+Dr7u62xx9/3G688UaXwDv33HNz6yxYsMCtc9BBB9kLL7xgp59+un3pS1+y++67bzgPDwAAAAAAAAAwyqTTDNkJoDyEh3Pjf/nLXwpuKzmnnnjPPvus7b///tbc3Gy//OUv7eabb7YPfOADbp3rr7/ett12W5cY3Guvveyvf/2rvfLKK/bAAw/Y5MmTbeedd7YLL7zQvvWtb9n5559v0WjUrrnmGpszZ45deumlbht6/N///ne77LLLbP78+b32q6ury118LS0tw3kaAAB5iMEAUDrEYAAoHWIwAIys+NvckbDG6siQbAsAKmJOPiX1ZNy4ce5ayT717jvkkENy68ydO9dmzZplTzzxhLut6x133NEl+HxK3CkYv/zyy7l18rfhr+Nvo69hRBsbG3OXmTNnDsPRAgD6QgwGgNIhBgNA6RCDAWBkxV+G7AQwqpJ86XTaDaO577772g477OCWLV++3PXEGzNmTMG6SujpPn+d/ASff79/30DrKBHY2dnZa1/OOussl3D0L4sWLRriowUA9IcYDAClQwwGgNIhBgPAyIq/nmfW3JkYkm0BQFkO15lPc/O99NJLbhjNUovFYu4CANj8iMEAUDrEYAAoHWIwAIy8+NvUmbCxtdFh2TYAlE1PvlNOOcXuvvtue/jhh23GjBm55VOmTLHu7m5ramoqWH/FihXuPn8d3S6+379voHUaGhqsurp62I4LAAAAAAAAADA6tcWT1p1Ml3o3AIxiw5rk8zzPJfj++Mc/2kMPPWRz5swpuH/evHkWiUTswQcfzC177bXXbOHChbb33nu727p+8cUXbeXKlbl17r//fpfA22677XLr5G/DX8ffBgAAAAAAAAAAQ62po7vUuwBgFAsP9xCdN998s915551WX1+fm0NPE5yqh52ujz/+ePv6179u48aNc4m7U0891SXn9tprL7fuoYce6pJ5n/vc5+ziiy922zjnnHPctv1u1l/5ylfsqquusjPOOMOOO+44l1C87bbb7J577hnOwwMAAAAAAAAAjGLrOhI2qaGq1LsBYJQa1p58V199tZvM9MADD7SpU6fmLrfeemtuncsuu8w++tGP2hFHHGH777+/G3rzD3/4Q+7+UCjkhvrUtZJ/n/3sZ+3zn/+8XXDBBbl11ENQCT313nvf+95nl156qf3iF7+w+fPnD+fhAQAAAAAAAABGMQ3X2daVLPVuABilwsM9XOf6VFVV2U9/+lN36c/s2bPt3nvvHXA7SiQ+//zzG7WfAAAAAAAAAABsjLVt3VYXG9aqdgDY/D35AAAAAAAAAAAYyVriCUuk0qXeDQCjEEk+AAAAAAAAAAA2kga0W9feXerdADAKkeQDAAAAAAAAAGATrGnvHtT0VQAwlEjyAQAAAAAAAACwCZIpz5o6EqXeDQCjDEk+AAAAAAAAAAA20eq2rlLvAoBRhiQfAAAAAAAAAACbKJ5IW2uc3nwANh+SfAAAAAAAAAAADIFVrfTmA7D5kOQDAAAAAAAAAGAItHelrL0rWerdADBKkOQDAAAAAAAAAGCIrKQ3H4DNhCQfAAAAAAAAAABDpC2epDcfgM2CJB8AAAAAAAAAAENoeUu81LsAYBQgyQcAAAAAAAAAwBDq6EpZSzxR6t0AMMKR5AMAAAAAAAAAYIgtb46b53ml3g0AIxhJPgAAAAAAAAAAhlhXIm1r2rtLvRsARjCSfAAAAAAAAAAADIMVLXFLptKl3g0AIxRJPgAAAAAAAAAAhkE6bba8JV7q3QAwQpHkAwAAAAAAAABgmKxrT1h7V7LUuwFgBCLJBwAAAAAAAADAMFrS1GnptFfq3QAwwpDkAwAAAAAAAABgGHUl0railWE7AQwtknwAAAAAAAAAAAyz1a3d1sawnQCGEEk+AAAAAAAAAAA2g0VrOyyZSpd6NwCMECT5AAAAAAAAAADYDJIpzxav6yz1bgAYIUjyAQAAAAAAAACwmbTGk7ayhfn5AGw6knwAAAAAAAAAAGxGK1q6rCWeKPVuAKhwJPkAAAAAAAAAACjB/HzxRKrUuwGggpHkAwAAAAAAAABgM0unzd5Z027dyXSpdwVAhSLJBwAAAAAAAABACSSSnkv0JVMk+gBsOJJ8AAAAAAAAAACUSFciTaIPwEYhyQcAAAAAAAAAQAl1dpPoA7DhSPIBAAAAAAAAAFAGib63VzNHH4DBI8kHAAAAAAAAAECZDN351qo2iydSpd4VABWAJB8AAAAAAAAAAGUimfLszZVt1tyZKPWuAChzJPkAAAAAAAAAACgjnme2cE2HLW+Om6cbANAHknwAAAAAAAAAAJShVa1dzNMHoF8k+QAAAAAAAAAAKFMdXSl7Y2WrrWvvLvWuACgzJPkAAAAAAAAAAChj6bTZ4nWdtmB1u3UlU6XeHQBlgiQfAAAAAAAAAAAVoC2etDdWtLm5+lJp5uoDRrtwqXcAAAAAAAAAAAAMjudl5upb295tkxpiNq4masFgoNS7BaAESPIBAAAAAAAAAFBh1JNvWVPcJfwm1MVsXG3UQiT7gFGFJB8AAAAAAAAAABUqmfLc8J0rW+Mu0adLLBwq9W4B2AxI8gEAAAAAAAAAUOHSabPVrd3uUlcVtrE1EWuoijCUJzCCkeQDAAAAAAAAAGAEaYsn3SUQ6LTG6og1VEesPhYm4QeMMCT5AKDUTazaVpi1LDFrXpy9XmK27K1S7xkAjHzJbrPWpZm4mx+Hl75d6j0DgJGvuz0bfxcXxuHlxGAAGFaeZ9a5rqf+QXG4RWXixWbLiMEj9SVv6ki4SyBgVhcLW31V2PX0Y0hPoAR1we0re5eDN6EumCQfAAxn5XH7qkwSr3VZH5UYSzKVy+lkz2PCVWYN081iU0q55wBQ+bo7MvG3bWUm5uZXYvhxWPeZ1/OYWKNZ43SzCDEYADapJjHenImxbct7Ko5zcTibzIs3FT6udmKmHBwlBgPAJlUed64tqofooxyc6Oh5TCBkVj81Uw5WHMaI/5pujSfdRSLhgNVGw1YbC1tNNGRVEZJ+wEZLJXrqgluW9e7U4RpVLDNLJ3oeE4pl4u8mlIFJ8gGoaKm0Z+1dmYKJCiSSfzs01EMQpFNmnU2ZFhd+5XHr8p7/869VsM7jhaLm1U9zl1T9dOuaNM+8hunWWT3FVgcnWaJuinWFx9iqtm5raWkxsz8P7b4DQKXHYBWYO9YUxdy8/1vzbne3Fj42WpeptGiYZjZ5O7NtDu2pyGickVkeq8+sqxh8YuPQ7jsADHMM1u2mjm4bUxO1aDg49E+Y6MxWWvQRf4uXJeMFD/Wqx1m6Ybql66ZaaurulnrPxy1ZO80SdVOtW9e1ky0ViFra86yjvc3Mbhv6/QeASo3Bysp0tfZUHPdXFnbXK828VN6DA2b1UzJlXZV7t9kuW/5VOThbBtb9wWxix9VF/Hpo9x9lLZH0rCmZ6eUnwaBZTTRs1ZGQu1RFg/T2wyivC05nGqetN/6uyNRX5AtGeuKv4u7MPbL1D34cnm5WM95cF1vF35M2rh5iRCX5fvrTn9oll1xiy5cvt/e973125ZVX2h577FHq3QJGZbBd195tLfFum1RfbfFEyta2d9m42piNrY26+3VbhQSNB67bq1ozFQGN1VFr7uy2ZMpz96kFkQrKKtO2dyesOhK2rmTKpo2psbaupN3x/BJ7+p01Fg4FbbupDeZ5nr2xot0882ze7LF22E7TbGJ9rP+edmplrACshJyuO7LXnWst3b7GXbz2zO1A5zoLdTVZIL/XhzqLhOusIzre2iPjrSU01lakt7V44/ttSU29LU402Mp0oy1Lj7WVqTqLt5lFOwO2ZkG3dSXTFgkF3PGnvWYz0yUj3ZXXqg4AhigGK67qttZRwVcF4O5k2pY2dbj4GwkFbUlTh00fU+PKmLpPMTcSDFp3Ku0e09GddDG4pTNhf3h+sf1rcZOFAwGbuyExWEFdlcUqKOfF3UwcXtdPXF5n1qVKhyIqENdNNqubZDZmptmMednb2WW1kzKF6qrGTMEZADZDDF7X0WVja2KuLLuiRfPgRF3MVTnXLwMrpnZ2pwpi8KK17TaxvsqVmVVZ0RrPVLjpMYrHwUDAJjVUuefIj8Ezx9XYsqa4tXYlbVJ9zI7dZwsXl/ukGNzdlomvfcRelX09t7wnPgc61log2Vm4mUDI0jUTLFUzyZK61G1liUl7WaJ6onVXTXDXyepJlqidYl64euAT1+3OXuYcptJD82IAGHVUdlXdgmJxfVXExUyVbWeNq3WJt+J6CN0OB4MuHuuxitEqMyteqx5Cj1fs9cvO2qYeu6Ilbr97dpG9trzVrTNjbPXgY7AaDqtM62JsfhzuXSb2/OWKw/m9PrSZUMwSVROsq2qCxWMTrLNqrnU07GdtkXHWFhlvTcGx1hQcZ2uD46wjFXS/AeKJtHWtTVl8RaaMH08krCu5wOKJN919WqejraihHEbnrDLZufx8tbGQja+LWUNV2AL8pkIfFCdVR6D6AsVZP662dSVc/YFul1VdcGde7C2Iw33EZdVbeEXl02h9pr7Br3eY8N6e22o44f6fkhmpQpnzYTZikny33nqrff3rX7drrrnG9txzT/vJT35i8+fPt9dee80mTZpU6t0b1fShXdEctzdWtFg0FLItJ9W5H62JVNp9aHX/8uZOV5jQh1XL9YM2GspUKOrHrj7Iov/1Q1cffhXQ9Fjd5wcPXbRNbUPrFldk6kf0gtVtNqE2ZlXRkPvCentVq3vM9tPHuPUWr2t3hTy1vtJj8rehba5p63ItTPWcutZ6riDUnXStX/Qjfkpjda5yVM+pz/Lkhmp33KL1VRDUsQQsYO+uabMJdVWudYyOTdvV/Qp+2oaOVQVNHZdof/398vnHKDp/uk/Ht3Btu02oi7lWONqe9m1CfSwXbP0Aq20qoGp/kum0W6bn1X4sa+5wt/VYLfMfp/MkOnYdp16Lhqqo/d/T79o9/17mColqPJHW65ROW0NVxPbdcoK1xBP27roOqwqHbKcZDbZwbYe9urzNEsnM+ol02lIpzxprIu55dRzrOnXezZ2bsZGUbVFvNrPOs0Ur1lg41Wl1wbgtfCtu9YEOe08obtXpdqt+u8Ne+kfcxoe7LJpss6qULu1WlW63mnS7RTO1Cb00eXW2zupsrVdv6/S/rm1y9lq362yVN8ZW2hhb7TVa3Pr54uilq9eSRCrzGuq8JlNpV1iaXB8zrzttizbokwb0pjjg4lNXyl5avM4aqqM2e0KtKzT5cdKvQFThSa30UnlxTQU0xQNtR/G5oytpK1rjLgGk5YorKrD5P4z9GJwfn/zYpNsrW+LuM6zHKS6saotbvDvtYuSWE+vdPim2KA5WZ4cJKY51ij8q5I2vrXIxRz+0dQyqINV9qhjVvimmaluK2Toe94OkOlIQI7X+6ra4i3u6339O3a9t18UiLi6K9kmxTtsSbVfr+t8Tkv/9o21oHVXCKvYrSaZz994pDS62ieKmvjO0rzov2qf877XBxmAVfnXRMWi9G59Y0GcMro2GbeuJtRYMBl0cnlQXs6ljquzZd5tspSpDUp4l0p77/goFAjalIWZNnUl3fDqnOk+JVNLGhpM2p9FsQiRlq9attZgXt4ZIt61b3GkNgQ7bK9pltekOq13eYe3/SduE2qQFVJGhiwrT8ez/+UMV5w8VVDMuk7ir1vU4syk75N0en03qZQvPKjCHM68JUK4tTBVL31rZ6n6cbje90cUavyyoz7LWU1wULVdcURzRZ1+fO33udb/bXl78K47BUhyH+yoD11aFXcxXGViVOLVVIZvaqB/MiYJyp+KSX57WcsUBHcOa9rjVRiNuPW1fx6GyrJ7Dj8FKbql87zcK0HwvfjlV50P7r98FKnfrOBRb/e8RPWd+mVT365j0XVUcg/OX67F+fPfjq74j9Lw6z9rPLSbUufNfHIMVu7WvfoMGPUYX/zvST6zlP4f/GvcVg//0wlJr605ZLBRwZTutHVblcCzkGhvo++XgbSfZVhPq7Od/f9sWr+twMVjPrZgdCQdti/E1bhgtjfCQVIWw3guBtI2LJG2nSRGLpeO2ZPUaF4PHhOPW8nabzQjGbcv6pHkrW2zN4m6LTw5ZMNGaicHxFncd6G61YHerBYorKlSpF4xad2ysJaJjrCs61rp1XbO9dTWOta5Io8UjY6xTl+gEa4+Ot67IGEta0L2fVLmi94xfXlcnknSrZ+kW3ddqaa+l577sdbr4cWlVzagNiHryAUNT2agKxOVrO21cfcy2mlzvYpcfg3VfcT2EP0ydYoIfR/W7tTORcmUkxSQt88tsul1cHlxfDFYl5itLmywUDNqWE+vcOor5xfUQ/vb8smlxDPaPUzFIsUqxuzORdNtx7alSaRd//TKkf07yY7Diltbx437xd1P+94tfplcMVqz243ZxPYQfX/3vNi2fPrYmVw+Rvx8qY/v1KcUxWOVoldVnj69z+5j/OL+crroCPVa/T1TWvvyB1+3fS1qsW69NJGQdeq2DAfc7Z1pjlYvNfj3EipYue2tVm3V0pyzgedYcz+y/vic0X5l+q7d0dltCMSqVtupgytVBbD8xYivWrLV4e5vVBuI2OdZtza+32pRAh+1SlbDw4lZb8HrcvLqURZOt2UubxVQXoToJr7DBhK/DqqzJGqwpWxex1quzNelZts7b3tZavaunWG2NtsrTZYy1WI1Z+/qSLUrYbVjSLp3tDQPka+9KWXtXh/sMN1RrPr+I+5z012NqY+uC+4rBQ1kXrBjclUjbvxattdpYxHacsel1wSpPK1b5ZXi/Hkb7pHii8rG2U+l1wflJPMXreLLnN4Ie/+eXl9l9Ly23tW3drvwbDQWspUvfSQH33BNqo7amI9FvXXBSdSIpndtMkk/HsbYjc951GRfx7L3jg/besSF7+d3lFkq2W32wy1Yu6rIxwU7bI9plNV6H1S3vsNZXVSeUyquHyKuPKBptIqdqTGFdxLitzGbsnlnm10X4CT1dorVWTgKeStUjgBJ7u+++u1111VXudjqdtpkzZ9qpp55qZ5555oCP1bB4jY2N9oHv32v1DQ3uy19jEMciQffh1IdcvW3CocwHW2/sWChzX0jLsj+sdb/W1Zu34La77vnR6u5z9/esq+2rgJdZnl2m7WYf629XhZMN5RewlGTSB1If9OJWTH6GXHStAKEPsT6sCsjanykN1e4Hpx88VeBSpaoKVwrUfmD3g5mSdKo0vP4f79hd/15i3dnRAqrDAdt19ljbfYvx7lgff2u1vby0JVOIzJ57Fby6UykLmt/LqeeHXzB7vpQwUqDTcj13owqvY6ptbHXUJjbEbFVrl611PRkyFZljqqP2j7dX27r2LvMs4AJtU3vC/J+3DVUha6yO2LqOhHvOyQ1VNmdCjSmWaht6X6zrUCGz27pcAT/gAo/2WfuhgN4aT7vtqbitnuzKTeq2vqLG1UXtIztMsTkT62zJuk57cUmze4yCmt9YdVxt1GaMrbEtJtTaGytabWlTp/sxoedQCwRVLlRFMsFWr+uqtkzhW+8rFVh3mjnG/VB+cXGz/WdZiy1piueOT0IBs9poyFUq7LPVBLv3xeW2YE179ge1Z/GkZx1diez+h6y+OmzNHYnMF1EwYNPGVNtO0+rtjeVNtralw5Kpbguk0+alEhbykhYLJKw6mLSo120RL2mRQMKilrSYdVssoOUJiwaSVmWZ66glLKL/LWExS1iVdVtNoMtqrMuqLe7+r7bM7czyuFWbWtMNHLY6vai1Wo21etXuusWrsVarthavtmB5q1fjCsYukWcqRNdbs9VZ2p2BQvr86TOj97Wu/VjgL4tl/9d7cWJdzLUsUYvqWeOq3bqiApDet6vbu2z6mGrbZnK9vbmizWpiIZs1rsZ9Ieu1ra+O2Np1TTZ76kRrbm62hoZ+WgCOEH4MHonH6heC9BlS5Z9iqh+D9V5RbFZFqF9A1Y/2qnDYJb38H65+Al2FaBUOFW/8BJV6CajA7PcG8J9ThS4VrP69pMkeeX2lPfb6aktmg0FDLORaNm09qd4WreuwN1a0uViiJLNi8tiaqIt3ij1argKXlleHQy4BlMwmgRRz9MNXn0Ytq4+GXAz2H7u6tcvFSa231aQ6e3V5i720uMXiyaTrcRBXI4hkz2e5OqJCYNAdn74f54yvdTGxM6HjVIsurZ+2tmyPBn0/TBlT5fZPP+jbunqiXXU06H6odyU81ydAn8CpjTE78D2TrDoWtleXtdi7a9vd8XUnMvtQFQ3YlhPq3OfUxflkyj13WscYMFdAndpY7b4n9P20qlUFV7OJ+v4L6/lU6A7b+PqoLWvqtFeXt9rKlq7CGOy+a8L21QO3tmljq+0Xf19gq7M/FsbXRl0Stbkz6RKtihvj6yK2urU7U4kfCtqO0xrs4++bao+9tszeXtFinZ2dlkwlrLsrYSFLWl0wYVPqAtYZ77RwsssigaQFPcXXpNWFEhZKJ1wsboymrTqQtJpQ0hJdcQulu93/oWQm7tYFuizmKe7GM/E4LxZXB/puHJGvM1hj8WCtdQRqLVDVYBMmTLRQdaN5sQazqgazWIN5VQ0WiDVYsHqsBesm9BScy6S33UiOS/0d68sLllnjmEb3A0vfRboEcv/rZQms975ya9Wb/wNWZVvFY8VVVSRIcQxe2dqZ+3Gvz6B+7KsidnxtzALBTLLfj8FxVw6Lu8drHhPd5xJ68W6XhFuyrsMeeW2l/fnl5fbKkpZs/ySzcTVh++hO0ywaDtlTb6+x5c1x61KFRFDl2aB7/1dHgq7CUWUJPZ9fzlC7IK2i+KdeAoq1fgyuDgddAzb9mFcc1uP7KgNr+yrTq4yuyhovG5sUN1XWU1xXuVNlPlV6uMYdLXFb3NSZGUaxK5kbz0BxS+fqndXt1tSZcPund4AerziZyAbAaNBsh+mNdsB7J7kf608tWOvKwGv1HZP33TShQfuaKUO1diWstTMT++pjYauOhl381e8EbXtFi1r2eu68NdTEbFyNviNj9u6adntzVbutaonntq3vAP2r+vDpY6vtS/tt6Y7llqcX2dr2hCX1m8NVvKRz30F6TsXrta7iPJkta8dsakPU1rR0WGtnp6WTSUskui2VSLh4WxVI2Nho2lKJuIXTmdthV85NWnUwYRGVgy1hNUGVmZNWFUxYOJ2wsOeXgzPl39ps3FW514/BmbJxl3vcQFJewNpU9s2Wc/V/pgys8nBP+dcvD/sVyao4VgVyp2u4VvrPsUa0WPST/x5VMfhHdz9n9fUNuToBv87Ar1foc3lePUSfywse38fy7PVwxe78egg9jxJqqn1SmVhlYz9Ro3Kr9k29WFWmVTJIcVaVn34MTlsm4eTHcsUQPUa/v/xkvpYrBiuOvLO6zR55Y6X98dkltrgpnotbs8ZW20d2nOri5j/eWGVLmhXbMnFL8aVDZT/9Nvb02zjlyp9qHKXvO5V6FU8Uj7SuRmXReio7q9GU6m/08dG6A8Vg/VZc1tyZqx9R7l/7r3KrjtOvh9Dx6aVRXFrZ0p2LizoWPa9iol5D1cs0x1O5Mqf20a2T/TTXRIO22xZj7Uv7bmnPLFxnD7+6qicGpzLrqYfOzLE1ttXkOntrRZsrW3dnvxsVD2MuQVZtcybUujL026varTOZcnULetz20xvdeXt5aXNBDPbPu78f+79noh303kn29Dvr7Jl317qKdh2jzrPOmRr76rhro6ooD9ia9u5ssjFke8weZx1dcVu4qsUSyYR56aR5qaQbyj0aSFhNIOXirsq1irtaFvXrGgJJV++gWFud/d+/rXVVD+HHWlfnkBd3a/KWhwMD9zLu9kJ5cba6J95mY26L1RbEYj8GqzGx/u+2TEPA/uhcuXoHlQsioex1ZhhFV0+Zd8ncVl2ffx1yyzMNZIK9b4czdaBaNxFvt123nj7iY7Affx9/ZaHV1Y+841QM9oeP1edTZb9J9VWuXlexRNcq36hsp/t1HY1meuvpN/aSNe0WVP1Arcq6QdcIVNftHQlb0Ra3+kjYamoirm5VMcRveKU6L/VovXEj6oL7isGBgBotDE1dsD5E42qitqw57sqtUhcLuji+sXXB+q3R0pkXgwOZARO87P+K1e+b2Wi7zhrnvqf8uuB31+TXBUcGrAueWFQXvDqvLnhqY5Urs+scvbSk2dV1LG0uqocI6DhD9rH3TbNDt59itz+z2F5f2erqOhRXdN7VoEHrxSJhm1gfdXUZej1VLt551hj70r5b2PPvrLGHX1lia1o7LJlMmGVjsMq5tSHF1qSF06oPztRPKP6q/rc2nLRgSrE4YZOrPVdHkU50W9hT7FV5uMuVgxVr1XAiUybuqQvW/7qE1lMX3B2IWTyUqYdQncP4bD2EX/+g657/G10dhIaTzyT1xpgFw2URlyaMG7tR8XdEJPm6u7utpqbGfve739nhhx+eW37sscdaU1OT3XnnnQXrd3V1uUv+CVRCcObpt1kwlvnRX6704StMKmYK/C5JmK1w0QdQFAxV8GzuTLgfsuKS/Z4+xJkCvV5+/w2gVRQkvNzzKIufSa655862ENDzuhFeVKg1L/PDNZBwBaqIpVyyJxxIWdh0SVrI8/9PueWR7PLakKJe0oLp/PVTFrK0uwRcqsXLXfJvhwK97w9mb7vHuw9+4f3F3WqLf8oUD8Ho3/Z/8+iYi3//FD+mpxjb33Oo0J13zrPbCOSuMxe3v3n36djy17E+lmnfco/Va+z2vWebxc+jx4fduU7lXafcufVfh8LrzHrrS7ANRpcXsS7TJewKsrqt67hFrcOLWYfFXCVDh1eV93/2Ovt/PBCzdk+hX/9Xuf+bvSo3dGZVVVUuMa7kgrpu63ZNTAWTTPJcFWhapoJsbfaHmn5k6uOjwq5+RKpgrMKu3vMqRPuteDLvB//90X+rpU0ZA3okVzD3F4Mr+VjzxwNX4db12ljVZg+9utL+8eYqV2mqH8jLWzKthVUYUyErnsq0dB1TrdZVCUuk1GPKcwVXvcP0Y7czWwmr9+rEuqirSFZBcq162SWVRE9aYyRlYyL6HKvCMWFeUi3DVMGYsnQq6T7DkUDmc6wYHA2kbEwsYMlEtyuU+THY/5xn4kRPTM3E4J44qzhQfL8fhwNF/2fieU/s2tAYnLvdx8dpw2Nw7/hVHGe1jZ5lhfHTv69neWHsLlymQn3me6f4Pv/89BVjQ4GimJy3nl7DTZX2Ai7+dlvYulx/5nA2BofzYm0m9hbG3ewyxeRsnFZrY/9/xWBVWLRZdZ8NJQaiUJnfGzTT8Kmw8jK8ntv++q5clN+4Kq/BVHFjq+JGV65hV7bxViLeZp/df7uKjksbGoOHooLDlUVceUQN0zIVnZnySO9EoejHeuazkinD+uv6CcTM7Z5lhetmrvV9rFb/Sh75ZTVVXL65otXu+NdS15hKj9f3vHoTq8GDKiX1vtAPWv1YVzxu7ki67UhdVD/aPVeBqZa52mdVPGsbSs6pwkQ/+lW2VEMmJXZqQylLJTONnoJq6GTqFZC0QDpT7o3klXVjgZTVR80S3d1ufX3uXRnalZXTrpFCQczNi8GZMnBh2de/P1eGDuSXj71sj62e+NdX6WRDY3Bf8XRjY3Cw3zhbHD+Lyr7Z2N1nnM2WgfPvy3+eXuVfxdpAHzE5/3o9lbuDkfSC2RicjcPZMrCW9cTXqqJY2/N/X+Vj/d+WrTRut6qNTtJlemX615nflsGiZX5i33123Tp9f74LGwUU39fTWKC/+7zudrv+yweNqhhcyroI//vXNSrOj7fBfl4nP67nxXlx62Z7aam8q1ipsJp5XXtGMMn8RMokzTL/Ze7zk1JKXKj+QmViP2rkvw9Vz6H79bms8hPnwZQFVOZVksfLlHuDui6oh8iUiVUOjiiWpjOx2r8vU6YtLPeGiuohgkUxOP/+4nUDgWxM9jYuNhbc3sB6iME8T2C9cXagcm5PTO3ZVl7sLorB+WXqzLnqia25uBsYIP66+ze9HkJJOL/86+Kwp/KwH4Or8uoi8v4viL895WTVQcSzy1z8DdRYMpj5rdatnijVEdtrq/EuQZBJvPUk4gqv/fszdRNqwJm59m9nEnq6X5/RzdGgaqTWRfQXfw/5wZ8tnBd/8+tI++JHpvz7c/8WLPPWc7//PH0/kb84/96e7fQs9XvJu+/P7OgwKtO6Xl3+Nvz6q2xsz39Kv1OFf7/rbZvtde/T972Wp3P1xpm6YMVgNVqKmmJuJsZm6hwy//dVF1wdTLt1A9lYval1wbqdib/ZuolsWToXszcwBvcZkzdLDO6jPqHPOore9cO96ijKui44E3f9GKzrTotaZx/l257/i+snqgrqKlqyDdsSI2DAyk1p6Fb5R29mq1evtlQqZZMnTy5Yrtuvvvpqr/Uvuugi++53v9tr+TWfm2ehWI2rcHWtiFKZ1pwqXKogqYKnbmfmp8l0R1XLMgU49W5IZW+79bO3E9n79Xh/uf9/ZrmWZVoE59bVdlzLhd7H6pJrKimrnq9wOO7iNV3AVWujCdkeUbXuOu6y4lpeq1b6rrVoZrla51cF1eMq06LJ9b4KJvJuZ3paZW53WyyUSewNJRW6FK7Vhy9TxA7kXfvhKPO/C+ue/7+/Xn/rZmqd/OqDnrOU/3/xfUW3iyL0+tYfcN2ijWVa2vn7XRjC86vHe0KyrsN5yzLbLAzjmWUF4d+1Jsn8nwoEc1+jCS/ohtrRedeypF6HQNASnlIGQTffRioQsmQ6aOlAyILhsHWng9aZDFoie97zKysUsDPt48LWka288EKZZJ6WKcGmFpf63GgYwVRaXyjq6p02dezRHqtltiri/J6RBa1QNAmwetoGlIxTV3lzj1Xr7IPnTnYtCwc1DvMGyk/ara9wPeSTvI4g/cXgUlBhV/FcrUjVUkzX6iGgZYrJ/nxkbrn/f/Z7wP8uUKsu9ZzVHAyKz1quVlDBVNyqvUx8rTO1pIrbHP0fyC5v77I611I0brVxtVbqzsTZQLfF4tm4q3gbzYvJHQmLdXTn3ZfXot//132ABvFN73czDvW0/lf1RiYu9MSevuKqYoW7z8UYPyYNFK8ztwvOffFrsb4YPMD6A8XfwcTgzP7lF539ZiI9y3ritOJkcVzufdtt08VlK4jB/nZdrM3G3FzszcXgotvZdXLXXqjX411BOZus8ysrXAVGNib7MVrbKIdeGvnS+WWbMjGS50XtLwarUUK0usP9qFcL2oLr7GgK/rLM8LLZSoGC5Zkf/u7+gvsy6+bu62fdgmXZ2+n1rNPXz019Av1W95lyb6aH1HZ+Gbgrs8wvA9ck1Ho0W+7VdTIbd8PZ2/o/mbCqVPZ/XSLqvZX3pvULLIPlFcZq/3OfKQMXxlO/yjl/eV8x2C8/96ybfaySoUMYgzekDLwxMbjfmJpN6eXf31N2zo/TfvzticE6V7kYr14jmeoKF0cVU3virXpMZsq9Kh9rmcrB/noqHwdUpk0HrSul781MbO5ptJatOM7G4a5sBbIXjFhHOuKe0zU0UwOycMj1IuxMZJKSHdme5apIc8NYZqN18WulnuWuN0co6Hr/qBeUyqXbTKhxDdaUXFEr9Y/tPN3maIjmbEI8k5jT137mHGQ6HfUkzfOH0fR7ChUPr5kZltOGXTLeZtfb6IrBh+88zcJVtT31BNk6gvx6gz6X56+f6md5tq6hP/5w4evvqz84Km0oxjbmxeBcHUS2h2rmOlNPoWsXb9Vw2I+5unYxOK8uQmVk/R/K3N8r6bMJtVv63Zspj/UTR/P+T/VRD5F/f+8YPHA9xPrKtRsar22gbfdTD+E3kbY+y775VcPFy/ztFy3Li8Gu6jmvHiIQVDzN1CsozmbqIvLKuKp7sExdhGKuFwhn1vGCFgxHLBAMW3vCLJ7OvBbqL9KTsFO/kbAlAhGLp3vKw4FI1NoSSgMEbUq9asrMNaRU7FWjefUg785WOOTH4IiS03kvgM5QVSTTMKy+KuwaAK1u6XIjgXxm+8lupA/1/l7vnHwoq/jr5lWMldEPkU3SUxc8sbguOBt3MyMGZK79kVsy9QvdLmmXK/vm1QVnRufqidHlVhfcUw7OrhsYwrpgK5+64FRfdcG2gXXB7tJHHYOui8vExevl4nXm/uK64PyGxD31EH7ZOFx29RAjzYjoybd06VKbPn26Pf7447b33nvnlp9xxhn26KOP2lNPPVV5vUhSSUt3rLNkZ5O7TnU2W7qzybzOpuzkkM1uLNlAvNm8eLOtXLnSwokWq7d2i6Q6XTfW9bX414/dTtcDKtMCXxnwuPsxGrXuQMQNeZj5cer3utKHMmqpYNTaUmHX60of3nj2fhWmXLsMFdbSIUuF1ApaH/CQK3gpCLgOuy54h22XLcbbOy1JW9LU7T7sqmDWRVQFOZiv2KA/HIV6HoYyrbTVyqkhFrGW7LwiaqGv+TA01FBXKlP2H2igGz23/6HQEPI1GlM5mBn/uSuZCbv6jeRlhx9SIioTWNevNhK07abVW3tX2pY2tVtLdnjPfFVBs6iGu+tO5Z7H/G7eNRE3JJ56ZyqJpB9vqhhVay91F1fLLgVNVRi8u67vMYa1huYD2WZynRv+IhwwW9bS5ZIVbgzkbGNvTVei/7UPGt5IFQThcMCNoeyG9kyk3VjKfvfy/O1rfb/reih7/ruyvZPcnHxdCdeyPpY3DvNry9vc61U8DrO6/rd25o/DrBb4YTd3wafnzbTnFq1zvaMm1ETt+P23dPNd+T2qVPFRqcm2kdp6bqAY/PaSlRarrnPJtswQlZmJv/3km3/tL3cJN/d/YSJOCV8NL+OSd73+77l2l+I3cJYKsQ3W7uYXa8xeN1iHNQTa3XV90e3M/e1WF+jMVVysr6WTfqiqxb0ufgtRxVQ/5mZibH4MjuZitB+T3XrZ25lBwcK5wpnibWaQBC33C2f6MZ2psKyvrbamLrOOZMC6soVqUUzItfjrY7/9pHumR03m4vey0eden1PFIjcSp5cZeqKtK2Wt8cykyRquY6AzowS/Pue6rqmKuNjenZ0kXq1itQ03z5yGxwwHrCNvyM+BaL8n1mWGl04mU/bO2nhmH/Mo7un41arW9eJJ6Id/5j4939SGmKtM1XeJ5qvTkB56H2koUA3lpPehhgNRTNN9fScfzMZWh91wR0ua49nhqzRXlKv2cM+bmRNv4Bisz8ia9mSv7xBtvyGWSSRqmJX8GFwbDdtWEzVUbGZOPg0XNaWxyp5b2OSG0Cqek29yY8xaOjNzrvbMyZeZQ0FDl+4yqzHTAzXt2Y7TNZToDDc0tc6RqEd0/jDjxUVOP1mTq7DMVU76DazybucqN7ONoQa4nanMLK4czWtgVbSOzrm/Db9xV3tbq9126sGjKgaXz4gWXrZyuD0vxvbE2vq8mFt43WG1gc5shUXvOXCLKba2F7UE9ZPl8V4xOJorB2fibmEMziR0cmNYZJNDYVeBGXc/lhWPw64MrHgcDIasoa7GVrSlXPzV+n4M9hs59RfZ/BisGOFuZ3vcaJmGVVac0GfZ9XhV74BQwPVgdGVgV8Ya+LxkSpKZBlWaO0Otn1viKpNqzo1MTPLThX4sHkz/NpWZZ4ypsvaEehYmbWVbz7BGvljQ3NCnGrJO+6B9zXzHZI5360mZIe+7Up5Nro/a8tYu953wnsl1bh4lzY1dGwnY22s6c99jxXQOdpxWb6Gw5qLqdNvXnEx+Rk2P07765Wy/R5Pipv5XOVzDqq9uz8wD5Q8Jmv/6aAoAJaVVLomENfxUpvLJn5NP35m1g5iTb052Tr6V2Tn5XA9Z1ys17H5PzJ3SYIvWdrj91DBQn9xlpvuO84fm8ufrGmpe0Zx6hXPs5c+z17OsYP1sY1Y/eZ+/rkvcax6xzjbbdZsZoyoGb45j1bnvK4mY3/DYU6sM1Td0tViwq9kC/iXe6m4Htby7Jfd/a9MaS3U2WU26zaLpTqvx4q4ieH3yW+arPqInzmbiqivz5pWLM2VdjfrSUy7WfYrViq+u8jAYsq60KhYzZV4li7pyMVj1EJkYXVsVs8b6antrdVcmuadEfrYeQmVBf2i5gQT9371hfTIzMWtyY7V7//q/1fU5VjJec04pBhcnjAaKwaqHmNZY4z4fK1q7LBTMDEOvRJQ/HKffCGAwJeGaSMC2mVjnhr5v7eyyFa29y5DaP8Wrzu5MHUWmcVombmruVg3h19aZcHFKoye0xJPuu0LDO/v1ECqzvb1aDYb63g8NzXzIthPtP8vb3G92DUfX1KERSDLxtycGqxFv5jsgFlY8NpdUG18Tzg7ln7A2PyuXfwzBzBQorZ3d5gWCrjddZ96cfNOzc/L59RCK/2+varP2blVhW25OPtUrNVaHrTvpWZPm5FPjopSGxgu4hsV7bTneDbGv0VsUb4/ec5btMmtsbn7E4YzBm8NIrYvoL/7+5J7nrbq2vqC7lv9fftvuwpqlwMD3Z2/09HXu7/68RfpNnU5aNNlisURmLsdIss3djmZv+9eRRKurA25rXmOxZJsrH7sYrOi5iXXBKufGi+KvLqlA1Npc8jxT9vXXU5nXb0zqkvPBkMXTmdv+xa8LVoJq1y0n2IKmRLYuOJs42ogYnKsLDgfcKB1V2brgZtUFJ9IW3sAYXFwXXFelOlbVBXdbPFs29etoVWb1y4CDKQfXhM2mamqTaNiWrtMw973rgqtVF6whS7t61wWPrY1Yg+Yp7eh28VYxKTNnX8jFPD8GJ5IpW7C27zk/pT4adHMjajhTxXZ9v6ieO1cXnFfPrZdB67jpnMJB23pSrRvSVcOWqn6nr98Uoez3iD83Yn0sYm1uSO6A+w4ZXxOxdZ1JFx+3n9bgyr9vrmwvqAtWrFUDCtUFq6ytKWoy5URtO+SGNP3E+2a4qWk0tPT46qh9dp8t3HRI2j93vlUXXGbTSAyW4tKsqRNGb0++CRMmWCgUshUrVhQs1+0pU6b0Wj8Wi7nLZqPSUec6s441/VzW9l4Wb3YfpMzU8vkCmflsNGeNxo+tarSuaJ2tCE+z7ur3Wleo1l5clbKWVNTSkRpb3R11FcgqRPuVyVVVdbY0HrauQMRmja1xyS9VnLpW1tln6S/Jpg94YyRoTd3pXveH8scezozE6eb3UMHUb5maPw7ztluMtx1DAXvyrTX20tJm9wNDFcQKzq3ZOfnU0jQ5wJx8mR8jReMw10Rdz63icZj3mjPBHn97tRvmLjLIOfm2zI7D3BxP2JaRuiGeky+ywXPyaZ9i+eMwt2sercI5+eTfi5vc+VraHC9oCazCslqZfXznafah7afarc8sstdXtNqMMaFBjcO8y6wx9t/zZtl9ryy3V5a2uP3I9MZLuvn8dMyaM+GD2012x6Ixoz+0/TRXINd514SxqnzQ+fXnyFHw1m1VMIuGt9B8OTou3efPF6n3VHu3xsMOu4p0zaej1/AT82b0KkjrcShf/cXgAy55ZFgqmFV1Os5abWyg1aZkr8cFWm2stdq4sP5vcfeP85cHNOBK3xXEKqB2BOusM1hr8ZCu62xNss6WpCfZG8FaW5OM2dpExBWWVXHR5lUVxGANsaWhQJZ3ZZJymR/SmfjoxyK/KNJfgkg/0hWziysWFZ/9StHMEA2ZmKx4qWSVvz03J98WY23riZk5+d5c2WYrW/uek09jvXevZ04+SQxyTr6Xl7Tm5uRTslUxx49P+r5QIdyfD2nriXWugjmTzOp2y5XcVcWJe10DmR/ZSmRpXhNVQvvb0jyXqphWYtBVSAfMZmgOlh2muom2/72o2f3wX6aK7+yJ1PO/d3KDm0Rc58Pv1a9KV/140BA5miNmbE3ExaDlzV02dUzIJtfHMsNkq9AZU9zMJM40Hr7G+veHPvH879DqiJ0xf67NGl9jlz/4hqtc0Dj6/lyequhQ4VZD86wvBoeC3S753RbPFLJVmb/TjEZ7/3smurjaVwxWfCyeiFyvsebYVfzV98mSpg6bPqbGvc5+D1Y1dlGljh6jJJ5isGJuX40qRkIMVuH6tlNtVMXgXWeNsarauswwfXlDtOWG7iu4tr6Xacg3fxg+9786qyWsNtlkdalmq9El0ZS7rk42W3WiyaqSTVaVaLJY9zp3rfl0+pIKxSwVqbd0rMHS0UZLROttUUe9reyO2ZJQnS1oDdqahIZ8qbKWtB9/dZ2pTO7yYhasrrMVnSHzgpmhuvUj1a/ItD5GD7C85ZFQJqZ2dGvepN7cUEb63GQbSykeuoYoebWdmpPvI++bZpFQdk4+xaFkz5x8iptVGzAnnx+DB5qTb++8MnB0Q+fk687MybekqTMz5+sg5+RLpDUqSk/PM83Jd9DcSS5mPPn2WguF/Tn5MltTxYXmUdEchzpu7bsqTxWTNDeeKkX0XDPG1eZi8OxxmrMpaI01UdtyYr1Nbaiyt1a3uUpwzXXoj4ziVwKpmKhy+Bkf3s49px+DpzRmEnCq5FXDIFWY6Ng0RLbiuL6DVGb1E2tvrWyzaKTTzcuo3wZqDNFXDI6GA3bw3CmubK95yRRjFStVzvXLwPrsHDh3UkEM1rxkE+urXJlZ50vfAe6zG9YcYOp5EnDzdOuxfcVg3TecckPqDmNr7OZmG7E2e11Ed7tZ+ypXxxDsWGvR9dZHrDXz+qlhjdRm6iGyl2S0wVZWT7ZlgRnWHaqz15vNVnVFrDtQbU3pTNxtz0vmpUK6rrbmZNQikZD7vlA5LDWIGJwZxjPz+zrT66x3xWxYSaJssl51Dpm53jKJMcubk+/DO03NjNgRWuVimz8nn+ohVDZNDfGcfHtuMb6nHmKQc/KpHiKc3Z565K5szdRr+HPySeGcfMlcmTN/Pii/XLz7FmPtxPdvZc8uXGcP/melBUP+nHyZ3wh6fs0Rr0pS1UPou8mfk08xWL/JVTZUY7EFa9qzcVDTXYRt9riagnoI/U5RDNa28+eo0tDYn9hluh21x2x74D8r3EWV2f78XzqG/Bis30kLVne47wn1vjv5gK1tVXuX2381oKhTWb0r6b7HRXOCvW9Go+08a6w11oRtt1njXb2KXg+VbTUnusquxfUQuu0PAa9yr2K0ysw6J6pn0OMVe/2ys0Yk8h9bXA+h+4c7BmPo4+8ec8YPz5x8GjKyu9nC8bXuEnLX67LXay3UtS67PHvdtdbCXf1/AaaiDQWXeKzO3g5Nc9eqn3h9nWct6ZglwzW2LtFTF+xiscUsHKu1FfFMYm5yQyw7L3EmBqy3HKzPcMSsLVvHmS+qegglvVKZOgh9hai8HAyq0az1qgt+7xbjbft+6oL7isF9zcm3IXXBxTF4MHPy5dcFq3HuUMzJN2/2OGvuSAx7XbDO52DrgmeGw4OuC/a/Q/7y0vLM75eEXp9MAzVtX42dt5veYO+ZVO/K9O/feqLbb8XVtq6Eqz/Q6zVUdcHabnEMHlfbO4tSaQLJyOjuySd77rmn7bHHHnbllVe62+l02mbNmmWnnHKKnXnmmcPTSiWVMGtbada2PHPdqusVmUtr9tq/pPqorKgak5ncseAyzqx2QnbSx7EFhWh3idZnft3n0Rv7vDtfsjdWtdmk2og9+sZqi3crox9wiRf/Q63KAxVQ/QlRFQj0Y1YfKt2vH9RrNHmn57necLPGZBKA61SQVI+JSGZCTwUe/eD/z/JWF1wUEPTDXD9ExWX01Tre89wHbMfpjfapXWa4Aqt6nKnVgNb1ewPo+dWyQpWO+rBquX6wqkJDwUJBSx9k0f8KMvrw60Osx+o+BQh/LgFt0281UFyRqf1dsLrNJtTGXEWIWgW8varVPWb76WPceovXtbtCngKFHpO/DW1T50hJRz2nrrWe1tE5UQti/Yif0lidqxzVc+ol04Tj/jnS+grOOha17NGk4hPqqqwqGnTH5o+nreCXaZ0RdAVNHZd767hKo8x++fxjFDf2dtpzx7dwbbur8FGrX21P+6aKc78Q6wdYbVMBVfujL0x/zHjtx7LmTK87PVbL/Me5Hx5u3rBMTw+9FqpkUcDV/mmbldqTrtRGauu5gY41vxeJPv96r+Wu8+Yu8Oc0qAsmbFJwnU30mmycNdk4b62NTa2zxtQaq0+utdrEGqvtXm1VXWvdYAf5lOBJV40zLxt3g7UTLFhbFI/7isGRmoLmevqc/eG5xXbfy8tdqyn9YH/X9SDIfDb91lBK7uiHqmKwP/eXPyefKgnVUtQVsrM9mBqrMl/s7Yot2XmmFLOmNcZcrFDl7Mq2rtxk9fXRsOvp685nPNMqVh89VXjO32GqfXiHqba8qcMaqqM2e0KtKzT5cdKvQNRzqGI4lRfXVMHqt+xWfNYPabWW0o98LVdcUYEtfz614vjkxybdVm8SxTc9To02VrXF3feVQolih19IVhxUHOkr1in+qJA3vrbKxRz90NYxqIJU96liVPum86RtKWbreFSB4Cef/Bip9VXAVtzT/f5z6n5tW8OeKS6K9kmxTtsSbVfr+t8Tkv/9o21oHVW8KPar4kfnTr2N/ddKcVPfGdpXvwdD/vfaYGOwCre66BiUiNQ5JwZvmtEYgzdoTj6VUxKtFulYaWFdOle5/6PxVRbpzC7rWGWhjpWu4qLXw0NRN8m5V5Mt89aMs0DNeAvUjreAWzYuM/m5ysp+/NVE6ZHCirP8GNydSNrrK9pcQia/R4Bly8CqlNXHQZ8hlVvVIlXlYD8G64d7Zr5p9baNZIZe7kpYSj3gQpZJutRE3Q/kpc2droyshLw6baucpZiuxgaaW1XxVPFG6++3zQT74LZTrKmjy/043W56Y66c5Jf1Mr0GMmU4LVdcURzRZ1/xSfus+938r3nxrzgGS3Ec7qsMrMYO2keVgdXITz00pjbWuG3llzsVl/zytJYrtuoY1rTHrTYacev5iV6VZfUcfgxWsk7le79RQF1VOFdO1XeL9l+/C1Tu1nEotvbMyxksKJPqfh2TvquKY3D+cj/ppeP246u+I/S8Os/azy0m1LnzXxyDFbu1r36DBj1GF/87sjix5n8v+ZW8xOChNRpj8AYdqz64nWuL6h+W99RN5NdFdLf1nawrrnvwb7sysB+D/TLwGLNYvVkoMmAMfm1Fmxuu0FVwZuOwqNgTDmUqEjXfeX2VEnzBbOMxNWQI2NKmuCXSmR5iW02otfZule3irrIvFMr0qJjoGiuF7Z01HS6OuGR6JGBTG6pdvcOSprh1JJQoUgyK2vQx1falfefYFhNrbfnaThtXH7OtJte72OXHYFUuFtdD6LMrigl+HNV+q3ztRq6IZpLqfplNt4vLg+uLwTquV5Y2ucYdGqFG6yjmF9dD+Nvzy6bFMdh/HRSDFKsUuzsT6jWRGSJTx6T465chtW5xDHa/q6rCubhf/N2U//3il+kVg/15jvuqh/Djq//dpuWKj349RP5+qIzt16cUx2CVo1VWnz2+zu1j/uP8crrqPPRY/T4Zk1fPRPzdeKMlBm9UGVjSSQt3rrZIxwpXBla515WJi//vXGXBVO/Gw0rQJavGWapqnCVjYy1ZPd5Sus4uS8XGWCrW2JPQU+O2SF0mk5ZHse7ax960xeviNqY6aM8tbMk00A1aQeMGfQqDoUws0ed9Ql3U1RWr3lz0eVVjLX3+FSem1le5JFJrPJO4qgqrrFvlykGq6317dXtBXbDKfvp8KvGjz7oS/HqOnWeO2ai64L5i8FDWBSsGqx7lX4vWupEV1KhtU+uCdSoVq/wyvD83rfZJ5U6dI798WMl1wX4M9uO1ErH+bwQdh1/PRAwuTfwdMUm+W2+91Y499li79tprXbLvJz/5id12221uTr7iufoGdQJTSbPWZWbNi81alpg1LzJrXpK9rcvSTEu3AhrHYKJZ/WSzOl2m5P0/KXNfrvJ4nFlo6DpSvrqsxW58/B3X+yDtpW3x2kzlQzo7ROSUMTW2zaRa+8zus11LruJWTH6GXHStAKEPsT6sb6xQb4FMq18NOeEHTxW4VKmqwpUCtf8B9oOZKudVWawfvJU8VAFQCqOlYJ1/rC8tWGqTxo918SWc6rJQ+1ILtizJXVzsVQxWLFZ87mop3FAwkom3ubg7ufB2XmWyq6woajCxsdRS7J5/L7Vn313nCosd3Ql7c1W7talSMKiWYhGbObbGDpg7ybXo1w9vxWDFTP34VUWoX0DVj/aqsIY4tNwPVz+BropKFQ79IQYVnzV0gQrMfm8AcT0tssMl+i1NKWABG2Y0xuAnX13ortUQIdTdarGOZRZpW5q9LLFQ21ILtS6xYOtSC7atsECyaCgYNYJwMXdKptxbl73W7VqVg/MaUURVUREY8hisH51qBOFa2roKzKCrENbIFfu9Z6Ltt/VE1wJYFQlSHINXtnbmftzrB7p+7KsiVqMUqF5FP779GKzkoBoq6PEaJkj36Yd1S7zbJeEU6/N7awEYvNEYg3PH6pqsry4s96ouwtVJZOshlLxLF01AoWRcQf2DXw6eUlgPoXJwpHrI9r84Bqt+QD1kXT1ENOjqFDRE4q5bjLM9thjvknGqH/CH3ld5V+VWxV71YlXMVDJIcVaVn34MViWxn0zT86gyVY9RPYOfzNdyxeAx1TF3rUa2flIfwOCN6iRfOumSdCr7RtqX5a6j/u32Za4nnj/rr6jbRLJqvCVrJlmyZqIlqnU9yZLVE93tZNUES1YreTfOkq4eYuhGPXlnTbvd9a8l1tSh5E7alYPXtnXnknMqk84eX20f2mGaK5dOqq9y9brqFaxrlXfVkFcNcHWt4SL93rVL1rZnpmkYW+N6x7rGblWRPuuC/UZf+cl96oKBDUeSL+uqq66ySy65xJYvX24777yzXXHFFa6H36BP4A1HW0NiZaYArQpkL6/pg4bGbJxu1jjDrGF65uIK0HkVGKpAHsLE3YbK76qqQrEqJlT5q8Dq9z4gwAKVYbQUrAuO9ZdHWkNieaYyo2N14UqqnGjIxmBd6qdmK5LzKjCGMHG3oVzviuyQWSoIq5JBCbiGqkzc9VtXUdELVIZRGYOv+5g1dK/IlIPzG1EEQpmY6+KvXwae2rtR2xAm7jYlBquyorgHAjEYqCyjMgZfPT8bg5eaJfPmVg/F8uohdJmWKffml4N1KerpXMoYnN87Tr0ShBgMVI7REoP943z3mv+28alVmSRexwoL5A1ZrGHiE3VTLVE73brrplqydmouiZdQAk//V08wC5a2LlgxODd6TmvcqoJBq9PIFNmesYOpC86UlzWXcGZIYo3ykz+/OoDyjr8jYk4+n4bm1GWjqVJ5ylZmWx6QrUye2VOZoXnwypyCdv7439tM7tlndZ0GgLKmXiFTdzab+9GeBhX+dQkrLgZDBeL8ecg0DIIuAFAxglGzOe/Pi7/ZcrCSeCVsxLYxMXh6dOjndwWAYaWRfubM64m9flJPw2mWqAHFxsbgWeNrS7o/ALAhwh2rrXvibGufurcl6qa5S3ftdJfcS0croy44Gu6Zi2x2XgweKBrrq0UJQA1Frznc/WEyAVSm8v7Fvrkdc7vZCG6lAgBl7TM3EYMBoFSO/CUxGABK5RPXEIMBoATe/dANGzYnXwXTwEcN2Sk96mOaJqS8G5EAGDySfAAAAAAAAAAAjCDqsaeeeprCqaEqbIEy7x0OYOOQ5AMAAAAAAAAAYASIhAM2rjZq42qiFg6tf04+AJWNJB8AAAAAAAAAABWsOhq0iXVV1lBNrz1gNCHJBwAAAAAAAABAhSb3JjVUuTn3AIw+JPkAAAAAAAAAAKgg0XDQpjRUWWMNyT1gNCPJBwAAAAAAAABABdBInJPqYzaxPsawnABI8gEAAAAAAAAAUO5qYyGbPrbaYuFQqXcFQJkgyQcAAAAAAAAAQJlSh70pjVU2oS5W6l0BUGZI8gEAAAAAAAAAUKZz780eX2NVEXrvAeiNJB8AAAAAAAAAAGWmoTpsM8bWWCjI3HsA+kaSDwAAAAAAAACAMjKxPuaG6ASAgZDkAwAAAAAAAACgTObfm9pYZeOZfw/AIJDkAwAAAAAAAACgDBJ8M8fWWGNNpNS7AqBCkOQDAAAAAAAAAKDUCb5xNdZYTYIPwOAFN2BdAAAAAAAAAAAwhEjwAdhYJPkAAAAAAAAAACiR6WOqSfAB2Cgk+QAAAAAAAAAAKIHJDTEbWxst9W4AqFAk+QAAAAAAAAAA2MzG1ERsUkNVqXcDQAUjyQcAAAAAAAAAwGZUHQ3ZjLHVpd4NABWOJB8AAAAAAAAAAJtJKBiwWeNqLBAIlHpXAFQ4knwAAAAAAAAAAGwmM8dVWzRM1TyATUckAQAAAAAAAABgM5hQH7X6qkipdwPACEGSDwAAAAAAAACAYVYVCdqUhqpS7waAEYQkHwAAAAAAAAAAw0jT780Yyzx8AIYWST4AAAAAAAAAAIbRhLqYVUdDpd4NACMMST4AAAAAAAAAAIZJNBy0SfWxUu8GgBGIJB8AAAAAAAAAAMNk2pgqCwYZphPA0CPJBwAAAAAAAADAMGioDlt9VaTUuwFghCLJBwAAAAAAAADAEAsEzKY0VpV6NwCMYCT5AAAAAAAAAAAYYuProhYLh0q9GwBGMJJ8AAAAAAAAAAAMoWDQbFI9vfgADC+SfAAAAAAAAAAADKGJ9TELBQOl3g0AIxxJPgAAAAAAAAAAhoiSexNqY6XeDQCjAEk+AAAAAAAAAACGsBdfkF58ADYDknwAAAAAAAAAAAxRL77xtdFS7waAUYIkHwAAAAAAAAAAQ2BCXZRefAA2G5J8AAAAAAAAAABsokDAbBy9+ABsRiT5AAAAAAAAAADYRErwhUNUuQPYfIg4AAAAAAAAAABsovF19OIDsHmR5AMAAAAAAAAAYBM0VIctFg6VejcAjDIk+QAAAAAAAAAA2ATMxQegFEjyAQAAAAAAAACwkaLhoNVXRUq9GwBGIZJ8AAAAAAAAAABsJHrxASgVknwAAAAAAAAAAGyEQMBsbA29+ACUBkk+AAAAAAAAAAA2QkNVxMIhqtkBlMawRJ933nnHjj/+eJszZ45VV1fbVlttZeedd551d3cXrPfvf//b3v/+91tVVZXNnDnTLr744l7buv32223u3LlunR133NHuvffegvs9z7Nzzz3Xpk6d6p7rkEMOsTfeeGM4DgsAAAAAAAAAgJwxtfTiAzDCknyvvvqqpdNpu/baa+3ll1+2yy67zK655ho7++yzc+u0tLTYoYcearNnz7Znn33WLrnkEjv//PPtuuuuy63z+OOP21FHHeUShs8//7wdfvjh7vLSSy/l1lFi8IorrnDbf+qpp6y2ttbmz59v8Xh8OA4NAAAAAAAAAAALhwJWHwuXejcAjGIBT13hNgMl8a6++mp7++233W39/+1vf9uWL19u0WhmYtIzzzzT7rjjDpcklE9/+tPW3t5ud999d247e+21l+28884uqaddnzZtmn3jG9+w//f//p+7v7m52SZPnmw33HCDfeYznxnUvinh2NjY6B7b0NAwDEcPABtmNMWl0XSsACrDaIpLo+lYAVSG0RSXRtOxAqgMoyUu+cf5+CsLra5+045zQn3UpjZWD9m+ARidWjYh/m62wYK1c+PGjcvdfuKJJ2z//ffPJfhEPfBee+01W7duXW4dDb+ZT+touSxYsMAlCfPX0YnYc889c+v0paury520/AsAYPMgBgNA6RCDAaB0iMEAMPLi79ianrptACiFzZLke/PNN+3KK6+0L3/5y7llSs6px10+/7buG2id/PvzH9fXOn256KKLXDLQv2g+QADA5kEMBoDSIQYDQOkQgwFgZMXfqkjQqiKhIdkWAGyWJJ+G0wwEAgNe/KE2fUuWLLEPfehDduSRR9oJJ5xg5eCss85yPQv9y6JFi0q9SwAwahCDAaB0iMEAUDrEYAAYWfG3sToyJNsBgE2xQbOCau67L3zhCwOus+WWW+b+X7p0qR100EG2zz772HXXXVew3pQpU2zFihUFy/zbum+gdfLv95dNnTq1YB3N29efWCzmLgCAzY8YDAClQwwGgNIhBgPAyIq/jTUk+QBUWJJv4sSJ7jIY6sGnBN+8efPs+uuvt2CwsNPg3nvvbd/+9rctkUhYJJIJiPfff7+9973vtbFjx+bWefDBB+3000/PPU7raLnMmTPHJfq0jp/U05jKTz31lJ100kkbcmgAAAAAAAAAAKxXdTRosTBDdQIYoXPyKcF34IEH2qxZs+xHP/qRrVq1ys2Rlz9P3tFHH23RaNSOP/54e/nll+3WW2+1yy+/3L7+9a/n1jnttNPsL3/5i1166aVuGNDzzz/fnnnmGTvllFPc/RoeVAnA733ve/anP/3JXnzxRfv85z9v06ZNs8MPP3w4Dg0AAAAAAAAAMIo1VNGLD0AF9uQbLPW2e/PNN91lxowZBfd5nueuNcnpX//6Vzv55JNdb78JEybYueeeayeeeGJuXQ3zefPNN9s555xjZ599tm2zzTZ2xx132A477JBb54wzzrD29nb3uKamJttvv/1cYrCqqmo4Dg0AAAAAAAAAMIo1MB8fgDIR8Pys2yimIT6VdNTEqw0NDaXeHQAYVXFpNB0rgMowmuLSaDpWAJVhNMWl0XSsACrDaIlL/nE+/spCq6vf8OOMRYL2nsn1w7JvAEanlk2Iv8MyXCcAAAAAAAAAACMNQ3UCKCck+QAAAAAAAAAAGISG6mGZAQsANgpJPgAAAAAAAAAA1iMUDFhNlCQfgPJBkg8AAAAAAAAAgPWoryLBB6C8kOQDAAAAAAAAAGA9mI8PQLkhyQcAAAAAAAAAwAACAbM6evIBKDMk+QAAAAAAAAAAGEB1NOTm5AOAckKSDwAAAAAAAACAATAfH4ByRJIPAAAAAAAAAIAB1MeYjw9A+SHJBwAAAAAAAABAPzRMp4brBIByQ5IPAAAAAAAAAIB+1MUYqhNAeSLJBwAAAAAAAABAP+qYjw9AmSLJBwAAAAAAAABAP2pjDNUJoDyR5AMAAAAAAAAAoA+RcMBiYZJ8AMoTST4AAAAAAAAAAPpQG2WoTgDliyQfAAAAAAAAAAB9qIuR5ANQvkjyAQAAAAAAAADQhxrm4wNQxkjyAQAAAAAAAABQJBxiPj4A5Y0kHwAAAAAAAAAARRiqE0C5I8kHAAAAAAAAAECRmii9+ACUN5J8AAAAAAAAAAAUqaUnH4AyR5IPAAAAAAAAAIA8waBZVYSefADKG0k+AAAAAAAAAADy1ETpxQeg/JHkAwAAAAAAAAAgD/PxAagEJPkAAAAAAAAAAMhDkg9AJSDJBwAAAAAAAABAHobrBFAJSPIBAAAAAAAAAJAViwQtFAyUejcAYL1I8gEAAAAAAAAAkFUdYahOAJWBJB8AAAAAAAAAAFnMxwegUpDkAwAAAAAAAAAgi/n4AFQKknwAAAAAAAAAAJhZIGBWFaHaHEBlIFoBAAAAAAAAAGBK8IUsoEwfAFQAknwAAAAAAAAAAJhZNfPxAaggJPkAAAAAAAAAAFCSL0KSD0DlIMkHAAAAAAAAAICZ1dCTD0AFIckHAAAAAAAAABj1NBVfLEyVOYDKQcQCAAAAAAAAAIx6VZGgBZTpA4AKQZIPAAAAAAAAADDqVTEfH4AKQ5IPAAAAAAAAADDqVZPkA1BhSPIBAAAAAAAAAEa96ihJPgCVhSQfAAAAAAAAAGDUqwqT5ANQWUjyAQAAAAAAAABGtWg4aMFgoNS7AQAbhCQfAAAAAAAAAGBUYz4+AJWIJB8AAAAAAAAAYFSrilBVDqDyELkAAAAAAAAAAKNajJ58ACoQST4AAAAAAAAAwKhGTz4AlWjYI1dXV5ftvPPOFggE7IUXXii479///re9//3vt6qqKps5c6ZdfPHFvR5/++2329y5c906O+64o917770F93ueZ+eee65NnTrVqqur7ZBDDrE33nhjuA8LAAAAAAAAADACBAJmsTA9+QBUnmFP8p1xxhk2bdq0XstbWlrs0EMPtdmzZ9uzzz5rl1xyiZ1//vl23XXX5dZ5/PHH7aijjrLjjz/enn/+eTv88MPd5aWXXsqto8TgFVdcYddcc4099dRTVltba/Pnz7d4PD7chwYAAAAAAAAAqHBVDNUJoEKFh3Pjf/7zn+2vf/2r/f73v3f/57vpppusu7vbfvWrX1k0GrXtt9/e9fT78Y9/bCeeeKJb5/LLL7cPfehD9s1vftPdvvDCC+3++++3q666yiX11IvvJz/5iZ1zzjn28Y9/3K3z61//2iZPnmx33HGHfeYzn+m3d6Eu+QlHAMDmQQwGgNIhBgNA6RCDAaB84y9DdQKoVMMWvVasWGEnnHCC/eY3v7Gamppe9z/xxBO2//77uwSfTz3wXnvtNVu3bl1uHQ2/mU/raLksWLDAli9fXrBOY2Oj7bnnnrl1+nLRRRe59fyLhgoFAGwexGAAKB1iMACUDjEYAMo3/jJUJ4BKNSxJPvWw+8IXvmBf+cpXbLfddutzHSXn1OMun39b9w20Tv79+Y/ra52+nHXWWdbc3Jy7LFq0aKOOEwCw4YjBAFA6xGAAKB1iMACUb/ylJx+AUTFc55lnnmk//OEPB1znP//5jxuis7W11QXQchSLxdwFALD5EYMBoHSIwQBQOsRgACjf+MucfABGRZLvG9/4huuhN5Att9zSHnroITdcZnHwVK++Y445xm688UabMmWKG9Izn39b9/nXfa2Tf7+/bOrUqQXr7LzzzhtyaAAAAAAAAACAUSYYNIuE6MkHYBQk+SZOnOgu63PFFVfY9773vdztpUuXurn0br31Vjdfnuy999727W9/2xKJhEUiEbfs/vvvt/e+9702duzY3DoPPvignX766bltaR0tlzlz5rhEn9bxk3qaOPWpp56yk046aUMODQAAAAAAAAAwyjAfH4BRk+QbrFmzZhXcrqurc9dbbbWVzZgxw/1/9NFH23e/+107/vjj7Vvf+pa99NJLdvnll9tll12We9xpp51mBxxwgF166aV22GGH2S233GLPPPOMXXfdde7+QCDgEoBKKG6zzTYu6fed73zHpk2bZocffvhwHBoAAAAAAAAAYIRgPj4AlWxYknyD0djY6ObuO/nkk23evHk2YcIEO/fcc+3EE0/MrbPPPvvYzTffbOecc46dffbZLpF3xx132A477JBb54wzzrD29nb3uKamJttvv/3sL3/5i1VVVZXoyAAAAAAAAAAAlYCefAAq2WZJ8m2xxRbmeV6v5TvttJP97W9/G/CxRx55pLv0R735LrjgAncBAAAAAAAAAGCwYvTkA1DBiGAAAAAAAAAAgFEpFqaKHEDlIoIBAAAAAAAAAEadQIDhOgFUNpJ8AAAAAAAAAIBRh158ACodUQwAAAAAAAAAMOrQiw9ApSPJBwAAAAAAAAAYdWIRqscBVDaiGAAAAAAAAABg1GG4TgCVjigGAAAAAAAAABh1oiT5AFQ4ohgAAAAAAAAAYNRhTj4AlY4kHwAAAAAAAABgVAmHAhYKBkq9GwCwSUjyAQAAAAAAAABGlQhDdQIYAYhkAAAAAAAAAIBRJRaiahxA5SOSAQAAAAAAAABGlSg9+QCMAEQyAAAAAAAAAMCoEg2FSr0LALDJSPIBAAAAAAAAAEaVWISqcQCVj0gGAAAAAAAAABhVoszJB2AEIJIBAAAAAAAAAEaVYDBQ6l0AgE1Gkg8AAAAAAAAAAACoMCT5AAAAAAAAAAAAgApDkg8AAAAAAAAAAACoMCT5AAAAAAAAAAAAgApDkg8AAAAAAAAAAACoMCT5AAAAAAAAAAAAgApDkg8AAAAAAAAAAACoMCT5AAAAAAAAAAAAgApDkg8AAAAAAAAAAACoMCT5AAAAAAAAAAAAgApDkg8AAAAAAAAAAACoMCT5AAAAAAAAAAAAgApDkg8AAAAAAAAAAACoMCT5AAAAAAAAAAAAgApDkg8AAAAAAAAAAACoMCT5AAAAAAAAAAAAgAoTLvUOlAPP89x1S0tLqXcFAArikR+fRjJiMIByQwwGgNIhBgNA6YyWGEz8BTCS4i9JPjNbs2aNu545c2apdwUAesWnxsZGG8mIwQDKFTEYAEqHGAwApTPSYzDxF8BIir8k+cxs3Lhx7nrhwoUV+wWmTK++mBYtWmQNDQ1WiTiG8sAxlIfm5mabNWtWLj6NZMTg8sAxlAeOoTwQgyvLSHjPcQzlgWMoD8TgyjIS3nMcQ3ngGMrDaInBxN/ywDGUB46h8uMvST5NTBjMTE2ooF6pbwKf9p9jKD2OoTyMhGPw49NIRgwuLxxDeeAYygMxuLKMhPccx1AeOIbyQAyuLCPhPccxlAeOoTyM9BhM/C0vHEN54BgqN/6O7IgNAAAAAAAAAAAAjEAk+QAAAAAAAAAAAIAKQ5LPzGKxmJ133nnuulJxDOWBYygPHENlGQnHyjGUB46hPHAMlWUkHCvHUB44hvLAMVSWkXCsHEN54BjKA8dQOUbCcXIM5YFjKA+xUX4MAc/zvGHZKwAAAAAAAAAAAADDgp58AAAAAAAAAAAAQIUhyQcAAAAAAAAAAABUGJJ8AAAAAAAAAAAAQIUhyQcAAAAAAAAAAABUGJJ8AAAAAAAAAAAAQIUhydePe+65x/bcc0+rrq62sWPH2uGHH26VqKury3beeWcLBAL2wgsvWKV455137Pjjj7c5c+a412Crrbay8847z7q7u62c/fSnP7UtttjCqqqq3Pvnn//8p1WKiy66yHbffXerr6+3SZMmuff8a6+9ZpXsBz/4gXvvn3766VZJlixZYp/97Gdt/Pjx7v2/44472jPPPGOjBfG3tCo1/goxuHxUavwVYjAxuJQqNQYTf8tLpcbg0R5/hRhcWsTgzY8YXD6IwcTgUiMGb37E4JETg0ny9eH3v/+9fe5zn7MvfvGL9q9//cv+8Y9/2NFHH22V6IwzzrBp06ZZpXn11VctnU7btddeay+//LJddtllds0119jZZ59t5erWW2+1r3/96+4L6LnnnrP3ve99Nn/+fFu5cqVVgkcffdROPvlke/LJJ+3++++3RCJhhx56qLW3t1slevrpp937Z6eddrJKsm7dOtt3330tEonYn//8Z3vllVfs0ksvdQXM0YD4W3qVGH+FGFw+KjX+CjGYGFxqlRiDib/lpVJj8GiPv0IMLj1i8OZHDC4PxGBicDkgBm9+xOARFIM9FEgkEt706dO9X/ziF16lu/fee725c+d6L7/8sqeX+vnnn/cq2cUXX+zNmTPHK1d77LGHd/LJJ+dup1Ipb9q0ad5FF13kVaKVK1e6982jjz7qVZrW1lZvm2228e6//37vgAMO8E477TSvUnzrW9/y9ttvP280Iv6Wr3KPv0IMLg+VHH+FGEwMLkflHoOJv+WjkmPwaI6/QgwuX8TgzYsYXBrEYGJwuSIGb17E4MqNwfTkK6Ksu7pHBoNB22WXXWzq1Kn24Q9/2F566SWrJCtWrLATTjjBfvOb31hNTY2NBM3NzTZu3DgrR+o6/uyzz9ohhxySW6b3kG4/8cQTVqnnW8r1nA9ErVAOO+ywgtejUvzpT3+y3XbbzY488kjXVV5x6Oc//7mNBsTf8lXO8VeIweWjkuOvEIOJweWonGMw8be8VHIMHs3xV4jB5YsYvHkRg0uDGEwMLlfE4M2LGFy5MZgkX5G3337bXZ9//vl2zjnn2N133+26Rh544IG2du1aqwSe59kXvvAF+8pXvuLeICPBm2++aVdeeaV9+ctftnK0evVqS6VSNnny5ILlur18+XKrNOoer7GL1VV4hx12sEpyyy23uAKaxpWu1Bh09dVX2zbbbGP33XefnXTSSfY///M/duONN9pIR/wtT+Uef4UYXB4qPf4KMZgYXG7KPQYTf8tHpcfg0Rx/hRhcnojBmxcxuHSIwcTgckQM3ryIwZUdg0dNku/MM890ky4OdPHH/pVvf/vbdsQRR9i8efPs+uuvd/fffvvtFXEMCoCtra121llnWbkZ7DHkU2uaD33oQy6brRYp2DytH9RiSUGykixatMhOO+00u+mmm9yEt5VIMWjXXXe173//+67lxoknnuje9xqHvFIRf8sD8bdyVGIMHgnxV4jBxODhQgyuDJUYf0dKDB6J8VeIweWBGFwZiMGlQwwmBg8nYnBlIAZXdgwO2yjxjW98w7VoGMiWW25py5Ytc/9vt912ueWxWMzdt3DhQquEY3jooYdct2Dtdz615DjmmGNK2hJnsMfgW7p0qR100EG2zz772HXXXWflasKECRYKhVzX+Hy6PWXKFKskp5xyimu19Nhjj9mMGTOskqibvCa3VWD0qVWNjuWqq66yrq4u9zqVMw0LkR9/ZNttt3WTQFcq4i/xd7gRg0tvJMRfIQYTg4fLSI3BxN/yMBJi8EiMv0IMJgYPJ2JweSAGly9iMDF4OBGDywMxeJQl+SZOnOgu66PWGgqIr732mu23335uWSKRsHfeecdmz55tlXAMV1xxhX3ve98rCI7z58+3W2+91fbcc0+rhGPwW20oqPstaDSucbmKRqNuPx988EE7/PDDc1l43VagrJSu/aeeeqr98Y9/tEceecTmzJljlebggw+2F198sWDZF7/4RZs7d65961vfKvugLuoWr/iT7/XXXy95/NkUxF/i73AjBpfeSIi/QgwmBg+XkRqDib/lYSTE4JEYf4UYTAweTsTg8kAMLl/EYGLwcCIGlwdicJaHXk477TRv+vTp3n333ee9+uqr3vHHH+9NmjTJW7t2rVeJFixY4Omlfv75571KsXjxYm/rrbf2Dj74YPf/smXLcpdydcstt3ixWMy74YYbvFdeecU78cQTvTFjxnjLly/3KsFJJ53kNTY2eo888kjB+e7o6PAq2QEHHOA+05Xin//8pxcOh73//d//9d544w3vpptu8mpqarzf/va33mhA/C29Soy/QgwuP5UWf4UYTAwutUqMwcTf8lRpMXi0x18hBpceMXjzIwaXB2IwMbgcEIM3P2LwyInBJPn60N3d7X3jG99wwby+vt475JBDvJdeesmrVJUY2K+//nq3z31dytmVV17pzZo1y4tGo94ee+zhPfnkk16l6O9867WoZJUW2OWuu+7ydthhB1dQmDt3rnfdddd5owXxt/QqNf4KMbi8VGL8FWIwMbiUKjUGE3/LTyXG4NEcf4UYXHrE4M2PGFw+iMHE4FIjBm9+xOCRE4MD+uP36gMAAAAAAAAAAABQ/sp3YFsAAAAAAAAAAAAAfSLJBwAAAAAAAAAAAFQYknwAAAAAAAAAAABAhSHJBwAAAAAAAAAAAFQYknwAAAAAAAAAAABAhSHJBwAAAAAAAAAAAFQYknwAAAAAAAAAAABAhSHJBwAAAAAAAAAAAFQYknwAAAAAAAAAAABAhSHJBwAAAAAAAAAAAFQYknwAAAAAAAAAAACAVZb/Dwy46rDzZRPqAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 2200x400 with 5 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from matplotlib.axes import Axes\n",
+    "\n",
+    "\n",
+    "def plot_method(\n",
+    "    ax: Axes,\n",
+    "    name: str,\n",
+    "    x: torch.Tensor,\n",
+    "    mean: torch.Tensor,\n",
+    "    std: torch.Tensor,\n",
+    "    color: str | None = None,\n",
+    ") -> None:\n",
+    "    \"\"\"Plot predictive mean and a +/- 2 std band.\"\"\"\n",
+    "    x_np = x.detach().cpu().numpy().flatten()\n",
+    "    mean_np = mean.detach().cpu().numpy().flatten()\n",
+    "    std_np = std.detach().cpu().numpy().flatten()\n",
+    "\n",
+    "    ax.plot(x_np, mean_np, label=name, color=color)\n",
+    "    ax.fill_between(\n",
+    "        x_np,\n",
+    "        mean_np - 2 * std_np,\n",
+    "        mean_np + 2 * std_np,\n",
+    "        alpha=0.2,\n",
+    "        color=color,\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "fig, axes = plt.subplots(1, 5, figsize=(22, 4), sharey=True)\n",
+    "\n",
+    "# dropout\n",
+    "plot_method(axes[0], \"dropout\", test_x1, mean_do, total_std_do)\n",
+    "axes[0].scatter(train_x1.cpu().numpy(), train_y.cpu().numpy(), s=8, alpha=0.35)\n",
+    "axes[0].plot(test_x1.cpu().numpy(), test_y_true.cpu().numpy(), linewidth=1)\n",
+    "axes[0].set_title(\"dropout\")\n",
+    "\n",
+    "# dropconnect\n",
+    "plot_method(axes[1], \"dropconnect\", test_x1, mean_dc, total_std_dc)\n",
+    "axes[1].scatter(train_x1.cpu().numpy(), train_y.cpu().numpy(), s=8, alpha=0.35)\n",
+    "axes[1].plot(test_x1.cpu().numpy(), test_y_true.cpu().numpy(), linewidth=1)\n",
+    "axes[1].set_title(\"dropconnect\")\n",
+    "\n",
+    "# ensemble\n",
+    "plot_method(axes[2], \"ensemble\", test_x1, mean_ens, total_std_ens)\n",
+    "axes[2].scatter(train_x1.cpu().numpy(), train_y.cpu().numpy(), s=8, alpha=0.35)\n",
+    "axes[2].plot(test_x1.cpu().numpy(), test_y_true.cpu().numpy(), linewidth=1)\n",
+    "axes[2].set_title(\"ensemble\")\n",
+    "\n",
+    "# bayesian\n",
+    "plot_method(axes[3], \"bayesian\", test_x1, mean_b, total_std_b)\n",
+    "axes[3].scatter(train_x1.cpu().numpy(), train_y.cpu().numpy(), s=8, alpha=0.35)\n",
+    "axes[3].plot(test_x1.cpu().numpy(), test_y_true.cpu().numpy(), linewidth=1)\n",
+    "axes[3].set_title(\"bayesian\")\n",
+    "\n",
+    "# evidential\n",
+    "plot_method(axes[4], \"evidential\", test_x1, mean_evi, total_std_evi)\n",
+    "axes[4].scatter(train_x1.cpu().numpy(), train_y.cpu().numpy(), s=8, alpha=0.35)\n",
+    "axes[4].plot(test_x1.cpu().numpy(), test_y_true.cpu().numpy(), linewidth=1)\n",
+    "axes[4].set_title(\"evidential\")\n",
+    "\n",
+    "for ax in axes:\n",
+    "    ax.set_xlim(-6, 6)\n",
+    "\n",
+    "plt.suptitle(\"Predictive mean ± 2 std (total uncertainty)\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "854eb2a1",
+   "metadata": {},
+   "source": [
+    "## Reading the plots (mean ± 2 std)\n",
+    "\n",
+    "- The line is the predictive mean.\n",
+    "- The shaded band is ± 2 standard deviations (a rough uncertainty interval).\n",
+    "- On extrapolation regions (outside [-4,4]), good uncertainty methods often widen the band.\n",
+    "- Inside [-4,4], methods should fit the data and not inflate uncertainty too much.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "4ebf70f9",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAl8AAAF2CAYAAABQ9P1+AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvc2/+5QAAAAlwSFlzAAAPYQAAD2EBqD+naQAAU0VJREFUeJzt3Qd4U2XbB/A7SXcppay2QBlFoGyw7K3wMVUUFJXNi+AARVFB1BcQfUXBgQNBUEEFZQioDNlL2aDsDWXTltHBKB3J+a77LicmXXQkORn/33WFk5ycJHdOU/Lv8zznOTpFURQCAAAAAIfQO+ZlAAAAAIAhfAEAAAA4EMIXAAAAgAMhfAEAAAA4EMIXAAAAgAMhfAEAAAA4EMIXAAAAgAMhfAEAAAA4EMIXAAAAgAMhfIFHO3PmDOl0Opo9e/Y9tx04cCBVrlyZtNKuXTu5FAa/x/Hjx9u8JneyceNG2U+8dHZafxZdHe873of2/r0DyA3CF7gUDkn8BZnbZfv27eTKDh8+LCGJQyEUzPvvv0+//vqrJq996dIl+bnt3btXk9eHosHvHTial8NfEcAGJkyYQFWqVMm2/r777ivQ81SqVIlSUlLI29ubnOVL4J133pG/tLO2bKxevVqzulwlfD3++OP06KOPFurxbdq0kc+Cj49PocIX/9z4Z9agQYNCvT44zrFjx0iv/7ftAb934GgIX+CSunTpQo0aNSry83BrmZ+fH7mCwoQCd6coCt25c4f8/f2L/Fz8ZewqnwUoGl9f33xvi987sAd0O4LbSU9Pp5IlS9KgQYOy3ZecnCxfsK+99lqeY764+6pOnTqyLS+XLFmS42uZTCaaMmUK1a5dW7YNDQ2lZ599lhISEqy247+mH3roIfrrr7+oSZMmsm1kZCT98MMP5m24hieeeEKuP/DAA+auVHUMUtaxJ2lpaTR27FiKjo6m4OBgCgwMpNatW9OGDRuK1KWbteslp7FQXAfvF24x4FoDAgKofPnyNGnSpGzPy+GIu3SqV68u7zs8PJx69OhBp06dKvR+XLVqlYRvDl1ff/211Hfr1i36/vvvzftNHdNz9uxZeuGFF6hGjRqyfalSpWQ/2+p98vaNGzeW6/yZU1+f9+e4ceOkVfXKlSvZ9svQoUOpRIkSsn/yYuvPIvvjjz+obdu2FBQURMWLF5f6f/rpJ6ttFi5cKJ8t3melS5emvn370sWLF6224X1crFgxOnfunPxc+Drvn6lTp8r9Bw4coAcffFA+m9zKnPU11M/c5s2bpVb+2XA9/fv3z7Hur776St4fh6dy5crRsGHDKDEx0WqbEydOUM+ePSksLEz2Q4UKFeipp56ipKSkHMd8FfT3jsXHx9PgwYNlH/Nr1K9fXz57ltT/Wz766COaMWMGVa1aVermfb1r164cf4bgORC+wCXxf6RXr161uly7dk3u4y+7xx57TL60OKBY4nWpqanyn3FuuJuB//Pm/zgnTpwo3Vj8pbp79+5s2/IXxuuvv04tW7akzz77TLabO3cuderUSUKgpZMnT0q32P/93//Rxx9/TCEhIfIFcOjQIXO310svvSTX33zzTfrxxx/lUrNmzRzr5CD5zTffyBfDhx9+KAGHv+T5tR0x9oi/HDt37ixfPPx+oqKiaPTo0fLFrjIajfKlzF06/EXO240YMUJ+fgcPHizUfuQuo6efflr2I2/L3Xy8n/iLjcOnut/4ORl/0W3dulV+5p9//jk999xztG7dOtlvt2/fLvL75J8Pd4OrgUp9ff559uvXjzIyMmj+/PlWz8mfy19++UU+Z3m1ttnjs8hho1u3bnT9+nUaM2YMffDBB7IPV65cabVNr169yGAwyOsOGTKEFi9eTK1atcoWdvhnzC3REREREko52AwfPlyeg/cbh2T+fHLQ41AVExOTrXbe/siRI/IZ5m24bn6v3LKp4vs4bHHo4p8D7xcO3h07djS/P96v/H557OeLL74oIZB/JqdPn85Wt6qgv3fcNc2fHd6mT58+NHnyZPnjh3+Xeb9nxYGTt+Gfz3vvvSehjP/4yPq5Bg+jALiQWbNm8f/GOV58fX3N261atUrWLV261OrxXbt2VSIjI823Y2JiZDt+XlWDBg2U8PBwJTEx0bxu9erVsl2lSpXM6/78809ZN3fuXKvXWLlyZbb1/Dhet3nzZvO6+Ph4qfnVV181r1u4cKFst2HDhmzvvW3btnJRZWRkKKmpqVbbJCQkKKGhocp//vMfq/X8nOPGjVPys295n1jiWrLWxHXwuh9++MG8jmsJCwtTevbsaV733XffyXaffPJJttczmUyF3o98X1aBgYHKgAEDsq2/fft2tnXbtm3LVn9R3ueuXbuyfY5UzZs3V5o2bWq1bvHixbn+nC3Z+rPIzxMUFCT1pKSk5PjzSEtLU8qWLavUqVPHaptly5bJc40dO9a8jvc3r3v//fetPoP+/v6KTqdT5s2bZ15/9OjRbJ9D9TMXHR0tr6uaNGmSrP/tt9/Mvys+Pj5Kx44dFaPRaN7uyy+/lO34c8b++ecfuc2/R3nhfWf5WSnI792UKVNk2zlz5pjXce38cy5WrJiSnJxs9X9LqVKllOvXr5u35feU0/9N4FnQ8gUuif+iXbNmjdXFssWFuzq4q8SyxYFbMHi7J598MtfnvXz5srQaDRgwQP6aVXErS61atbJ1y/A2fJ9lCxy38HD3S9buP348t8yoypQpI11h/Fd5YXCrhDoehbucuCWDW1m4peHvv/8me+P3yF1RKq6Fu1Qt38+iRYvk58CtEFlxa05h9iMfaMGtG/llOR6MWxu4hZQPzOAuv/zsp/y8z7xwS86OHTusulm5ZYdbirjrz5GfRf7837hxg954441sLW7qz4Nb1bhbjbtqLbfh1jJu9Vu+fHm2Wp955hnzdd6v/LnmrkZuPVPxOr4vp/3GrVOWB708//zz5OXlRStWrJDba9eulVatl19+2WqgPLfIcTelWpO6n7hbOj+tmoXBNXGXJre+qrh2bj27efMmbdq0yWp7/v+GW7lV6v8Bhf29B/eA8AUuib/8OnToYHXh8Roq/o+buyV+++036WZk3G3CX755hS8eH8SqVauW7T7+8sg6toS7z8qWLStByvLC/wnzF5ilihUrZntO/k85p7Et+cXjTOrVqydfkjxehl+bv4gsx7fYC4+lUb+wc3s/HDh4v/HPIzcF3Y85HeWaF+4m4rFxHHa4a5LDID83d0PlZz/l533mhT9v/LocuBi/5rJly6TLKuvz2vuzqAZAHjt2r9fN+hqMw5d6v4o/e/w6ljgE5bTfeH1O+y3re+TAyGMD1XF5udXEQZjHTqr382dj5MiR0h3PP2cO6fyHmi1/H/i1uF7LEMjUbsqs+yfr770axIryew+uD0c7gtviMT48JoRbxHj8yIIFC+TLg8fu2AK3NvGXnfqlmlXWLyRuqcqJ5biWgpgzZ46MM+H3xmN9uBZ1jI5lK0t+5RYEeExPTmz1fgq6Hwt6ZCO3us2aNUtaTZo3by4BgN8rfz74te+lqO+Tv2x53Bu/Pw6BPNaL/yCwbE0rqoLuQ1vKbf/Y+vOeXzwejH8v+A8vHjPHLVL8O8HjwDgQOppW+wGcG8IXuC0eSMt/PXPXIw8UXr9+Pb311lt5PoaPyFJbErLigd6W+Ogl7g7hAc62mOqA5dUSkhV/ifNf/dyiZ/k4PsKuMNS/yLMOTM76l3xB8D7iLjduccxtLjVb7cfc9h3vJ+664y9lFR9hmNsAbFu+tmXXY/fu3WXwPwekhg0bylF7jv4s8naMD3bIbU489XX5Nbj7PuvrqvfbEr9Hy5Zrbq3jbteuXbtmq4k/8yruiuQB/Nzybalu3bpyefvtt+VgC94v06dPlwHvRf2941r2798vgdey9evo0aNWtQLkBd2O4Lb4P0Y+unDp0qVyZBKPh8qry5FxWOMjv7g7z7KrgsfK8HQDlng8C7cKvfvuu9meh1+rMF/uPE6G5eex6l/Uln9Bc9DZtm0bFYb6xcyH/av4/fFh8oXFXb889ujLL7/Mdp9at632I++7nLbl/ZS1leGLL77ItUWvMO71c+OjAbkbjI/64zFB+Wn1ssdnkY8M5KMOuSUo6xQX6j7iMYPcisZhRe2yZ9yCzEck8tgvW+PPmOXRf9OmTZO6eb8xDlfcxchHq1r+LL/99lvZN2pNfAQwP84ShzD+v8DyvRTl944DYWxsrNV4Un5N/kxxd2le4/gAVGj5ApfEXwTqX5qWWrRoYfWXMYct/k+RW4P4P+HcDh+3xF9M/J85t5b95z//kYHs/BzcUsF/kav4P1k+fJy354HR/MXGrTv8VzwPgObDzjn8FQR/2XJY4C9p/lLhsULc+sBfhllxVxa3evG0GlwvtwDwFyYPxrasM7/4/TVr1kymH+D3zHOlzZs3L9uXWUFwiw/PZcbjcHbu3CmDjXk+Lm6l4QHd3Bpkq/3Ig8v5eT/55BOZjoDH/zRt2lT2E4dv7m7kfcPhlLfjMXK2wsGVB5Pz/udww1/m/Nrq+DR+P9zNySGUf76Wg7Ud+VnkwemffvqpDJDn+aZ69+4tLZ779u2TAeoc9Phx/PnjqSr4ebnWuLg4eQ6eRuKVV14hW+MWrPbt20uI5NYtns+L3/Mjjzxi7jblzyVPWcLTV/B6dTt+H2qY5dZtnraC5+3ieeX4s8s/e97n/IeALX7v+OAAHs7AXZt79uyRfcKtq1u2bJF51vjnD3BPWh9uCWCrqSZyOtSfD5+PiIiQ+957771sz5fTVBNs0aJFSs2aNWUqiFq1asnUAHxouuXh/aoZM2bIofJ8eD0fxl+3bl1l1KhRyqVLl8zb8OO6det2z8PY2cyZM2U6DIPBYHX4e9Zt+b3xIf783Fxnw4YNZTqAnOrMz1QT7NSpU0qHDh3k+XjKijfffFNZs2ZNjlMw1K5dO9vjc3ptnurhrbfeUqpUqaJ4e3vLNA2PP/64vJat9qM6lUGbNm3k8VyvOpUAT30waNAgpXTp0jIVQKdOnWTbrNMN5DbVRH7fJ08hwJ8VLy+vHD9TO3fulPU8XUJB2PqzyH7//XelRYsWsl3x4sWVJk2aKD///LPVNvPnz5fPFL9uyZIllT59+igXLlzIth94io+scttvWX9+6u/zpk2blKFDhyohISHyM+LXunbtWrbH89QSUVFR8jniz+fzzz8vP1/V6dOnZZqVqlWrKn5+flL3Aw88oKxduzZbHVmnJcnv7x2Li4szf6Z4Cgzez1l/3ur/LZMnT872PvL7+wjuS8f/3DuiAQBAUXDrErewcEsgT74KmZO5cgsbj4WzxenCAFwFxnwBADjAzJkzZUwQz24OAJ4NY74AAOyID/jgAfI8qJzHI6mDuwHAcyF8AQDYEc8zxgPW+Sg5HjAOAIAxXwAAAAAOhDFfAAAAAA6E8AUAAADgQG475otP/XDp0iWZ8K4gp44AAAAAKCgexXXjxg2Z5Dnridc9Jnxx8IqIiNC6DAAAAPAg58+fv+dJ3N02fKmneOCdwKfUAAAAALAXPrcoN/rk5xRTbhu+1K5GDl4IXwAAAOAI+RnqhAH3AAAAAA6E8AUAAADgQAhfAAAAAA5UoDFfEydOpMWLF9PRo0fJ39+fWrRoQR9++CHVqFHDvE27du1o06ZNVo979tlnafr06ebb586do+eff542bNggJ5odMGCAPLeX17/lbNy4kUaOHEmHDh2SAWxvv/02DRw4sGjvFgAAwILRaKT09HStywAX4ePjc89pJGwevjhUDRs2jBo3bkwZGRn05ptvUseOHeWksZYnix0yZAhNmDDBfDsgIMDqg96tWzcKCwujrVu30uXLl6l///7k7e1N77//vmwTExMj2zz33HM0d+5cWrduHT3zzDMUHh5OnTp1KvKbBgAAz8ZzMsXGxlJiYqLWpYAL4eBVpUoVCWGandvxypUrVLZsWQllbdq0Mbd8NWjQgKZMmZLjY/744w966KGHZB6u0NBQWcetYqNHj5bn4zfE15cvX04HDx40P+6pp56SX5KVK1fm+5DP4OBgSkpKwtGOAABghf/w5+8U/g7jBgJMxg35nbydG4sqVqyY7TNTkNxRpKkm+AVYyZIlrdZza9WcOXOkdevhhx+m//73v+bWr23btlHdunXNwYtxaxZ3Q3IXY8OGDWWbDh06WD0nb/Pyyy8XpVwAAADpgVGDV6lSpbQuB1xImTJlJIBx7x+HsMLyKkoC5DDUsmVLqlOnjnl97969qVKlSjK9/v79+6UV69ixYzJWjHEzr2XwYuptvi+vbThVpqSkyHizrFJTU+Wi4m0BAACyUsd4WQ6JAcgPtbuRA7wm4YvHfnG34F9//WW1fujQoebr3MLF47Tat29Pp06doqpVq5K98ID9d955x27PDwAA7gVdjaDVZ6ZQQ/aHDx9Oy5Ytk6MV73X+oqZNm8ry5MmTsuSuyLi4OKtt1Nt8X17bcB9qTq1ebMyYMdINql74tEIAAAAAzqZA4YvH5nPwWrJkCa1fv15G/N/L3r17ZcktYKx58+Z04MABio+PN2+zZs0aCVa1atUyb8NHOFribXh9bnx9fc2nEnLEKYV+Xjmc+s6+nxasxjg0AABwDmfOnJHWGfW71xnNnj2bSpQooXUZVLly5VwPDnSq8MVdjTyQ/qeffpITR/LYLL7wOCzGXYvvvvsu7dmzRz4Av//+u0wjwUdC1qtXT7bhqSk4ZPXr14/27dtHq1atkjm8+Lk5QDGeYuL06dM0atQomVPsq6++ogULFtArr7xCzuLKrTjap0un4wnHtS4FAADAZQLdk08+ScePH3frYGfT8DVt2jTp0uPpJLglS73Mnz/fPBBt7dq1ErCioqLo1VdfpZ49e9LSpUvNz2EwGKTLkpfcktW3b18JaJbzgnGLGk81wa1d9evXp48//pi++eYbp5rjKyyovCxjUxO0LgUAAMBlDnbw9/eXI009WYG7HXO6qDPP80z0POfXtWvX6M6dO3TixAmaNGlSti5APhpyxYoVdPv2bZnb66OPPrKa3Z5xwPvnn3/kCEZuUXO22e3LlYiU5WXjba1LAQAAD8FzXbZq1Upad3iaDJ43k78j88IHx3Xp0kXOKMMzB3DP09WrV/P9nOoQI54KilvA+PtZnfWAG0547Df3XPEcn5ZzcaotZtxA07ZtW/Lz85OpqGbn0DrFjTQ8gTtvU7p0aXrsscdyfT/ca/bAAw9IDxzni+joaNq9e7ecGWfQoEHSSMSvy5fx48fLY3ioE099xcGP3w/XoSWc27GQwkvVlOVlMmpdCgAAFBE3JNxOy3D4paDznN+6dUtOvcdhg8dG84zrHFQ4COWE5zN78MEHJTjxYzgc8QFsvXr1yvdz7ty5U5bcs8WT06pTR3322WfSM8UNKDy1FPdOPfLII9LwYumNN96gESNG0JEjR3LswVq+fLm8XteuXaXRhWto0qRJrvugT58+Evh27dolw5z4+XnaBz7lIY/h4kDGdfLltddek8dwAw4fiMcHCv7yyy8ynMly7LmjFWmSVU8WHpo5hu2GXkc3ki9RUPFyWpcEAACFlJJupFpjVzn8dQ9P6EQBPvn/KuahPJa+++47mfiTT/NnOeem6ssvv5TgpZ6+T30M91TxuKvq1avf8zn5OuNWMXVWAsahi+fy5DPQMD7XM4cbDkBTp041b8dzgvbo0SPX9/S///1PnsNyuigecpQbPj/066+/LsObWLVq1cz38Qzz3OJlWSe/Tz67DodIbl1j3377LdWsmdmIogW0fBVSQLFQCr77V0Fs/H6tywEAAA/ArUpPP/00RUZGSgsPH7GnBpLcuug4EHGXo3pRQ4vatVjQ51QnMueZ3nmidUt8m1u4LDVq1CjP97R3716ZDzS/uJWOz/fMZ8L54IMP7tntyvXw0CbunlTxPtByYD5avoognLwoiUx0+dpRqnZfZ63LAQCAQvL3NkgrlBavWxA8bonHTc+cOVPOJMNdg9w6lZaWluP2N2/elMdwq1RW6hRQBX3OggoMDMzzfv9c5u/MDY/j4rPpcHclt2iNGzeO5s2bl+c4MWeD8FUEYYZAOqrcoMuJp7UuBQAAioC7qgrS/acFPpiNT9fHIal169ayLutZZrK6//77adGiRdKalfXAtvw+p+UpdVTcQsZBbcuWLTKYXsW38xqvlZN69erJOC8eLJ9f3F3KF56CilvtZs2aJeGLa7WsU23l4nMx8vgwtduR3zOPh9MKuh2LoJxf5gnFL9+8pHUpAADg5kJCQmTc1YwZM+SsMTzZOXfB5YXn0Lx+/boEFB6gzl10PL8mBx0OKfl5Tp4Wglun1MH6fDQh43FX3KLGRzNymOGB79yFyIPrC2LcuHH0888/y5K7CHki9pxa6hjPK8qTvfORjWfPnpWwx+9LHb/FIZNb+zjM8RGdPKtCjRo1qHPnzvTss8/Sjh07JIRxt2VBW9xsCeGrCMIDMgf0Xbrz7yG7AAAA9sBHIXL3GocH7hbkVp/Jkyfn+Ri1dYqDFs/Byedc5gHwPN6Jny8/z8ktZp9//jl9/fXX8nzdu3eX9S+99JIENZ7Tk5+XwxlPrm45AD4/2rVrRwsXLpTH8nQVfHSmeoRlVjxHKLfW8fyg3PLFR23yNBrqYH0+4pEnaueJXPlAAZ7uinHLGNfOrXQ8+J/PQ63lXGM6paDHuboIHgzIRz1wQrfXqYZW/fkuvXZ6ATVUfOiHgXvs8hoAAGBbPA9lTEyMzPfE80oB2OKzU5DcgZavIggvWV2Wl02pWpcCAAAALgLhqwjCy2TOqRKv51MmYKZ7AAAAuDeEryIoVaoGeSsKmXQ6unLlsNblAAAAgAtA+CoCvcGLwkw6uX75yiGtywEAAAAXgPBVROX0mQPuLl23PpcVAAAAQE4QvooozCdYlrE3cj8NAwAAAIAK4auIwv0zTzh66Xac1qUAAACAC0D4KqJyQRVkeTlVu9MUAAAAgOtA+CqisJCqsow1pmhdCgAAALgAhK8iKle6liwv6UykmExalwMAAJCn2bNny+mFnFHlypVpypQpbr9/EL6KKCy0vixT9DpKTDqjdTkAAAB54vMeHj9+3CmD2q5du+S8i+4a7FQIX0Xk6xdMZYyZp8e8ePlvrcsBAADIk7+/v6Ynlc4Lnww7ICCA3B3Clw2U1/vI8sK1I1qXAgAAbsxkMtHEiRPlxM4courXr0+//PKL+f6NGzeSTqej5cuXU7169eTkz82aNaODBw/m2pq1b98+euCBBygoKEhOCB0dHU27d++W5xo0aJCcKJqfky/jx4+Xx6SmptJrr71G5cuXp8DAQGratKlsn/U1li1bRjVq1JBA9fjjj9Pt27fp+++/l1aokJAQeumll8hoNObaOpWYmEjPPvsshYaGynupU6eOPGdOFEWR+ipWrEi+vr5Urlw5eX7Wrl07Onv2LL3yyivm92JZKz+Ga3zsscfo2rVrZG9edn8FD1DeO5j2ZlylS4kxWpcCAACFoShEWpyj1zuAyCII3AsHrzlz5tD06dOpWrVqtHnzZurbt6+0GLVt29a83euvv06fffYZhYWF0ZtvvkkPP/ywdDV6e3tne84+ffpQw4YNadq0aWQwGGjv3r2yXYsWLSQIjR07lo4dOybbFitWTJbDhw+nw4cP07x58yTkLFmyhDp37kwHDhyQuhgHrc8//1y2uXHjBvXo0UPCTYkSJWjFihV0+vRp6tmzJ7Vs2VK6QnMKml26dJHH8nuuWrWqvCbXmJNFixbRp59+Kq9Xu3Ztio2NlWDJFi9eLEGVuzSHDBlifsyOHTto8ODBsl8fffRRWrlyJY0bN47sDeHLBsoHlCVKvkoXb13SuhQAACgMDl7vl3P86755icgnMF+bcmvT+++/T2vXrqXmzZvLusjISPrrr7/o66+/tgpfHCD+7//+T65zS1OFChUkIPXq1Svb8547d07CWlRUlNxWwxMLDg6WViIOcZbbz5o1S5YcvBi3gnFw4fVcI0tPT5dAx6GJccvXjz/+SHFxcRLiatWqJS1uGzZsyDF88fvcuXMnHTlyhKpXr25+v7nherjODh06SHjk1qwmTZrIfSVLlpTQxq17lu+FAyqHxlGjRsltfp2tW7fKe7EndDvaQIWgirK8mJqgdSkAAOCmTp48Ka1JHKo4vKiXH374gU6dOmW1rRrO1ODBXX8cYnIycuRIeuaZZyS0fPDBB9meKytu3eKuQg4qlnVs2rTJ6rHcjacGL8Zdh9ytWOxu65m6Lj4+PsfX4RY4Do1q8LqXJ554glJSUiSgcesWh82MjIw8H8P7hLtMc9t39oKWLxsoX7I60cWVdNGoQZM1AADYpvuPW6G0eN18unnzpix5PBePtbLEY5wKi8dJ9e7dW573jz/+kFYz7rrjLsLc6uBWpD179mTrArQMVlm7OLkFLad1plymaeIxbQUREREh3aPcYrZmzRp64YUXaPLkyRIKc+pu1RLClw2UD61HdIDool4hkzGD9AbsVgAAl8LjrvLZ/acV7qbjkMXda5ZdjDnZvn27dLuxhIQEGe9Vs2bNXLfn1iW+8ID0p59+WroPOXz5+PhYDYhnPD6M13GLVevWrcle6tWrRxcuXJDa89v6xYGNx7fxZdiwYdKVyi11999/f47vhfcJj/vKuu/sDSnBBkLL1ieDolC6TkdXrh6mUA5jAAAANsTjlXhsFQckbi1q1aqVHIm4ZcsWOUpxwIAB5m0nTJhApUqVkm69t956i0qXLi0DyrPibjoe78XjsfgISg47PNcWD4Rn3E3ILV3r1q2TAevclchBiAfp9+/fnz7++GMJY1euXJFtODB169bNJu+3bdu21KZNG6nlk08+ofvuu4+OHj0qrWU8TisrPmqRwxV3I3KdPEifw1ilSpXM74UPUHjqqackxPI+4aMhecD/Rx99RN27d6dVq1bZfbwXw5gvG/Dy9qMwU+bRKhdj92pdDgAAuKl3332X/vvf/8rRedxqwyGEuws5OFnisVsjRoyQaSP4qL+lS5dKy09W3G3IUytwkOJQxQPy+QjDd955R+7nIx6fe+45GRDPR1ROmjRJ1nPLGD/m1VdflfFkHOw4tKmtbbayaNEiaty4sbTGccsfD4zP2nql4qMoZ86cKWGKQyB3P/L75hCqBtIzZ87IODR+L4yn4eDH8MB7DperV6+mt99+m+xNp/DEGG4oOTlZjtLgvwr4LwJ7e2Z2Y9qhu0PvV3yEHn7gf3Z/PQAAKJw7d+5QTEyMBBaeO8qd8FxbfAQhdzU66ymE3PWzU5DcgZYvGynnGyzLCzjFEAAAAOQB4ctGygeEy/Li7TitSwEAAAAnhvBlI+WDK8vyYlqi1qUAAICH4tPo8GgidDk6N4QvG6lQKnNm4IumO1qXAgAAAE4M4ctGyoc2kGWcnk+pgMlWAQAAIGcIXzZSunRN8jUpZNLpKDb2H63LAQAAACeF8GUjOr2eyimZu/NC/AGtywEAAAAnhfBlQ+UNmefounj9uNalAAAAgJNC+LKh8n4lZXkh+ZzWpQAAAICTQviyoYpBFWR5PgVzfQEAgOsbOHBgjueEtMcUGS+//DJ5CoQvG6oYknnW9fPpN7QuBQAA3FBhQ4oW4YZPdcQnwU5MxPyXWSF82VBE2fqyPE8ZpJhMWpcDAAAATgjhy4YqlG/CZyqnm3odJSSe1rocAABwsy7ATZs20WeffSYtSnw5cybzfMK8vkmTJuTr60vh4eH0xhtvUEZGRp6PMxqNNHjwYDlJtL+/P9WoUUO2KYizZ8/Sww8/TCEhIRQYGEi1a9emFStWyPPzCb4Z38evyXWwW7duUf/+/alYsWJS68cff0yexkvrAtyJr18whZqIYg1E5y7tpJIl79O6JAAAyAc+JU9KRorDX9ffy1+CSX5wMDp+/DjVqVOHJkyYIOvKlClDFy9epK5du0q4+eGHH+jo0aM0ZMgQ8vPzo/Hjx+f6OJPJRBUqVKCFCxdSqVKlaOvWrTR06FAJRL169cpXTcOGDaO0tDTavHmzhK/Dhw9LqIqIiKBFixZRz5496dixY1S8eHEJeOz111+XMPjbb79R2bJl6c0336S///6bGjTInKzcEyB82ViE3o9iKZXOXzlEnvMxAgBwbRy8mv7U1OGvu6P3Dgrwzpym6F6Cg4PJx8eHAgICKCwszLz+q6++krDz5ZdfSpCLioqiS5cu0ejRo2ns2LG5Ps5gMNA777xjvs0tYNu2baMFCxbkO3ydO3dOAlbdunXldmRkpPm+kiUzZwDggKWea/LmzZv07bff0pw5c6h9+/ay7vvvv5cQ6EnQ7WhjFX0zP2zn0e0IAAAOcOTIEWrevLlVC1rLli0l6Fy4cCHPx06dOpWio6OlJYxbrGbMmCGBKr9eeukleu+99+T1xo0bR/v3789z+1OnTklLWdOmTa1CGnd5ehK0fNlYRLHyRNcv07nbsVqXAgAABej+41YoLV5XK/PmzaPXXntNxlxxeAsKCqLJkyfTjh353w/PPPMMderUiZYvX06rV6+miRMnyvO9+OKLdq3do1q+eKc2btxYfkDcjMhzf3BfrqU7d+5IHzD3H3OK5ubIuDjrea84VXfr1k2aQPl5uP9XHRhoeYjq/fffL4MH77vvPpo9eza5goohmeO8zqclaV0KAADkE7cacfefoy/5He+l4u5DHihvqWbNmtJdyOPWVFu2bJHvarU7L6fH8TYtWrSgF154gRo2bCjftdwyVVDc5fncc8/R4sWL6dVXX6WZM2eaX5NZvm7VqlXJ29vbKuAlJCTImDRPUqDwxQPkOFht376d1qxZQ+np6dSxY0c5ckH1yiuv0NKlS2UAH2/P/c49evQw388/BA5e3OzIg/u4r5eDFfdLq2JiYmQbPlJi7969MjcJp+tVq1aRs4sok9nvfZ7StC4FAADcTOXKlSW48NGEV69elUHzHJ7Onz8vrU082J4HsnMX4MiRI0mv1+f6uGrVqtHu3bvlu5XDz3//+1/atWtXgerh72d+PH9v86D5DRs2SBhklSpVknC5bNkyunLlinSDcqPM4MGDpdFl/fr1dPDgQTlQQK3TYyhFEB8fzzFb2bRpk9xOTExUvL29lYULF5q3OXLkiGyzbds2ub1ixQpFr9crsbGx5m2mTZumFC9eXElNTZXbo0aNUmrXrm31Wk8++aTSqVOnfNeWlJQkr8tLR7p547JSZ3YduSQlnXfoawMAwL2lpKQohw8flqWrOXbsmNKsWTPF399fvuNiYmJk/caNG5XGjRsrPj4+SlhYmDJ69GglPT09z8fduXNHGThwoBIcHKyUKFFCef7555U33nhDqV+/vvlxAwYMULp3755rPcOHD1eqVq2q+Pr6KmXKlFH69eunXL161Xz/hAkTpB6dTifPxW7cuKH07dtXCQgIUEJDQ5VJkyYpbdu2VUaMGKG48menILlDx/8UNridPHlSkvOBAwfkEFZOsXz0Ajchqkc2qOmX0zG3inEL1++//y4tWipOzHyEBKdmbvps06aNdDlOmTLFvM2sWbPkOZKScu7OS01NlYsqOTlZmkJ5ez7E1ZHafVeHrhl0NK/pBKod9ZhDXxsAAPLGw2P4e4eP7uPpGABs8dnh3MFHluYndxS6nY+bLDkM8REOHLxYbGys9PFaBi8WGhoq96nb8O2s96v35bUNv7GUlJRcx6Pxm1YvHLy0EqHP7Oc+H39AsxoAAADAORU6fPHYL+6r5aMlnMGYMWMkbaoX7v/WSkWfzPB5PvGkZjUAAACAG4Wv4cOHywA6HlhnOTEaT97GA+mznkSTj3ZUJ3bjZdajH9Xb99rGcobcrPioSL7f8qKViMBysjx365JmNQAAAIAbhC8eHsbBa8mSJTK+i/s8LfFEbXwI6bp168zreCoKnlqC5xBhvOQxYvHx8eZt+MhJDku1atUyb2P5HOo26nM4u4rBVWV5LhVncgcAAIAihC/uauRTAvz0008yfwiPzeKLOg6Lx1rxIaR8eCu3iu3Zs4cGDRokoalZs2ayDU9NwSGrX79+tG/fPjlE9e2335bn5tYrxvOFnD59mkaNGiWHzfKpE/h0Bzxg3xVElMkcA3fedEfrUgAAIBdFON4MPJRio89MgcLXtGnTZDxVu3bt5MSb6mX+/PnmbT799FN66KGHZHJVPmqRuxB54jXLc0lxlyUvOZT17dtXzm6unuyTcYsaz5bLrV3169eX2XK/+eYbmUXXFVQs30SWVww6un3z3xY+AADQHvfQsNu3b2tdCrgYHlrFOMMURZGmmnBmBTnk0x7azKpDCXodzW/2LtWq8ajDXx8AAHJ3+fJlGZ/MZ1nhs60UdKZ58Dwmk0kmjufwXrFixWyfmYLkDpzb0U4q63wpgdLobOxehC8AACejHuBlOf4Y4F54Jv6cgldBIXzZSWXfEPonLY7OJHjW+aoAAFwBf3nysBlu+eJT5QHkB89laotTISF82UnlYhFE1+MoBtNNAAA4LR67U9TxOwAF5WFnsnScSqWiZHkmDdNNAAAAwL8QvuykSngjWZ6lDFJMJq3LAQAAACeB8GUnEeWakUFR6LZeR1euHta6HAAAAHASCF924u0bSOVNmUdDnLm4XetyAAAAwEkgfNlRZa9AWZ65clDrUgAAAMBJIHzZUSX/UFmeSYrRuhQAAABwEghfdlQ5OPPE42dS4rQuBQAAAJwEwpcdVbl7gu2zGbe0LgUAAACcBMKXHVUu30yWF/UKpacigAEAAADCl12VLl2LAkwKGXU6On9ph9blAAAAgBNA+LIjnV5Ple+ewSnm8m6tywEAAAAngPBlZ5V9Ssgy5homWgUAAACEL7urGhQhy5gb57UuBQAAAJwAwpedVS1VW5anUq9rXQoAAAA4AYQvO4u8e8TjaUonk8modTkAAACgMYQvO4so34y8FIVS9DqKjf1H63IAAABAYwhfdubl7UeVTZm7+dSFrVqXAwAAABpD+HKAqj7Bsjx95YDWpQAAAIDGEL4coGqxzCMeTyXjBNsAAACeDuHLASJL1ZTlqTs44hEAAMDTIXw5QNXwJrI8TWmkmExalwMAAAAaQvhygEoRLcmgKHRTr6P4Kwe1LgcAAAA0hPDlAN6+xaiiesTj+b+0LgcAAAA0hPDlIFW9g2R5+sp+rUsBAAAADSF8OUhkYHlZnkrCEY8AAACeDOHLQSJLRsny9J2rWpcCAAAAGkL4cpCq4Y1keUJJxRGPAAAAHgzhy0EiK7WTIx5v6HUUh5nuAQAAPBbCl4P4+BU3n+PxxNlNWpcDAAAAGkH4cqBqPiVkeTzuH61LAQAAAI0gfDlQ9eKVZXki+YzWpQAAAIBGEL4cqFrZ+rI8noZzPAIAAHgqhC8Hqh7RRpYxOiOlp9/WuhwAAADQAMKXA4WHR1Mxk0IZOh2dObtZ63IAAABAAwhfDqTT66mazkeuH7+wVetyAAAAQAMIXw5Wza+sLE9cO6x1KQAAAKABhC8Hqx5STZbHb13QuhQAAADQAMKXg1ULayzLExk3tS4FAAAANIDw5WDVKj8oy1iDjpKSzmtdDgAAADgYwpeDBQVXoHJGRa6fPLNe63IAAADAwRC+NFDdK0iWxy7v1LoUAAAAcDCELw3UCKooy6MJx7QuBQAAABwM4UsDNcs2lOWRO1e1LgUAAACcPXxt3ryZHn74YSpXrhzpdDr69ddfre4fOHCgrLe8dO7c2Wqb69evU58+fah48eJUokQJGjx4MN28aX303/79+6l169bk5+dHERERNGnSJHIXUXcH3Z/UZVB66i2tywEAAABnDl+3bt2i+vXr09SpU3PdhsPW5cuXzZeff/7Z6n4OXocOHaI1a9bQsmXLJNANHTrUfH9ycjJ17NiRKlWqRHv27KHJkyfT+PHjacaMGeQOyoU3ouJ3TzN08sxarcsBAAAAB/Iq6AO6dOkil7z4+vpSWFhYjvcdOXKEVq5cSbt27aJGjRrJui+++IK6du1KH330kbSozZ07l9LS0ui7774jHx8fql27Nu3du5c++eQTq5DmyqcZqqnzpx10h46e/4tq1uiudUkAAADgymO+Nm7cSGXLlqUaNWrQ888/T9euXTPft23bNulqVIMX69ChA+n1etqxY4d5mzZt2kjwUnXq1ImOHTtGCQkJOb5mamqqtJhZXpxZVGB5WR7GaYYAAAA8is3DF3c5/vDDD7Ru3Tr68MMPadOmTdJSZjQa5f7Y2FgJZpa8vLyoZMmScp+6TWhoqNU26m11m6wmTpxIwcHB5guPE3NmUWXqyvJoymWtSwEAAABn7na8l6eeesp8vW7dulSvXj2qWrWqtIa1b9+e7GXMmDE0cuRI821u+XLmAFYzog3R2V/pmJJGxow0Mnj928oHAAAA7svuU01ERkZS6dKl6eTJk3Kbx4LFx8dbbZORkSFHQKrjxHgZFxdntY16O7exZDzOjI+etLw4s8qV2pKfSaEUvY7OXdiqdTkAAADgLuHrwoULMuYrPDxcbjdv3pwSExPlKEbV+vXryWQyUdOmTc3b8BGQ6enp5m34yEgeQxYSEkLugFu6qpO3XD9ydoPW5QAAAICzhi+ej4uPPOQLi4mJkevnzp2T+15//XXavn07nTlzRsZ9de/ene677z4ZMM9q1qwp48KGDBlCO3fupC1bttDw4cOlu5KPdGS9e/eWwfY8/xdPSTF//nz67LPPrLoV3UFN/8xWvKNXDmhdCgAAADhr+Nq9ezc1bNhQLowDEV8fO3YsGQwGmRz1kUceoerVq0t4io6Opj///FO6BVU8lURUVJSMAeMpJlq1amU1hxcPmF+9erUEO378q6++Ks/vDtNMWIoqVVOWR25d0LoUAAAAcBCdoigKuSEecM8hLikpyWnHfx06upie2jFOJlz9a8B+mf8LAAAA3Dt34NteQ9WrdCJvRaFkvY7OX9ymdTkAAADgAAhfGvL2DaSaSuag+4OnV2tdDgAAADgAwpfGagdkHmRwMD7zAAYAAABwbwhfGqtTpr4sD2LQPQAAgEdA+NJYnSodZHlESaWM9DtalwMAAAB2hvClscoV21Axk0J39Do6dWad1uUAAACAnSF8aUxv8KLaOn+5fhAz3QMAALg9hC8nUDso8wTgB69ipnsAAAB3h/DlBOqENpLlwRTrk4kDAACA+0H4cgJ1q3aW5QldBt1JSdC6HAAAALAjhC8nEBragEoZFTLqdHT01B9alwMAAAB2hPDlBPicjnW9Ms8Dtf/cJq3LAQAAADtC+HIS9UOqy3LvtcNalwIAAAB2hPDlJBpEtJXlvvQEUkwmrcsBAAAAO0H4chK1q3cnL0WheIOOYmP/0bocAAAAsBOELyfhH1CSaihecn3viaValwMAAAB2gvDlRBoEZk62ujdut9alAAAAgJ0gfDmRBqHRstx764LWpQAAAICdIHw5kQbVH5HlMV0G3b59VetyAAAAwA4QvpxIWFhDCr072eqh479rXQ4AAADYAcKXM9HpqL5PiFzdd26z1tUAAACAHSB8OZkGJWvJ8p/EY1qXAgAAAHaA8OVkGlbuIMu9xhtkMmZoXQ4AAADYGMKXk4mq9jAFmBRK1uvoxKlVWpcDAAAANobw5WS8vP2ooT5Qru8+tULrcgAAAMDGEL6cUHRIDVnuubpf61IAAADAxhC+nFCjyv8nyz0ZOMk2AACAu0H4ckK1azxKviaFrut1FHN2o9blAAAAgA0hfDkhH98gqq/zk+u7T2CyVQAAAHeC8OWkooOryXL3lb1alwIAAAA2hPDlpBpVelCWe1KvYtwXAACAG0H4clJ1o3qSl6JQvEFHFy5u07ocAAAAsBGELyflH1CS6pGvXN95dLHW5QAAAICNIHw5sabB1WW5PW631qUAAACAjSB8ObGmkZ1luTP9Gs7zCAAA4CYQvpxYvajHyf/ufF84zyMAAIB7QPhyYt6+gRStLybXt5/4TetyAAAAwAYQvpxcs9J1Zbn9Gs7zCAAA4A4Qvpxcs+qPynKP8Salp97SuhwAAAAoIoQvJ1ctshOVNCmUotfR/qOLtC4HAAAAigjhy8npDV7U1LuUXN9++g+tywEAAIAiQvhyAc1CG8tyW+IxrUsBAACAIkL4cgEt6vSR5QFdGiUlntG6HAAAACgChC8XEBbekO4z6sik09HW/bO1LgcAAACKAOHLRbQuXlWWf13YrHUpAAAAUAQIXy6iVWRXWf6VGo9TDQEAAHhS+Nq8eTM9/PDDVK5cOdLpdPTrr79a3a8oCo0dO5bCw8PJ39+fOnToQCdOnLDa5vr169SnTx8qXrw4lShRggYPHkw3b9602mb//v3UunVr8vPzo4iICJo0aRJ5soa1e1PA3VMNHTmO2e4BAAA8JnzdunWL6tevT1OnTs3xfg5Jn3/+OU2fPp127NhBgYGB1KlTJ7pz5455Gw5ehw4dojVr1tCyZcsk0A0dOtR8f3JyMnXs2JEqVapEe/bsocmTJ9P48eNpxowZ5MmnGmpmCJbrfx63DrwAAADgQpQi4IcvWbLEfNtkMilhYWHK5MmTzesSExMVX19f5eeff5bbhw8flsft2rXLvM0ff/yh6HQ65eLFi3L7q6++UkJCQpTU1FTzNqNHj1Zq1KiR79qSkpLkdXjpLhasGqHUmV1H6TOrodalAAAAQCFzh03HfMXExFBsbKx0NaqCg4OpadOmtG3bNrnNS+5qbNSokXkb3l6v10tLmbpNmzZtyMfHx7wNt54dO3aMEhIScnzt1NRUaTGzvLib1nX7y/IApVFiQozW5QAAAEAh2DR8cfBioaGhVuv5tnofL8uWLWt1v5eXF5UsWdJqm5yew/I1spo4caIEPfXC48TcTVj4/eYpJ/7c963W5QAAAIAnH+04ZswYSkpKMl/Onz9P7uiB4Bqy3HB+k9alAAAAgNbhKywsTJZxcXFW6/m2eh8v4+Pjre7PyMiQIyAtt8npOSxfIytfX185etLy4o4eiOolyy0ZCZSWekPrcgAAAEDL8FWlShUJR+vWrTOv47FXPJarefPmcpuXiYmJchSjav369WQymWRsmLoNHwGZnp5u3oaPjKxRowaFhISQJ6sd9RiVNSp0W6+jHfsw2z0AAIDbhy+ej2vv3r1yUQfZ8/Vz587JvF8vv/wyvffee/T777/TgQMHqH///jIn2KOPPirb16xZkzp37kxDhgyhnTt30pYtW2j48OH01FNPyXasd+/eMtie5//iKSnmz59Pn332GY0cOZI8nd7gRe0CKsj1DaeXa10OAAAA2Dt87d69mxo2bCgXxoGIr/PEqmzUqFH04osvyrxdjRs3lrC2cuVKmSxVNXfuXIqKiqL27dtT165dqVWrVlZzePGA+dWrV0uwi46OpldffVWe33IuME/2wN3Z7jfevoDZ7gEAAFyMjuebIDfE3Z0c4njwvbuN/+KxXm1+ak639Dr6qfFYqlvrCa1LAgAA8GjJBcgdbnO0oyfx8Q2ilt6ZY982HF2gdTkAAABQAAhfLurBCu1kuSbxGCkmk9blAAAAQD4hfLmottEvkI+i0BmDQsdPr9S6HAAAAMgnhC8XVSwonFrqM/uUVx/4XutyAAAAIJ8QvlxYp4rtZbk64Qi6HgEAAFwEwpcLa4euRwAAAJeD8OXCAoPCqZU+WK6vQtcjAACAS0D4cnEdKz4oyzXoegQAAHAJCF9u1PV49MQyrcsBAACAe0D4coOux7aGEnJ9+YHvtC4HAAAA7gHhyw08VPURWa5IPknGjDStywEAAIA8IHy5gdbRL1CwyURXDDrasQ+tXwAAAM4M4csNePsWo87+FeX68mMLtS4HAAAA8oDw5SYeqt1HlmtT4+j27WtalwMAAAC5QPhyE/Vr96byRqLbeh1t3PW51uUAAABALhC+3IROr6eHQmrJ9d/OYLZ7AAAAZ4Xw5Ua6Nxohy23KLbp0abfW5QAAAEAOEL7cSEREC2qq+JGi09GvOz/RuhwAAADIAcKXm+lRuassf72+H3N+AQAAOCGELzfTvtlIKm5S6LJBR9v/maF1OQAAAJAFwpeb8fULpocCK8n1Rcfma10OAAAAZIHw5YZ6NHxBlhsyEujq1WNalwMAAAAWEL7cUI1q3aieyYsydDpavPV/WpcDAAAAFhC+3NRTdwfeL7j6N2Wk39G6HAAAALgL4ctNdWo+mkqaFIoz6Gjjzk+1LgcAAADuQvhyUz5+xaln8Zpy/eeTi7UuBwAAAO5C+HJjvVqMIb2i0E66QydPrdG6HAAAAED4cm9h4ffTg4ZguT5318dalwMAAAAIX+6vT53BslyacoGuXTuhdTkAAAAeD+HLzUXXH0h1TAZK1eto/p/jtC4HAADA4yF8uTmdXk8Dqj4m1+cl7KeUlAStSwIAAPBoCF8eoEPz0VTeSJSg19HSP9/RuhwAAACPhvDlAby8/ahfeCu5/v2FdWTMSNO6JAAAAI+F8OUhHmv9DgWbTHTOQLR660StywEAAPBYCF8eIqBYWeob0kCuzzi1mEzGDK1LAgAA8EgIXx6k9wMfUJBJoZN6E63bPlnrcgAAADwSwpcHKR4cQb2Da8v1r4/PI8Vk0rokAAAAj4Pw5WH6PfABBZgUOqY30YYdn2hdDgAAgMdB+PIwwSFV6OniNeT6l0d/xNgvAAAAB0P48kCD2n8sY79O6E204q8JWpcDAADgURC+PFBwico0sGRDuT711BJKT7utdUkAAAAeA+HLQ/Vt/zGVMip0wUC0eMMbWpcDAADgMRC+PHjer6HhbeT69Ivr6fbNeK1LAgAA8AgIXx7siQcnUQUj0VWDjr5d86LW5QAAAHgEhC8P5u1bjF6r0Vuuf594iC5d2q11SQAAAG7P5uFr/PjxpNPprC5RUVHm++/cuUPDhg2jUqVKUbFixahnz54UFxdn9Rznzp2jbt26UUBAAJUtW5Zef/11ysjAlAj28GDz0dRY8aVUvY6mbHhN63IAAADcnl1avmrXrk2XL182X/766y/zfa+88gotXbqUFi5cSJs2baJLly5Rjx49zPcbjUYJXmlpabR161b6/vvvafbs2TR27Fh7lOrxdHo9jWr+X9IpCv2RcY3+OTBX65IAAADcml3Cl5eXF4WFhZkvpUuXlvVJSUn07bff0ieffEIPPvggRUdH06xZsyRkbd++XbZZvXo1HT58mObMmUMNGjSgLl260LvvvktTp06VQAa2F1WjO/XwDZfr/9s9iTLS72hdEgAAgNuyS/g6ceIElStXjiIjI6lPnz7Sjcj27NlD6enp1KFDB/O23CVZsWJF2rZtm9zmZd26dSk0NNS8TadOnSg5OZkOHTpkj3KBiEZ0mk7BJpOcduinNS9rXQ4AAIDbsnn4atq0qXQTrly5kqZNm0YxMTHUunVrunHjBsXGxpKPjw+VKFHC6jEctPg+xkvL4KXer96Xm9TUVAlolhfIv5CSVemVCp3k+tS4vyg2bp/WJQEAALglm4cv7iZ84oknqF69etJitWLFCkpMTKQFCxaQPU2cOJGCg4PNl4iICLu+njt67MFJ1MDkTbf1Ovpw9TCtywEAAHBLdp9qglu5qlevTidPnpTxXzxui8OYJT7ake9jvMx69KN6W90mJ2PGjJExZerl/Pnzdnk/7kxv8KL/tnqXDIpCa01JtHrL+1qXBAAA4HbsHr5u3rxJp06dovDwcBlg7+3tTevWrTPff+zYMRkT1rx5c7nNywMHDlB8/L8zrq9Zs4aKFy9OtWrVyvV1fH19ZRvLCxRc9WrdaHDxzP38v+M/UULCaa1LAgAAcCs2D1+vvfaaTCFx5swZOYrxscceI4PBQE8//bR0Bw4ePJhGjhxJGzZskAH4gwYNksDVrFkzeXzHjh0lZPXr14/27dtHq1atorffflvmBuOABfb3bLdv6T6jjq7rdTRxxX+0LgcAAMCt2Dx8XbhwQYJWjRo1qFevXjKZKk8jUaZMGbn/008/pYceekgmV23Tpo10JS5evNj8eA5qy5YtkyWHsr59+1L//v1pwoQJti4VcuHjG0TvNRsr3Y889xe6HwEAAGxHpyiKQm6Ij3bkljYe/4UuyML5fNHjNPPmMQoyKbSo8w8UHn6/1iUBAAC4fO7AuR0hV88//D3VNXnRDb2O3lg1hDIyUrUuCQAAwOUhfEGuvH0C6cP2X1KgSaG/dWk0cznGfwEAABQVwhfkKaJiS/pvlUfl+vSEfbRn/w9alwQAAODSEL7gnrq1e48e8SpDJp2ORu+eRNevn9K6JAAAAJeF8AX58lb3n6mykSjOoKORvz9J6em3tS4JAADAJSF8Qb4EFAulz9p9IuO/9uhS6cMlT2hdEgAAgEtC+IJ8i4z8P/qgxgCen4Tmp5yjX9a+pnVJAAAALgfhCwqkXYvXaXhIA7n+vwsr6e8Dc7UuCQAAwKUgfEGBDXnoe+qoD6YMnY5G7J5IMWc3a10SAACAy0D4ggLTGQz0bo8lVMdkoES9jp5dN4zi4g9qXRYAAIBLQPiCQgkILENTH1lAlYxElw1Ezy3vQ8nJF7QuCwAAwOkhfEGhlSxVnb7uOIPKGBU6qTfRi4sfpTspiVqXBQAA4NQQvqBIyldoTtNaTaRicgqiVBqxsDMCGAAAQB4QvqDIalR/mL5sOJL8TQptVW7Riws6UQoCGAAAQI4QvsAmohv8h75q8IoEsO10m15c0JFup1zXuiwAAACng/AFNtOo4WCafv9rFGBSaAel0PAFnejWzTitywIAAHAqCF9gU/fXH0hfR4+W0xDtojs0aGEnunLliNZlAQAAOA2EL7C5BvX60bdNx1FJk0JH9Ebqu6wXnT67SeuyAAAAnALCF9hF7VpP0Jz206mikeiSnqjf+mE4FREAAADCF9hTRMVW9GP3RVTP5EXJeh09s2ci/bL2da3LAgAA0BTCF9h9ItZveq2hDrogStfp6J2LK+md+V0oLfWm1qUBAABoAuEL7M4/sDR93GczvVSiPukUhX65c4EG/dyGYuMOaF0aAACAwyF8gUPoDV40pPscmho1mIJMJtqvS6fHVzxN67ZN1ro0AAAAh0L4Aodq3ewVmv/gdKpp0lOSXkcvH/+Bxs/rjAlZAQDAYyB8gcNFVGpNc3tvoUEBVaUbclHqRXpyXjvae2i+1qUBAADYHcIXaMLbtxiNfOJXmllnGJU1KnRGr1D/Xe/SxIWP0K1b8VqXBwAAYDcIX6Cppo2ep8WP/U7dvcqQotPRT7dj6NEF7WnTzs+1Lg0AAMAuEL5Ac8EhkfRen/X0da1nqbxRoVg90fAjM+mFH1tQzLnNWpcHAABgUwhf4DRaNB5Oi5/cQIMCIslLUehP0w3qsf4FmvTLo5ScfFHr8gAAAGwC4QucSkBgGRr5xG+0pO3n1JYCKEOnox9vnaIuizrRN8v+g6MiAQDA5ekURVHIDSUnJ1NwcDAlJSVR8eLFtS4HCkNRaMvOz+mjQ9/SSUPmx7SUSaEh4e2oZ7v/kZ9fsNYVAgAAFDh3IHyB0zOmp9KKP8fTV2eW0QVD5rqSJoWeLhVNT7WZQCVKVNK6RAAA8HDJCF8IX+4oPe0W/brhTfrm4jq6ZNDJOn+TQj2KRVK/luOofLlorUsEAAAPlYzwhfDlzjLSbtPqLe/T7JildMRgknV6RaE2hhL0RNRT1LLhs2Tw8ta6TAAA8CDJCF8IX55AMZlo++6vaNbh72mb7o55fbiJqEep++mx5qMotExtTWsEAADPkIzwhfDlaU6fXEW/7PmCfr8dQ0l6vbk1rIk+kLpWeJDaN36RigeV07pMAABwUwhfCF8eKzXlOq3d9hEtPLuS9ujTzeu9FYVae4VQl8qdqXXDoRQYWEbTOgEAwL0gfCF8ARGdP/cnrfz7a1pxfb95qgo1iDXWF6N2YU2pXf3BFB5aT9M6AQDA9SF8IXyBJUWh48eX0ooDs2ht8kk6e3e6ClV1k4GaF4+kppXaU3StpyggoJRWlQIAgItC+EL4gtwoCsWcXksbD82hjdf2015dOpl0mdNWMD6tUT2dHzUtEUVNI7tSnRqPkK9PMU1LBgAA54fwhfAF+XT96lHafuBH2nF5O+24E0cX784fpvJRFKqj86OGxSPp/gptqH5UDwrGwH0AAMgC4QvhCwpDUejCub9ox9FfaEf8HtqZnkDXDNanP+WWsccDq9DzHT6nkiFVNCsVAACcC8IXwhfYgGI00vlzm+nvk8vonyt76e878XTm7nixQJNC/Us2lNMbIYQBAEAywhfCF9jHzt3T6KP9080z6/sqCj3iX4l6NHyWald7mHQW48cAAMBzJCN8IXyB/ZiM6bT6zwk06/TvdPhuCGNVTXrqVKo+tYl6gmre15X0+iyHVQIAgNtC+EL4Aged3mj3PzNo4eE5tD4jkVL1/7Z6lTIp1NK/HDUKbUz1qnaiKhVaIowBALixZHcJX1OnTqXJkydTbGws1a9fn7744gtq0qRJvh6L8AWOdCPxLK3dNYU2XdpO20zJdPvuKY5UQSaFahmKUdWAMIoscR9FhjakyIqtqGTxiuiqBABwA24RvubPn0/9+/en6dOnU9OmTWnKlCm0cOFCOnbsGJUtW1bz8LVg13lacfAyeel1ZNDryMugN1/31uvJYNDJbS+9nrwM6npeZt42Py7LYzPvs3gug95qu3+vZ26XuY2O9LrM7flivq7TEWcAdZ26nhto8IVvP+kpSbTnwA+07exa2nfzHB2iNLqTJYxZhrJQ8qIwrwAK8w2hsIBQKhsYTiUCQykkqByVKB5BIcGVKSiwDOl1OT8HAABozy3CFweuxo0b05dffim3TSYTRURE0IsvvkhvvPGG5uFr4ooj9PXm0+SqOIBlD2r/hrN/g5plqMvyGHOoy3n9v8ucAuC/r8O5RGd5W6cjzoaW21jfr25/d53+3tvzNjk+1uq1LO/PWls+t7e8X5+5VNJv0OULa+lc/E66cDOGzqXG0xnTbbpk0JGSzxDMJwkPUogCSU/+pKdAvRcF6LwpwOBNAXo/CvTyowAvf/I1+JGPwUcuXgZf8vHyJR9e58Xrfcnb25+8vfzJR5Z+ZNB5k97gRXqdF3kZfEhv8CaD3vvu0osMvE6vruPn9JbuU4POIGGQlwjyAABUoNzhRU4oLS2N9uzZQ2PGjDGv0+v11KFDB9q2bVuOj0lNTZWL5U6wp271wum+ssXIaFIo3aSQ0WiiDJMiF16XYeSlKfO+u7czTJnbGI38GFPm+ru3zffx8xkt7pPbmc8lzy/XM7f/977M2yYTkVHJvH0vvInJyNs5ZfZ2Q3zKoi5Wa4J0CRTuc5pKeF8iP++rZPBOIJP3TUozpNIdQwbdMih0w0B0U6+XWfiTdERJ8vMyZl6UVKKMu0+WRprTKQpxDFOjmHpdbiuU+33y2Oz3Zbue5TnuPq0V821d9vtz2zbX57DcRpe/x95LYX7bdPlYn3UbXS4vmtdjADxBDWMQfTck5xzhSE4Zvq5evUpGo5FCQ0Ot1vPto0eP5viYiRMn0jvvvOOgConqVSghF2dl4uB2N4iZFL5Q5vW7663utwhtmdvmvN7y8eZt726Tdb3RlL2GzGXmerUmXioW13mZedvyfvUxBdj+7uup1623zeGxJuvH3nP7LK+lPse9trd8H6lKKTqdXpJMaZnrcqZQEN2kYK8rVMxwnXwNt8hHf5u89LfJW59CBn0K6fWpRHJJI0VnJEVnkqVJZ5KLUa+QkZc6XiqUoePMxteJTHzhzwvHObmuu7vk2zrzMj+4FS/Xt4FvegBwAikZ/zbSaMkpw1dhcCvZyJEjrVq+uJvSU0k3G/F4MK0rgfyyDm6Wwe5u0DPlFQxz2N4q9OUcLu++8t3X/7cOfjGdYuTmUZ5tVqbXUIxpZFLSyGQykqKkk8mYQSYlXbZV5CKHgMrzmTi2yetl3sevlxnp1HWKbCWvx88nNWTel/k4XpNZB2+XWVPmM8s2ZDH+jcMhb28xJo6fTXc38alL2U7u4zWZbWi6HNffzYrm0Kk+r/Xz6O6+Ht/KbPOzfIy5OMtHWj/P3Qry7HqW96q+J8toa7E+W9OdKcdmr8z9pr4uWrzBM5UILkPOwCnDV+nSpclgMFBcXJzVer4dFhaW42N8fX3lAuCqeOwUn1rSgGYiAAC35pSHT/n4+FB0dDStW7fOvI4H3PPt5s2ba1obAAAAgNu1fDHuQhwwYAA1atRI5vbiqSZu3bpFgwYN0ro0AAAAAPcLX08++SRduXKFxo4dK5OsNmjQgFauXJltED4AAACAK3Haeb6KCjPcAwAAgDPmDqcc8wUAAADgrhC+AAAAABwI4QsAAADAgRC+AAAAABwI4QsAAADAgRC+AAAAABzIaef5Kip1Bg0+9BMAAADAntS8kZ8ZvNw2fN24cUOWnnxybQAAAHB8/uD5vjxyklU+F+SlS5coKChITlhsr5TL4e78+fOYyLUIsB9tA/vRNrAfbQP70TawH11nX3Kc4uBVrlw50uv1ntnyxW+8QoUKDnkt/iHil6LosB9tA/vRNrAfbQP70TawH11jX96rxUuFAfcAAAAADoTwBQAAAOBACF9F4OvrS+PGjZMlFB72o21gP9oG9qNtYD/aBvaje+5Ltx1wDwAAAOCM0PIFAAAA4EAIXwAAAAAOhPAFAAAA4EAIXwAAAAAOhPBlQ8uXL6emTZuSv78/hYSE0KOPPqp1SS4rNTWVGjRoIGcn2Lt3r9bluJQzZ87Q4MGDqUqVKvJZrFq1qhzhk5aWpnVpLmHq1KlUuXJl8vPzk9/nnTt3al2SS5k4cSI1btxYzi5StmxZ+X/w2LFjWpfl8j744AP5//Dll1/WuhSXc/HiRerbty+VKlVK/k+sW7cu7d69W9OaEL5sZNGiRdSvXz8aNGgQ7du3j7Zs2UK9e/fWuiyXNWrUKDlFAxTc0aNH5fRaX3/9NR06dIg+/fRTmj59Or355ptal+b05s+fTyNHjpSw+vfff1P9+vWpU6dOFB8fr3VpLmPTpk00bNgw2r59O61Zs4bS09OpY8eOdOvWLa1Lc1m7du2S3+d69eppXYrLSUhIoJYtW5K3tzf98ccfdPjwYfr444+lgURTPNUEFE16erpSvnx55ZtvvtG6FLewYsUKJSoqSjl06BBPg6L8888/Wpfk8iZNmqRUqVJF6zKcXpMmTZRhw4aZbxuNRqVcuXLKxIkTNa3LlcXHx8vv8aZNm7QuxSXduHFDqVatmrJmzRqlbdu2yogRI7QuyaWMHj1aadWqleJs0PJlA/wXMjdr8vkkGzZsSOHh4dSlSxc6ePCg1qW5nLi4OBoyZAj9+OOPFBAQoHU5biMpKYlKliypdRlOjbtl9+zZQx06dDCv499pvr1t2zZNa3P1zx7D569wuBWxW7duVp9LyL/ff/+dGjVqRE888YR0g/N39MyZM0lrCF82cPr0aVmOHz+e3n77bVq2bJk0abZr146uX7+udXkug+f7HThwID333HPyywK2cfLkSfriiy/o2Wef1boUp3b16lUyGo0UGhpqtZ5vx8bGalaXK+Pubx6jxN0+derU0boclzNv3jz5457H0UHhv5+nTZtG1apVo1WrVtHzzz9PL730En3//fekJYSvPLzxxhsywDGvizq+hr311lvUs2dPio6OplmzZsn9CxcuJE+X3/3IAeHGjRs0ZswYrUt26f1oiVtkO3fuLH/1cYsigKNbbbgHgEMEFMz58+dpxIgRNHfuXDn4AwqHv5/vv/9+ev/996XVa+jQofJ/IY+D1ZKXpq/u5F599VVpiclLZGQkXb58Wa7XqlXLvJ7PHcX3nTt3jjxdfvfj+vXrpXsn63m3uBWsT58+mv+l4ir7UXXp0iV64IEHqEWLFjRjxgwHVOjaSpcuTQaDQbq+LfHtsLAwzepyVcOHD5degM2bN1OFChW0LsflcBc4H+jBwUHFLbO8P7/88ks5Ipw/r5A3HgZk+d3MatasKQfJaQnhKw9lypSRy71wSxcHBj6culWrVrKOj/DhQ/4rVapEni6/+/Hzzz+n9957zyo88JFmfAQaH/Lv6fK7H9UWLw5eaissj12CvPn4+Mj+WrdunXmaGP6rmW9zkID8Dx948cUXacmSJbRx40aZ8gQKrn379nTgwAGrdXw0fVRUFI0ePRrBK5+4yzvrVCfHjx/X/LsZ4csGihcvLuOU+PD0iIgI+aFOnjxZ7uPuHsifihUrWt0uVqyYLHmeKvzlnH8cvHi8IX8OP/roI7py5Yr5PrTg5I2nmRgwYIC0tjZp0oSmTJkiUyTwlx7kv6vxp59+ot9++03m+lLHywUHB8scS5A/vO+yjpMLDAyUuaowfi7/XnnlFWn9527HXr16ybx93BOgdW8AwpeNcNjy8vKSub5SUlKkpYa70TSfSwQ8Ds+txIPs+ZI1tHKrBOTuySeflLA6duxYCQ080e/KlSuzDcKH3PHgZsZ/AFjiFth7dZsD2BpP+MutsDyWeMKECdISy39U8VAWLel4vglNKwAAAADwIBgIAgAAAOBACF8AAAAADoTwBQAAAOBACF8AAAAADoTwBQAAAOBACF8AAAAADoTwBQAAAOBACF8AAAAADoTwBQAAAOBACF8AAAAADoTwBQAAAOBACF8AAAAA5Dj/D0/U+pYVZcADAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 700x400 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.figure(figsize=(7, 4))\n",
+    "plt.plot(test_x1.cpu().numpy(), ale_std.cpu().numpy(), label=\"aleatoric std\")\n",
+    "plt.plot(test_x1.cpu().numpy(), epi_std.cpu().numpy(), label=\"epistemic std\")\n",
+    "plt.plot(test_x1.cpu().numpy(), total_std_evi.cpu().numpy(), label=\"total std\")\n",
+    "plt.title(\"Evidential uncertainty decomposition\")\n",
+    "plt.legend()\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "probly",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
# Add transformation calls + uncertainty comparison notebook (and hook into Sphinx docs)

## Issue
Student sprint / project tracking:  
ProBlym-Löser: Add notebook demonstrating ProBly transformation calls + uncertainty comparison (PyTorch fixtures)  
Cortys/SEP-Probly-WS2526#643

---

## Motivation and Context
This PR adds a runnable Jupyter notebook that demonstrates **ProBly transformation API calls** on a small **1D regression toy example**. The notebook serves as a reference for:

- correct transformation invocation (“Aufrufe” / API usage)
- what each transformed model returns (**Tensor vs dict vs ModuleList**)
- how to obtain predictive uncertainty:
  - MC sampling (dropout / dropconnect / bayesian)
  - ensemble disagreement
  - evidential decomposition (epistemic vs aleatoric)
- an end-to-end training + evaluation loop with plots and simple metrics

In addition, the notebook is **integrated into the Sphinx docs** so it appears under **Notebooks → Notebook Examples**.

---

## What’s Included

### Notebook: transformation calls + uncertainty comparison
- Demonstrates `dropout`, `dropconnect`, `ensemble`, `bayesian`, and `evidential_regression`
- Uses a consistent base MLP across transformations (fixture-equivalent where applicable)
- Runs training, prediction, and evaluation for in-domain vs OOD regions

### Documentation (Sphinx)
- Adds the notebook to the docs sources and links it via the notebook examples toctree
- The notebook renders as part of the built HTML docs

---

## Key Fixes / Adjustments
- **Metrics**
  - NLL computed on noisy observations (`test_y`) and reported separately for **in-distribution vs OOD**
  - RMSE computed on noise-free targets (`test_y_true`)
- **MC sampling**
  - uses `torch.no_grad()`
  - includes sanity checks for stochasticity where relevant
- **Model consistency**
  - fallback/base model architecture aligned with the fixture-equivalent model for consistent results across environments
- **Docs integration**
  - notebook added under `docs/source/notebooks/examples/`
  - `docs/source/notebooks/examples/index.rst` updated to include the notebook in the sidebar

---

## Public API Changes
- [x] No public API changes  
- [ ] Yes, public API changes (details below)

---

## How Has This Been Tested?
- Restarted kernel and executed **Run All** locally (notebook runs end-to-end)
- `pre-commit` hooks pass (ruff check + ruff format)
- Built docs locally and verified the notebook appears under **Notebooks → Notebook Examples** and renders as HTML

---

## Checklist
- [x] The changes have been tested locally
- [x] Documentation has been updated (notebook added and linked in docs)
- [ ] CHANGELOG entry (not applicable for notebook-only change)
- [x] Style checks pass (pre-commit/ruff)
- [x] No public API impact

---

## Files / Location
- `docs/source/notebooks/examples/transformations_comparison.ipynb`
- `docs/source/notebooks/examples/index.rst`

