### PR TITLE
Fix: derive num_classes from dataset metadata instead of model shape …

### DIFF
--- a/src/probly_benchmark/train.py
+++ b/src/probly_benchmark/train.py
@@ -820,7 +820,7 @@ def _(
     model_ = cast("Any", model)
     amp_enabled = cfg.get("amp", False)
     alpha = train_kwargs.get("alpha", 0.5)
-    num_classes = int(model_.lower.shape[0])
+    num_classes = metadata.DATASETS[cfg.dataset].num_classes
 
     logits_train, targets_train = utils.collect_outputs_targets_raw(
         model_.predictor,


### PR DESCRIPTION
## Issue
#422 

## Motivation and Context
After ResNet50/ImageNet training completes, the `train_model` handler for `EfficientCredalPredictor` crashes when it tries to read `model.lower.shape[0]` to determine the class count. The `lower` and `upper` buffers are registered as `None` in the constructor and nothing in the current code path ever materializes them as real tensors (as far as I am aware).  

## Public API Changes

-   [x] No Public API changes
-   [ ] Yes, Public API changes (Details below)

---

## How Has This Been Tested?

-   [x] The changes have been tested locally.
-   [ ] Documentation has been updated (if the public API or usage changes).
-   [ ] A entry has been added to [`CHANGELOG.md`](https://github.com/pwhofman/probly/blob/main/CHANGELOG.md) (if relevant for users).
-   [x] The code follows the project's [style guidelines](https://github.com/pwhofman/probly/blob/main/.github/CONTRIBUTING.md) and passes minimal code style checks.
-   [x] I have considered the impact of these changes on the public API.

---
