### PR TITLE
ProBlym-Löser: Ensemble flax parameter reset (Draft)

### DIFF
--- a/src/probly/transformation/ensemble/common.py
+++ b/src/probly/transformation/ensemble/common.py
@@ -9,6 +9,8 @@ from lazy_dispatch import lazydispatch
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from flax.nnx import rnglib
+
     from lazy_dispatch.isinstance import LazyType
     from probly.predictor import Predictor
 
@@ -25,15 +27,23 @@ def register(cls: LazyType, generator: Callable) -> None:
     ensemble_generator.register(cls=cls, func=generator)
 
 
-def ensemble[T: Predictor](base: T, num_members: int, reset_params: bool = True) -> T:
+def ensemble[T: Predictor](
+    base: T,
+    num_members: int,
+    reset_params: bool = True,
+    seed: int = 1,
+    rngs: rnglib.Rngs | None = None,
+) -> T:
     """Create an ensemble predictor from a base predictor based on :cite:`lakshminarayananSimpleScalable2017`.
 
     Args:
         base: Predictor, The base model to be used for the ensemble.
         num_members: The number of members in the ensemble.
         reset_params: Whether to reset the parameters of each member.
+        seed: int, seed to be used for deterministic member reset.
+        rngs: nnx.Rngs used for flax member re-initialization, overwrites seed.
 
     Returns:
         Predictor, The ensemble predictor.
     """
-    return ensemble_generator(base, num_members=num_members, reset_params=reset_params)
+    return ensemble_generator(base, num_members=num_members, reset_params=reset_params, seed=seed, rngs=rngs)

--- a/src/probly/transformation/ensemble/flax.py
+++ b/src/probly/transformation/ensemble/flax.py
@@ -5,35 +5,60 @@ from __future__ import annotations
 from flax import nnx
 
 from probly.traverse_nn import nn_compose, nn_traverser
-from pytraverse import CLONE, singledispatch_traverser, traverse
+from pytraverse import CLONE, GlobalVariable, singledispatch_traverser, traverse
+from pytraverse.core import State  # noqa: TC001
 
 from .common import register
 
 reset_traverser = singledispatch_traverser[nnx.Module](name="reset_traverser")
 
+RNGS = GlobalVariable[nnx.Rngs]("RNGS")
+
 
 @reset_traverser.register
-def _(obj: nnx.Module) -> nnx.Module:
-    msg = "resetting parameters of flax models is not supported yet."
-    raise NotImplementedError(msg)
+def _(obj: nnx.Module, state: State) -> tuple[nnx.Module, State]:
+    if hasattr(obj, "rngs") and hasattr(obj, "rng_collection") and not any(obj.iter_children()):
+        obj.rngs = RNGS(state)[obj.rng_collection].fork()
+        return obj, state
+    if not any(obj.iter_children()) and "rngs" in obj.__init__.__code__.co_varnames:
+        params = {}
+
+        params.update(
+            {
+                name: getattr(obj, name)
+                for name in obj.__init__.__code__.co_varnames
+                if name in obj.__dict__ and name != "rngs"
+            }
+        )
+        params["rngs"] = RNGS(state)
+
+        params.pop("kernel_shape", None)
+
+        new_obj = obj.__class__(**params)
+        return new_obj, state
+    return obj, state
 
 
 def _clone(obj: nnx.Module) -> nnx.Module:
     return traverse(obj, nn_traverser, init={CLONE: True})
 
 
-def _clone_reset(obj: nnx.Module) -> nnx.Module:
-    return traverse(obj, nn_compose(reset_traverser), init={CLONE: True})
+def _clone_reset(obj: nnx.Module, rngs: nnx.Rngs) -> nnx.Module:
+    return traverse(obj, nn_compose(reset_traverser), init={CLONE: True, RNGS: rngs})
 
 
 def generate_flax_ensemble(
     obj: nnx.Module,
     num_members: int,
     reset_params: bool,
+    seed: int,
+    rngs: nnx.Rngs,
 ) -> nnx.List:
     """Build a flax ensemble based on :cite:`lakshminarayananSimpleScalable2017`."""
     if reset_params:
