### PR TITLE
Cleanup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ changelog = "https://github.com/pwhofman/probly/blob/main/CHANGELOG.md"
 
 [dependency-groups]
 torch = ["torch>=2.0.0", "torchvision"]
-jax = ["jax>=0.8.0", "flax>=0.12.0"]
+jax = ["jax>=0.8.0", "flax>=0.12.6"]
 jax-cuda12 = ["jax[cuda12]"]
 jax-cuda13 = ["jax[cuda13]"]
 all_ml = [{ include-group = "torch" }, { include-group = "jax" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -216,7 +216,7 @@ exclude_also = [
 exclude_lines = ["if TYPE_CHECKING"]
 
 [tool.ty.src]
-exclude = ["notebooks", "docs", "tests", "supporting_files", "examples"]
+exclude = ["notebooks", "docs", "tests", "supporting_files", "examples", "stubs"]
 
 [tool.ty.environment]
 extra-paths = ["./stubs"]

--- a/src/probly/representation/_protected_axis/array_functions.py
+++ b/src/probly/representation/_protected_axis/array_functions.py
@@ -483,15 +483,16 @@ def protected_moveaxis_function(
     return _apply_unary(internals, op)
 
 
-@array_function.multi_register([np.concatenate, np.concat])
-@array_function_override
+@array_function.register(np.concatenate)
 def protected_concatenate_function(
     func: Callable,
-    params: BoundArguments,
+    types: tuple[type[Any], ...],  # noqa: ARG001
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
 ) -> Any:  # noqa: ANN401
-    values = tuple(params.arguments["arrays"])
-    axis = params.arguments.get("axis", 0)
-    out = params.arguments.get("out", None)
+    values = tuple(args[0])
+    axis = kwargs.get("axis", 0)
+    out = kwargs.get("out")
 
     out_internals = array_axis_protected_internals(out)
     sequence = _extract_protected_value_sequence_internals(values)

--- a/src/probly/representation/sample/array_functions.py
+++ b/src/probly/representation/sample/array_functions.py
@@ -541,15 +541,16 @@ def _extract_sample_array_sequence_internals(
 
 
 @array_function.register(np.concatenate)
-@array_function_override
 def array_concatenate_function(
     func: Callable,
-    params: BoundArguments,
+    types: tuple[type[Any], ...],  # noqa: ARG001
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
 ) -> Any:  # noqa: ANN401
     """Implementation of np.concatenate for sample arrays."""
-    arrays = tuple(params.arguments["arrays"])
-    axis = params.arguments.get("axis", 0)
-    out = params.arguments.get("out", None)
+    arrays = tuple(args[0])
+    axis = kwargs.get("axis", 0)
+    out = kwargs.get("out")
     out_internals = array_sample_internals(out)
 
     cast_arrays, has_sample_arrays, create_sample, sample_axis, _ = _extract_sample_array_sequence_internals(arrays)
@@ -557,12 +558,10 @@ def array_concatenate_function(
     if not has_sample_arrays and out_internals is None:
         return NotImplemented
 
-    params.arguments["arrays"] = cast_arrays
-
     if out_internals is not None:
-        params.arguments["out"] = out_internals.array
+        kwargs["out"] = out_internals.array
 
-    res = func(*params.args, **params.kwargs)
+    res = func(cast_arrays, **kwargs)
 
     if out is not None:
         return out

--- a/src/probly/utils/sets.py
+++ b/src/probly/utils/sets.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterable
 
 
-def powerset(iterable: Iterable[int]) -> list[tuple[()]]:
+def powerset(iterable: Iterable[int]) -> list[tuple[int, ...]]:
     """Generate the power set of a given iterable.
 
     Args:

--- a/src/probly_benchmark/efficient_credal_prediction.py
+++ b/src/probly_benchmark/efficient_credal_prediction.py
@@ -4,22 +4,62 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import joblib
 from matplotlib import pyplot as plt
 import numpy as np
 from scipy.optimize import minimize
+from scipy.stats import entropy
 import torch
 from torch import nn
 import torch.nn.functional as F
 from tqdm import tqdm
 
 from probly.evaluation.tasks import selective_prediction
-from probly.method import efficient_credal_prediction
-from probly.quantification.classification import upper_entropy
+from probly.method.efficient_credal_prediction import efficient_credal_prediction
 from probly_benchmark import data, utils
 from probly_benchmark.models import LeNet
 
 if TYPE_CHECKING:
     from torch.utils.data import DataLoader
+
+
+def upper_entropy(probs: np.ndarray, base: float = 2, n_jobs: int | None = None) -> np.ndarray:
+    """Compute the upper entropy of a credal set.
+
+    Given the probs array the lower and upper probabilities are computed and the credal set is
+    assumed to be a convex set including all probability distributions in the interval [lower, upper]
+    for all classes. The upper entropy of this set is computed.
+
+    Args:
+        probs: Probability distributions of shape (n_instances, n_samples, n_classes).
+        base: Base of the logarithm. Defaults to 2.
+        n_jobs: Number of jobs for joblib.Parallel. Defaults to None. If -1, all available cores are used.
+
+    Returns:
+        ue: Upper entropy values of shape (n_instances,).
+    """
+    x0 = probs.mean(axis=1)
+    constraints = {"type": "eq", "fun": lambda x: np.sum(x) - 1}
+
+    def compute_upper_entropy(i: int) -> float:
+        def fun(x: np.ndarray) -> np.ndarray:
+            return -entropy(x, base=base)
+
+        bounds = list(zip(np.min(probs[i], axis=0), np.max(probs[i], axis=0), strict=False))
+        res = minimize(fun=fun, x0=x0[i], bounds=bounds, constraints=constraints)
+        return float(-res.fun)
+
+    if n_jobs:
+        ue = joblib.Parallel(n_jobs=n_jobs)(
+            joblib.delayed(compute_upper_entropy)(i) for i in tqdm(range(probs.shape[0]), desc="Instances")
+        )
+        ue = np.array(ue)
+    else:
+        ue = np.empty(probs.shape[0])
+        for i in tqdm(range(probs.shape[0]), desc="Instances"):
+            ue[i] = compute_upper_entropy(i)
+    return ue
+
 
 # ---------------------------------------------------------------------------
 # Config

--- a/src/probly_benchmark/posterior_network.py
+++ b/src/probly_benchmark/posterior_network.py
@@ -11,12 +11,30 @@ from torch import nn
 
 from probly.evaluation.tasks import selective_prediction
 from probly.method.posterior_network import posterior_network
-from probly.quantification.classification import evidential_uncertainty
 from probly.train.evidential.torch import postnet_loss
 from probly_benchmark import data, utils
 
 if TYPE_CHECKING:
     from torch.utils.data import DataLoader
+
+
+def evidential_uncertainty(evidences: np.ndarray) -> np.ndarray:
+    """Compute the evidential uncertainty given the evidences.
+
+    Based on :cite:`sensoyEvidentialDeep2018`.
+
+    Args:
+        evidences: Evidence values of shape (n_instances, n_classes).
+
+    Returns:
+        Evidential uncertainty values of shape (n_instances,).
+
+    """
+    strengths = np.sum(evidences + 1.0, axis=1)
+    k = np.full(evidences.shape[0], evidences.shape[1])
+    eu = k / strengths
+    return eu
+
 
 # ---------------------------------------------------------------------------
 # Config

--- a/uv.lock
+++ b/uv.lock
@@ -2640,13 +2640,13 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 all-ml = [
-    { name = "flax", specifier = ">=0.12.0" },
+    { name = "flax", specifier = ">=0.12.6" },
     { name = "jax", specifier = ">=0.8.0" },
     { name = "torch", specifier = ">=2.0.0" },
     { name = "torchvision" },
 ]
 dev = [
-    { name = "flax", specifier = ">=0.12.0" },
+    { name = "flax", specifier = ">=0.12.6" },
     { name = "furo" },
     { name = "ipykernel", specifier = ">=6.29.5" },
     { name = "ipython" },
@@ -2685,7 +2685,7 @@ docs = [
     { name = "sphinxcontrib-bibtex" },
 ]
 jax = [
-    { name = "flax", specifier = ">=0.12.0" },
+    { name = "flax", specifier = ">=0.12.6" },
     { name = "jax", specifier = ">=0.8.0" },
 ]
 jax-cuda12 = [{ name = "jax", extras = ["cuda12"] }]


### PR DESCRIPTION
+ np.concatenate / np.concat only supports inspec.signature since 2.4 - for older numpy versions we now no longer rely on signature inspection for the concat __array_function__

## Issue
Please link the corresponding GitHub issue. If an issue does not already exist,
please open one to describe the bug or feature request before creating a pull request.

This allows us to discuss the proposal and helps avoid unnecessary work.
