### PR TITLE
Keep DDU density head on CPU during training of backbone

### DIFF
--- a/src/probly_benchmark/train.py
+++ b/src/probly_benchmark/train.py
@@ -706,6 +706,10 @@ def _(
     density estimator (GDA) on all training features extracted from the frozen
     encoder, which is used at inference time for epistemic uncertainty scoring.
     """
+    # The density head buffer is ~16 GB at ImageNet scale and is unused during training
+    # Parking it on CPU during training decreases footprint sufficiently to use H200 cards
+    density_device = next(model.density_head.buffers()).device
+    model.density_head.to("cpu")
     _training_loop(
         model,
         train_loader,
@@ -717,6 +721,8 @@ def _(
         train_fn=train_epoch,  # ty: ignore[invalid-argument-type]
         val_fn=validate,
     )
+    model.density_head.to(density_device)
+
     amp_enabled = cfg.get("amp", False)
     _fit_ddu_density_head(model, train_loader, device, amp_enabled)
     run.summary["ddu_gmm_fitted"] = True


### PR DESCRIPTION
## Issue
#424 

## Motivation and Context
`TorchDDUPredictor.density_head` allocates a `~16 GB` buffer on construction (`scale_tril`, shape `(num_classes, feature_dim, feature_dim)` for ResNet50/ImageNet → `1000 × 2048 × 2048` fp32). The density head is not used during phase-1 training; it is only fitted afterward in `_fit_ddu_density_head`. The buffer therefore sits idle on GPU for the entire training run. This works fine on B200 GPU, but needlessly uses more VRAM than other experiments and pushes the total usage past the limit on H200 GPU (140 GiB) at `batch_size=2048`, causing OOM on the first backward pass.
 
## Proposed change 
Park the density head on CPU during phase 1 in the `train_model` handler in `probly_benchmark/train.py`.

## Public API Changes
-   [x] No Public API changes

---

## How Has This Been Tested?
-   [x] The changes have been tested locally.
-   [ ] Documentation has been updated (if the public API or usage changes).
-   [ ] A entry has been added to [`CHANGELOG.md`](https://github.com/pwhofman/probly/blob/main/CHANGELOG.md) (if relevant for users).
-   [x] The code follows the project's [style guidelines](https://github.com/pwhofman/probly/blob/main/.github/CONTRIBUTING.md) and passes minimal code style checks.
-   [x] I have considered the impact of these changes on the public API.

---