-        return nnx.List([_clone_reset(obj) for _ in range(num_members)])
+        if rngs is None:
+            rngs = nnx.Rngs(seed)
+        return nnx.List([_clone_reset(obj, rngs) for _ in range(num_members)])
     return nnx.List([_clone(obj) for _ in range(num_members)])
 
 

--- a/src/probly/transformation/ensemble/flax.py
+++ b/src/probly/transformation/ensemble/flax.py
@@ -18,7 +18,7 @@ RNGS = GlobalVariable[nnx.Rngs]("RNGS")
 @reset_traverser.register
 def _(obj: nnx.Module, state: State) -> tuple[nnx.Module, State]:
     if hasattr(obj, "rngs") and hasattr(obj, "rng_collection") and not any(obj.iter_children()):
-        obj.rngs = RNGS(state)[obj.rng_collection].fork()
+        obj.rngs = RNGS(state)[obj.rng_collection].fork()  # type: ignore[invalid-assignment, invalid-argument-type]
         return obj, state
     if not any(obj.iter_children()) and "rngs" in obj.__init__.__code__.co_varnames:
         params = {}

--- a/src/probly/transformation/ensemble/sklearn.py
+++ b/src/probly/transformation/ensemble/sklearn.py
@@ -7,7 +7,7 @@ from sklearn.base import BaseEstimator, clone
 from .common import register
 
 
-def generate_sklearn_ensemble(obj: BaseEstimator, num_members: int, reset_params: bool) -> list[object]:
+def generate_sklearn_ensemble(obj: BaseEstimator, num_members: int, reset_params: bool, **_kwargs) -> list[object]:  # noqa: ANN003
     """Generates an ensemble model from a sklearn base estimator."""
     if reset_params:
         obj.__setattr__("random_state", None)

--- a/src/probly/transformation/ensemble/torch.py
+++ b/src/probly/transformation/ensemble/torch.py
@@ -31,6 +31,7 @@ def generate_torch_ensemble(
     obj: nn.Module,
     num_members: int,
     reset_params: bool = True,
+    **_kwargs,  # noqa: ANN003
 ) -> nn.ModuleList:
     """Build a torch ensemble based on :cite:`lakshminarayananSimpleScalable2017`."""
     if reset_params:

--- a/tests/probly/transformation/ensemble/test_common.py
+++ b/tests/probly/transformation/ensemble/test_common.py
@@ -31,9 +31,5 @@ def test_registered_generator_called(dummy_predictor: Predictor) -> None:
 
     result = ensemble(dummy_predictor, num_members=4)
 
-    mock_generator.assert_called_once_with(
-        dummy_predictor,
-        num_members=4,
-        reset_params=True,
-    )
+    mock_generator.assert_called_once_with(dummy_predictor, num_members=4, reset_params=True, seed=1, rngs=None)
     assert result is expected_result

--- a/tests/probly/transformation/ensemble/test_flax.py
+++ b/tests/probly/transformation/ensemble/test_flax.py
@@ -40,11 +40,11 @@ class TestEnsembleAttributes:
                 jax.tree_util.tree_map(lambda x, y: jnp.array_equal(x, y), original_params, member_params),
             )  # no difference
 
-    @pytest.mark.skip(reason="not implemented yet")
     def test_ensemble_attributes_with_reset(self, flax_model_small_2d_2d) -> None:
         """Tests if the member attributes are not inherited from the base model."""
         num_members = 2
-        ensemble_model = ensemble(flax_model_small_2d_2d, num_members=2, reset_params=True)
+        seed = 2
+        ensemble_model = ensemble(flax_model_small_2d_2d, num_members=2, reset_params=True, seed=seed)
 
         assert ensemble_model is not None
         assert isinstance(ensemble_model, nnx.List)
@@ -122,12 +122,28 @@ class TestEnsembleGeneration:
             count_module_member = count_layers(member, nnx.Module)
             assert count_module_member == count_module_original
 
-    def test_not_implemented_error_with_reset(self, flax_model_small_2d_2d) -> None:
-        num_members = 2
+    def test_rngs_reset(self, flax_dropout_model) -> None:
+        num_members = 1
+        rngs = nnx.Rngs(0, params=1, dropout=2)
+        ensemble_model = ensemble(flax_dropout_model, num_members=num_members, reset_params=True, rngs=rngs)
 
-        msg = "resetting parameters of flax models is not supported yet."
-        with pytest.raises(NotImplementedError, match=msg):
-            ensemble(flax_model_small_2d_2d, num_members=num_members, reset_params=True)
+        assert ensemble_model is not None
+        assert isinstance(ensemble_model, nnx.List)
+        assert len(ensemble_model) == num_members
+
+        # simulate rngs
+        new_rngs = nnx.Rngs(0, params=1, dropout=2)
+        kernel1_key = new_rngs.params()
+        kernel_init = jax.nn.initializers.lecun_normal()
+        linear1_kernel = kernel_init(kernel1_key, (2, 2))
+        _ = new_rngs.params()  # linear1 bias
+        dropout_rngs = new_rngs["dropout"].fork()
+        kernel2_key = new_rngs.params()
+        linear2_kernel = kernel_init(kernel2_key, (2, 2))
+
+        assert jnp.equal(ensemble_model[0].layers[0].kernel.value, linear1_kernel).all()
+        assert ensemble_model[0].layers[1].rngs.key.value == dropout_rngs.key.value
+        assert jnp.equal(ensemble_model[0].layers[2].kernel.value, linear2_kernel).all()
 
 
 class TestEnsembleCalls:
@@ -145,10 +161,10 @@ class TestEnsembleCalls:
             assert custom_model_out.shape == member_out.shape
             assert jnp.equal(custom_model_out, member_out).all()  # no parameter reset
 
-    @pytest.mark.skip(reason="not implemented yet")
     def test_ensemble_flax_custom_model_call_with_reset(self, flax_custom_model) -> None:
         num_members = 2
-        ensemble_model = ensemble(flax_custom_model, num_members=num_members, reset_params=True)
+        seed = 2
+        ensemble_model = ensemble(flax_custom_model, num_members=num_members, reset_params=True, seed=seed)
 
         x = jnp.ones((2, 1, 10))
         custom_model_out = flax_custom_model(x)


### PR DESCRIPTION
## Issue

Part of [ensemble/flax flax.nnx support and parameter reset](https://github.com/Cortys/SEP-Probly-WS2526/issues/740)

Also addresses `ensemble.sklearn` [rename](https://github.com/pwhofman/probly/issues/295)

## Motivation and Context

To reset an object we check if "rngs" is in the `obj.__init__.__code__.co_varnames`:
- If this is the case all the relevant `__init__` parameters are gathered. After adding a new "rngs" to these parameters the `obj.__class__` can be called with the parameters, resulting in re-initialization.
- If this is not the case, the obj is simply returned.

However, when the main model class is being traversed and has the` __init__` arguments `rngs` as well as `in_features` for example, the main class gets completely reinitialized with the "wrong" `in_features` in this instance.

In this approach it is checked whether an obj has children via `if any(obj.iter_children())`. When this is negated we can tell when the obj is a leaf, therefore being a candidate to be reset.

---

## Public API Changes

-   [ ] No Public API changes
-   [x] Yes, Public API changes (Details below)


`transformation.ensemble.flax`:  
Addition of reset_traverser and key functionality.

`transformation.ensemble.torch` and `transformation.ensemble.common`:  
Addition of kwargs to support seed and rngs input required for `ensemble.flax`.

`transformation.ensemble.sklearn_models`:
Renamed to `sklearn`, also `ensemble.__init__` changes to support the rename.

---

## How Has This Been Tested?

With `tests.probly.transformation.ensemble.test_flax`, testing parameter reset and difference in output after re-initialization.

Additionally in `notebooks.examples.flax_ensemble_param_reset` with a simple CNN and a nested model.

---

## Checklist

-   [x] The changes have been tested locally.
-   [ ] Documentation has been updated (if the public API or usage changes).
-   [ ] A entry has been added to [`CHANGELOG.md`](https://github.com/pwhofman/probly/blob/main/CHANGELOG.md) (if relevant for users).
-   [x] The code follows the project's [style guidelines](https://github.com/pwhofman/probly/blob/main/.github/CONTRIBUTING.md) and passes minimal code style checks.
-   [x] I have considered the impact of these changes on the public API.

---
