### PR TITLE
Calibration benchmark

### DIFF
--- a/src/flextype/singledispatch.py
+++ b/src/flextype/singledispatch.py
@@ -159,6 +159,9 @@ class Flexdispatch[**In, Out]:
             # Check if an instance-level registry registration applies.
             registry_meta_matches: set[type] = set()
             for registry_meta_type in self.registry_meta_types:
+                if issubclass(cls, registry_meta_type):
+                    continue
+
                 if isinstance(registry_meta_lookup, registry_meta_type):
                     should_add = True
                     if len(registry_meta_matches) > 0:

--- a/src/probly/method/__init__.py
+++ b/src/probly/method/__init__.py
@@ -2,6 +2,7 @@
 
 from probly.method.batchensemble import batchensemble
 from probly.method.bayesian import bayesian
+from probly.method.cast import cast
 from probly.method.credal_wrapper import credal_wrapper
 from probly.method.ddu import ddu
 from probly.method.dropconnect import dropconnect
@@ -15,6 +16,7 @@ from probly.method.subensemble import subensemble
 __all__ = [
     "batchensemble",
     "bayesian",
+    "cast",
     "credal_bnn",
     "credal_ensembling",
     "credal_relative_likelihood",

--- a/src/probly/method/cast/__init__.py
+++ b/src/probly/method/cast/__init__.py
@@ -1,0 +1,7 @@
+"""No-op predictor casting method."""
+
+from __future__ import annotations
+
+from ._common import cast
+
+__all__ = ["cast"]

--- a/src/probly/method/cast/_common.py
+++ b/src/probly/method/cast/_common.py
@@ -1,0 +1,20 @@
+"""Shared no-op predictor casting implementation."""
+
+from __future__ import annotations
+
+from probly.method.method import predictor_transformation
+from probly.predictor import Predictor
+
+
+@predictor_transformation(permitted_predictor_types=None, preserve_predictor_type=True)
+def cast[T: Predictor](base: T) -> T:
+    """Return a predictor unchanged while optionally registering its predictor type.
+
+    Args:
+        base: Predictor to return unchanged.
+
+    Returns:
+        The unchanged predictor. If ``predictor_type`` is passed to this method,
+        the returned predictor is registered as that type.
+    """
+    return base

--- a/src/probly/quantification/measure/distribution/_common.py
+++ b/src/probly/quantification/measure/distribution/_common.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Literal
 
 from flextype import flexdispatch
-from probly.representation.sample._common import Sample
+from probly.quantification._quantification import measure
+from probly.representation.distribution import CategoricalDistribution
+from probly.representation.sample import Sample
 
 if TYPE_CHECKING:
     from probly.representation.array_like import ArrayLike
@@ -14,6 +16,7 @@ if TYPE_CHECKING:
 type LogBase = float | Literal["normalize"] | None
 
 
+@measure.register(CategoricalDistribution)
 @flexdispatch
 def entropy(distribution: Distribution, base: LogBase = None) -> ArrayLike:
     """Compute the entropy of a distribution."""

--- a/src/probly/train/calibration/torch.py
+++ b/src/probly/train/calibration/torch.py
@@ -99,50 +99,38 @@ class LabelRelaxationLoss(nn.Module):
         return loss.mean()
 
 
-class LabelSmoothingLoss(nn.Module):
-    """Label smoothing loss for classification logits.
+class LabelSmoothingLoss(nn.CrossEntropyLoss):
+    """Cross-entropy loss with label smoothing.
 
-    This loss uses the same smoothing convention as
-    :class:`torch.nn.CrossEntropyLoss`: each class receives ``epsilon / num_classes``
-    probability mass, and the target class receives the remaining ``1 - epsilon``.
+    This is a thin wrapper around :class:`torch.nn.CrossEntropyLoss` that exposes
+    PyTorch's ``label_smoothing`` parameter as ``epsilon``.
 
     Attributes:
         epsilon: Amount of probability mass to smooth away from the one-hot target.
     """
 
-    def __init__(self, epsilon: float = 0.1) -> None:
+    def __init__(
+        self,
+        epsilon: float = 0.1,
+        weight: torch.Tensor | None = None,
+        ignore_index: int = -100,
+        reduction: str = "mean",
+    ) -> None:
         """Initializes an instance of the LabelSmoothingLoss class.
 
         Args:
             epsilon: Amount of probability mass to smooth away from the one-hot target.
-
-        Raises:
-            ValueError: If ``epsilon`` is outside the interval ``[0, 1]``.
+            weight: Optional manual rescaling weight for each class.
+            ignore_index: Target value ignored by the loss.
+            reduction: Reduction applied to the output. One of ``"none"``, ``"mean"``, or ``"sum"``.
         """
-        super().__init__()
-        if not 0 <= epsilon <= 1:
-            msg = f"epsilon must be between 0 and 1, got {epsilon}"
-            raise ValueError(msg)
+        super().__init__(
+            weight=weight,
+            ignore_index=ignore_index,
+            reduction=reduction,
+            label_smoothing=epsilon,
+        )
         self.epsilon = epsilon
-
-    def forward(self, inputs: torch.Tensor, targets: torch.Tensor) -> torch.Tensor:
-        """Forward pass of the label smoothing loss.
-
-        Args:
-            inputs: torch.Tensor of size (n_instances, n_classes).
-            targets: torch.Tensor of size (n_instances,).
-
-        Returns:
-            loss: torch.Tensor, mean loss value.
-        """
-        num_classes = inputs.shape[1]
-        log_probs = F.log_softmax(inputs, dim=1)
-        smooth = self.epsilon / num_classes
-        target_prob = 1 - self.epsilon + smooth
-        with torch.no_grad():
-            targets_smooth = torch.full_like(log_probs, smooth)
-            targets_smooth.scatter_(1, targets.unsqueeze(1), target_prob)
-        return -(targets_smooth * log_probs).sum(dim=1).mean()
 
 
 class FocalLoss(nn.Module):

--- a/src/probly/train/calibration/torch.py
+++ b/src/probly/train/calibration/torch.py
@@ -99,6 +99,52 @@ class LabelRelaxationLoss(nn.Module):
         return loss.mean()
 
 
+class LabelSmoothingLoss(nn.Module):
+    """Label smoothing loss for classification logits.
+
+    This loss uses the same smoothing convention as
+    :class:`torch.nn.CrossEntropyLoss`: each class receives ``epsilon / num_classes``
+    probability mass, and the target class receives the remaining ``1 - epsilon``.
+
+    Attributes:
+        epsilon: Amount of probability mass to smooth away from the one-hot target.
+    """
+
+    def __init__(self, epsilon: float = 0.1) -> None:
+        """Initializes an instance of the LabelSmoothingLoss class.
+
+        Args:
+            epsilon: Amount of probability mass to smooth away from the one-hot target.
+
+        Raises:
+            ValueError: If ``epsilon`` is outside the interval ``[0, 1]``.
+        """
+        super().__init__()
+        if not 0 <= epsilon <= 1:
+            msg = f"epsilon must be between 0 and 1, got {epsilon}"
+            raise ValueError(msg)
+        self.epsilon = epsilon
+
+    def forward(self, inputs: torch.Tensor, targets: torch.Tensor) -> torch.Tensor:
+        """Forward pass of the label smoothing loss.
+
+        Args:
+            inputs: torch.Tensor of size (n_instances, n_classes).
+            targets: torch.Tensor of size (n_instances,).
+
+        Returns:
+            loss: torch.Tensor, mean loss value.
+        """
+        num_classes = inputs.shape[1]
+        log_probs = F.log_softmax(inputs, dim=1)
+        smooth = self.epsilon / num_classes
+        target_prob = 1 - self.epsilon + smooth
+        with torch.no_grad():
+            targets_smooth = torch.full_like(log_probs, smooth)
+            targets_smooth.scatter_(1, targets.unsqueeze(1), target_prob)
+        return -(targets_smooth * log_probs).sum(dim=1).mean()
+
+
 class FocalLoss(nn.Module):
     """Focal Loss based on :cite:`linFocalLoss2017`.
 

--- a/src/probly_benchmark/base.py
+++ b/src/probly_benchmark/base.py
@@ -1,0 +1,18 @@
+"""Benchmark-local base-model marker method."""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from probly.method.cast import cast
+from probly.predictor import Predictor
+
+
+@runtime_checkable
+class BasePredictor[**In, Out](Predictor[In, Out], Protocol, structural_checking=False):
+    """Benchmark marker for an unmodified base predictor."""
+
+
+base = BasePredictor.register_factory(cast)
+
+__all__ = ["BasePredictor", "base"]

--- a/src/probly_benchmark/builders.py
+++ b/src/probly_benchmark/builders.py
@@ -39,6 +39,7 @@ from probly.method.natural_posterior_network import natural_posterior_network
 from probly.method.posterior_network import posterior_network
 from probly.method.subensemble import subensemble
 from probly_benchmark import models
+from probly_benchmark.base import base
 
 if TYPE_CHECKING:
     from torch.utils.data import DataLoader
@@ -47,6 +48,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 METHODS = {
+    "base": base,
     "batchensemble": batchensemble,
     "bayesian": bayesian,
     "dare": dare,

--- a/src/probly_benchmark/calibrate.py
+++ b/src/probly_benchmark/calibrate.py
@@ -1,0 +1,150 @@
+"""Post-hoc calibration script for benchmark models."""
+
+from __future__ import annotations
+
+import pathlib
+import tempfile
+from typing import Any, cast
+
+import hydra
+from omegaconf import DictConfig, OmegaConf
+import torch
+from torch.nn import functional as F
+import wandb
+import wandb.util
+
+from probly.train.calibration.torch import ExpectedCalibrationError
+from probly_benchmark import calibration, data, utils
+from probly_benchmark.paths import CHECKPOINT_PATH
+
+
+def _log_artifact_file(path: pathlib.Path, artifact_name: str, metadata: dict[str, Any]) -> None:
+    """Log a checkpoint file as a wandb model artifact."""
+    artifact = wandb.Artifact(name=artifact_name, type="model", metadata=metadata)
+    artifact.add_file(str(path))
+    wandb.log_artifact(artifact)
+
+
+def _classification_metrics(logits: torch.Tensor, targets: torch.Tensor) -> dict[str, float]:
+    """Compute calibration metrics from logits and class labels."""
+    targets = targets.long()
+    probs = torch.softmax(logits, dim=1)
+    return {
+        "val_nll": float(F.cross_entropy(logits, targets).item()),
+        "val_ece": float(ExpectedCalibrationError()(probs, targets).item()),
+    }
+
+
+def _save_calibrated_artifact(
+    logit_calibrator: torch.nn.Module,
+    cfg: DictConfig,
+    metrics: dict[str, float],
+    source_run_id: str,
+) -> None:
+    """Save and log the calibration-only checkpoint artifact."""
+    metadata = cast("dict[str, Any]", OmegaConf.to_container(cfg, resolve=True, throw_on_missing=True))
+    checkpoint = {
+        "artifact_type": calibration.CALIBRATION_ARTIFACT_TYPE,
+        calibration.CALIBRATION_STATE_DICT_KEY: logit_calibrator.state_dict(),
+        "config": metadata,
+        "metrics": metrics,
+        calibration.SOURCE_ARTIFACT_KEY: utils.resolve_artifact_name(cfg, include_calibration=False),
+        calibration.SOURCE_RUN_ID_KEY: source_run_id,
+    }
+    artifact_name = utils.resolve_artifact_name(cfg)
+
+    if cfg.save_to_disk:
+        path = pathlib.Path(CHECKPOINT_PATH).joinpath(f"{artifact_name}.pt")
+        torch.save(checkpoint, path)
+        _log_artifact_file(path, artifact_name, metadata)
+    else:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = pathlib.Path(tmp).joinpath(f"{artifact_name}.pt")
+            torch.save(checkpoint, path)
+            _log_artifact_file(path, artifact_name, metadata)
+
+
+@hydra.main(version_base=None, config_path="configs/", config_name="calibrate")
+def main(cfg: DictConfig) -> None:
+    """Run post-hoc calibration for a trained benchmark model."""
+    print("=== Calibration configuration ===")
+    print(OmegaConf.to_yaml(cfg))
+
+    calibration.validate_calibration_config(cfg, allow_none=False)
+    seed = cfg.get("seed", None)
+    utils.set_seed(seed)
+
+    run_id = wandb.util.generate_id()
+    loss_suffix = utils.supervised_loss_name_suffix(cfg)
+    calibration_suffix = utils.calibration_name_suffix(cfg)
+    run_name = f"{cfg.method.name}_{cfg.base_model}_{cfg.dataset}{loss_suffix}{calibration_suffix}_{run_id}"
+    run = wandb.init(
+        id=run_id,
+        name=run_name,
+        entity=cfg.wandb.get("entity", None),
+        project=cfg.wandb.project,
+        config=OmegaConf.to_container(cfg, resolve=True, throw_on_missing=True),  # ty: ignore
+        mode="online" if cfg.wandb.enabled else "disabled",
+        save_code=True,
+    )
+    run.config.update({"seed": seed})
+
+    device = utils.get_device(cfg.get("device", None))
+    print(f"Running on device: {device}")
+
+    source_artifact = utils.resolve_artifact_name(cfg, include_calibration=False)
+    model, _, source_run_id = utils.load_model_from_wandb(
+        source_artifact,
+        cfg.wandb.entity,
+        cfg.wandb.project,
+        device,
+    )
+    print(f"Loaded model {source_artifact} from wandb run: {source_run_id}")
+
+    if cfg.val_split <= 0:
+        msg = "Post-hoc calibration requires `val_split > 0` so validation data is available."
+        raise ValueError(msg)
+
+    loaders = data.get_data_train(
+        cfg.dataset,
+        seed,
+        val_split=cfg.val_split,
+        cal_split=cfg.get("cal_split", 0.0),
+        batch_size=cfg.batch_size,
+        num_workers=cfg.num_workers,
+        pin_memory=cfg.pin_memory,
+        persistent_workers=cfg.persistent_workers,
+        prefetch_factor=cfg.get("prefetch_factor", 4),
+        shuffle=False,
+    )
+    val_loader = loaders.validation
+    if val_loader is None:
+        msg = "Post-hoc calibration requires a validation loader; set `val_split > 0`."
+        raise ValueError(msg)
+
+    logits, targets = utils.collect_outputs_targets_raw(model, val_loader, device, cfg.get("amp", False))
+    metrics_before = _classification_metrics(logits, targets)
+
+    logit_calibrator = calibration.fit_logit_calibrator(cfg, logits, targets)
+    calibrated_logits = calibration.predict_calibrated_logits(logit_calibrator, logits)
+    metrics = _classification_metrics(calibrated_logits, targets)
+    metrics.update(calibration.extract_calibration_metrics(cfg, logit_calibrator))
+
+    log_metrics = {
+        "calibration/val_nll_before": metrics_before["val_nll"],
+        "calibration/val_ece_before": metrics_before["val_ece"],
+        "calibration/val_nll": metrics["val_nll"],
+        "calibration/val_ece": metrics["val_ece"],
+    }
+    for key, value in metrics.items():
+        if key not in {"val_nll", "val_ece"}:
+            log_metrics[f"calibration/{key}"] = value
+
+    run.summary.update(log_metrics)
+    run.log(data=log_metrics)
+    _save_calibrated_artifact(logit_calibrator, cfg, log_metrics, source_run_id)
+    run.finish()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/probly_benchmark/calibrate.py
+++ b/src/probly_benchmark/calibrate.py
@@ -101,8 +101,11 @@ def main(cfg: DictConfig) -> None:
     )
     print(f"Loaded model {source_artifact} from wandb run: {source_run_id}")
 
-    if cfg.val_split <= 0:
-        msg = "Post-hoc calibration requires `val_split > 0` so validation data is available."
+    use_val_as_cal = cfg.calibration.get("use-val-as-cal", True)
+    split_name = "val_split" if use_val_as_cal else "cal_split"
+    split_value = cfg.val_split if use_val_as_cal else cfg.get("cal_split", 0.0)
+    if split_value <= 0:
+        msg = f"Post-hoc calibration requires `{split_name} > 0` when `calibration.use-val-as-cal={use_val_as_cal}`."
         raise ValueError(msg)
 
     loaders = data.get_data_train(
@@ -117,12 +120,12 @@ def main(cfg: DictConfig) -> None:
         prefetch_factor=cfg.get("prefetch_factor", 4),
         shuffle=False,
     )
-    val_loader = loaders.validation
-    if val_loader is None:
-        msg = "Post-hoc calibration requires a validation loader; set `val_split > 0`."
+    cal_loader = loaders.validation if use_val_as_cal else loaders.calibration
+    if cal_loader is None:
+        msg = f"Post-hoc calibration requires `{split_name} > 0` when `calibration.use-val-as-cal={use_val_as_cal}`."
         raise ValueError(msg)
 
-    logits, targets = utils.collect_outputs_targets_raw(model, val_loader, device, cfg.get("amp", False))
+    logits, targets = utils.collect_outputs_targets_raw(model, cal_loader, device, cfg.get("amp", False))
     metrics_before = _classification_metrics(logits, targets)
 
     logit_calibrator = calibration.fit_logit_calibrator(cfg, logits, targets)

--- a/src/probly_benchmark/calibration.py
+++ b/src/probly_benchmark/calibration.py
@@ -8,8 +8,9 @@ from typing import TYPE_CHECKING, Any, cast
 import torch
 
 from probly.calibrator import calibrate
-from probly.method.calibration import temperature_scaling, torch_identity_logit_model
+from probly.method.calibration import temperature_scaling, torch_identity_logit_model, vector_scaling
 from probly.predictor import predict_raw
+from probly_benchmark import metadata
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping
@@ -33,17 +34,24 @@ class CalibrationSpec:
         supported_methods: Benchmark methods this calibration is currently allowed for.
         state_keys: Calibration state keys expected in saved calibration artifacts.
         metric_extractors: Functions that extract calibration-method-specific metrics.
+        requires_num_classes: Whether the transform needs the dataset class count.
     """
 
     transform: Callable[..., torch.nn.Module]
     supported_methods: frozenset[str]
     state_keys: frozenset[str]
     metric_extractors: tuple[Callable[[torch.nn.Module], dict[str, float]], ...] = ()
+    requires_num_classes: bool = False
 
 
 def _temperature_scaling(model: torch.nn.Module, **_: Any) -> torch.nn.Module:  # noqa: ANN401
     """Wrap a torch model with temperature scaling."""
     return cast("torch.nn.Module", temperature_scaling(model))
+
+
+def _vector_scaling(model: torch.nn.Module, num_classes: int, **_: Any) -> torch.nn.Module:  # noqa: ANN401
+    """Wrap a torch model with vector scaling."""
+    return cast("torch.nn.Module", vector_scaling(model, num_classes=num_classes))
 
 
 def _temperature_metrics(calibrator: torch.nn.Module) -> dict[str, float]:
@@ -54,12 +62,38 @@ def _temperature_metrics(calibrator: torch.nn.Module) -> dict[str, float]:
     return {"temperature": float(temperature.reshape(-1)[0].item())}
 
 
+def _tensor_summary(prefix: str, value: torch.Tensor | None) -> dict[str, float]:
+    """Return compact scalar summaries for vector calibration parameters."""
+    if not isinstance(value, torch.Tensor):
+        return {}
+    flat = value.detach().float().reshape(-1)
+    return {
+        f"{prefix}_mean": float(flat.mean().item()),
+        f"{prefix}_min": float(flat.min().item()),
+        f"{prefix}_max": float(flat.max().item()),
+    }
+
+
+def _vector_scaling_metrics(calibrator: torch.nn.Module) -> dict[str, float]:
+    """Extract compact vector scaling metrics from a fitted calibrator."""
+    metrics = _tensor_summary("temperature", getattr(calibrator, "temperature", None))
+    metrics.update(_tensor_summary("bias", getattr(calibrator, "bias", None)))
+    return metrics
+
+
 CALIBRATION_METHODS = {
     "temperature_scaling": CalibrationSpec(
         transform=_temperature_scaling,
         supported_methods=frozenset({"base"}),
         state_keys=frozenset({"_temperature", "_bias", "_is_calibrated"}),
         metric_extractors=(_temperature_metrics,),
+    ),
+    "vector_scaling": CalibrationSpec(
+        transform=_vector_scaling,
+        supported_methods=frozenset({"base"}),
+        state_keys=frozenset({"_temperature", "_bias", "_is_calibrated"}),
+        metric_extractors=(_vector_scaling_metrics,),
+        requires_num_classes=True,
     ),
 }
 """Registry of post-hoc calibration methods supported by the benchmark."""
@@ -118,13 +152,22 @@ def calibration_params(cfg: DictConfig | dict) -> dict[str, Any]:
     return dict(calibration_cfg.get("params") or {})
 
 
+def _calibration_transform_params(cfg: DictConfig | dict, spec: CalibrationSpec) -> dict[str, Any]:
+    """Return transform parameters, injecting benchmark-derived values where needed."""
+    params = calibration_params(cfg)
+    if spec.requires_num_classes and "num_classes" not in params:
+        dataset_name = str(cfg.get("dataset"))
+        params["num_classes"] = metadata.DATASETS[dataset_name].num_classes
+    return params
+
+
 def apply_calibration(model: torch.nn.Module, cfg: DictConfig | dict) -> torch.nn.Module:
     """Wrap a model with the configured calibration method."""
     name = get_calibration_name(cfg)
     if name == DEFAULT_CALIBRATION:
         return model
     spec = get_calibration_spec(cfg)
-    return spec.transform(model, **calibration_params(cfg))
+    return spec.transform(model, **_calibration_transform_params(cfg, spec))
 
 
 def build_logit_calibrator(cfg: DictConfig | dict) -> torch.nn.Module:

--- a/src/probly_benchmark/calibration.py
+++ b/src/probly_benchmark/calibration.py
@@ -1,0 +1,181 @@
+"""Benchmark post-hoc calibration registry."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, cast
+
+import torch
+
+from probly.calibrator import calibrate
+from probly.method.calibration import temperature_scaling, torch_identity_logit_model
+from probly.predictor import predict_raw
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
+
+    from omegaconf import DictConfig
+
+
+DEFAULT_CALIBRATION = "none"
+CALIBRATION_ARTIFACT_TYPE = "post_hoc_calibration"
+CALIBRATION_STATE_DICT_KEY = "calibration_state_dict"
+SOURCE_ARTIFACT_KEY = "source_artifact"
+SOURCE_RUN_ID_KEY = "source_run_id"
+
+
+@dataclass(frozen=True)
+class CalibrationSpec:
+    """Benchmark metadata for a post-hoc calibration method.
+
+    Attributes:
+        transform: Function that wraps an uncalibrated model with a calibrator.
+        supported_methods: Benchmark methods this calibration is currently allowed for.
+        state_keys: Calibration state keys expected in saved calibration artifacts.
+        metric_extractors: Functions that extract calibration-method-specific metrics.
+    """
+
+    transform: Callable[..., torch.nn.Module]
+    supported_methods: frozenset[str]
+    state_keys: frozenset[str]
+    metric_extractors: tuple[Callable[[torch.nn.Module], dict[str, float]], ...] = ()
+
+
+def _temperature_scaling(model: torch.nn.Module, **_: Any) -> torch.nn.Module:  # noqa: ANN401
+    """Wrap a torch model with temperature scaling."""
+    return cast("torch.nn.Module", temperature_scaling(model))
+
+
+def _temperature_metrics(calibrator: torch.nn.Module) -> dict[str, float]:
+    """Extract scalar temperature scaling metrics from a fitted calibrator."""
+    temperature = getattr(calibrator, "temperature", None)
+    if not isinstance(temperature, torch.Tensor):
+        return {}
+    return {"temperature": float(temperature.reshape(-1)[0].item())}
+
+
+CALIBRATION_METHODS = {
+    "temperature_scaling": CalibrationSpec(
+        transform=_temperature_scaling,
+        supported_methods=frozenset({"base"}),
+        state_keys=frozenset({"_temperature", "_bias", "_is_calibrated"}),
+        metric_extractors=(_temperature_metrics,),
+    ),
+}
+"""Registry of post-hoc calibration methods supported by the benchmark."""
+
+
+def get_calibration_name(cfg: DictConfig | dict) -> str:
+    """Return the configured post-hoc calibration name."""
+    calibration = cfg.get("calibration", None)
+    if not calibration:
+        return DEFAULT_CALIBRATION
+    return str(calibration.get("name", DEFAULT_CALIBRATION)).lower()
+
+
+def validate_calibration_config(cfg: DictConfig | dict, *, allow_none: bool = True) -> None:
+    """Validate that the configured calibration is supported for the benchmark method."""
+    name = get_calibration_name(cfg)
+    if name == DEFAULT_CALIBRATION:
+        if allow_none:
+            return
+        msg = "calibration=none cannot be used by calibrate.py; choose a calibration method."
+        raise ValueError(msg)
+
+    spec = CALIBRATION_METHODS.get(name)
+    if spec is None:
+        supported = ", ".join(sorted(CALIBRATION_METHODS))
+        msg = f"Unknown calibration method {name!r}; supported calibration methods: {supported}."
+        raise ValueError(msg)
+
+    method_name = str(cfg.get("method", {}).get("name"))
+    if method_name not in spec.supported_methods:
+        supported_methods = ", ".join(sorted(spec.supported_methods))
+        msg = (
+            f"calibration.name={name!r} is only supported for benchmark methods "
+            f"({supported_methods}); got method={method_name!r}."
+        )
+        raise ValueError(msg)
+
+
+def get_calibration_spec(cfg: DictConfig | dict) -> CalibrationSpec:
+    """Return the configured calibration spec."""
+    name = get_calibration_name(cfg)
+    if name == DEFAULT_CALIBRATION:
+        msg = "calibration=none has no CalibrationSpec."
+        raise ValueError(msg)
+    spec = CALIBRATION_METHODS.get(name)
+    if spec is None:
+        supported = ", ".join(sorted(CALIBRATION_METHODS))
+        msg = f"Unknown calibration method {name!r}; supported calibration methods: {supported}."
+        raise ValueError(msg)
+    return spec
+
+
+def calibration_params(cfg: DictConfig | dict) -> dict[str, Any]:
+    """Return calibration method parameters as a plain dictionary."""
+    calibration_cfg = cfg.get("calibration", {})
+    return dict(calibration_cfg.get("params") or {})
+
+
+def apply_calibration(model: torch.nn.Module, cfg: DictConfig | dict) -> torch.nn.Module:
+    """Wrap a model with the configured calibration method."""
+    name = get_calibration_name(cfg)
+    if name == DEFAULT_CALIBRATION:
+        return model
+    spec = get_calibration_spec(cfg)
+    return spec.transform(model, **calibration_params(cfg))
+
+
+def build_logit_calibrator(cfg: DictConfig | dict) -> torch.nn.Module:
+    """Build a calibrator around an identity logit model for direct logit fitting."""
+    return apply_calibration(torch_identity_logit_model(), cfg)
+
+
+def fit_logit_calibrator(
+    cfg: DictConfig | dict,
+    logits: torch.Tensor,
+    targets: torch.Tensor,
+) -> torch.nn.Module:
+    """Fit the configured calibration method directly on logits and labels."""
+    logit_calibrator = build_logit_calibrator(cfg)
+    calibrate(logit_calibrator, targets, logits)
+    return logit_calibrator
+
+
+def predict_calibrated_logits(calibrator: torch.nn.Module, logits: torch.Tensor) -> torch.Tensor:
+    """Apply a fitted logit calibrator to logits."""
+    calibrated_logits = predict_raw(calibrator, logits)
+    if not isinstance(calibrated_logits, torch.Tensor):
+        msg = f"Expected calibrated logits to be a torch.Tensor, got {type(calibrated_logits)}."
+        raise TypeError(msg)
+    return calibrated_logits
+
+
+def extract_calibration_metrics(cfg: DictConfig | dict, calibrator: torch.nn.Module) -> dict[str, float]:
+    """Extract calibration-method-specific metrics from a fitted calibrator."""
+    metrics: dict[str, float] = {}
+    for extractor in get_calibration_spec(cfg).metric_extractors:
+        metrics.update(extractor(calibrator))
+    return metrics
+
+
+def load_calibration_state(
+    model: torch.nn.Module,
+    cfg: DictConfig | dict,
+    state_dict: Mapping[str, Any],
+) -> torch.nn.Module:
+    """Load calibration-only state into a calibrated model wrapper."""
+    spec = get_calibration_spec(cfg)
+    missing_state_keys = spec.state_keys.difference(state_dict)
+    if missing_state_keys:
+        missing = ", ".join(sorted(missing_state_keys))
+        msg = f"Calibration artifact is missing required state keys: {missing}."
+        raise RuntimeError(msg)
+
+    load_result = model.load_state_dict(state_dict, strict=False)
+    if load_result.unexpected_keys:
+        unexpected = ", ".join(load_result.unexpected_keys)
+        msg = f"Calibration artifact contains unexpected state keys: {unexpected}."
+        raise RuntimeError(msg)
+    return model

--- a/src/probly_benchmark/configs/calibrate.yaml
+++ b/src/probly_benchmark/configs/calibrate.yaml
@@ -2,6 +2,7 @@ defaults:
   - _self_
   - supervised_loss: cross_entropy
   - calibration: temperature_scaling
+  - conformal: none
   - recipe: ???
   - method: ???
 

--- a/src/probly_benchmark/configs/calibrate.yaml
+++ b/src/probly_benchmark/configs/calibrate.yaml
@@ -1,0 +1,17 @@
+defaults:
+  - _self_
+  - supervised_loss: cross_entropy
+  - calibration: temperature_scaling
+  - recipe: ???
+  - method: ???
+
+seed: 1
+wandb:
+  enabled: true
+  entity: "probly"
+  project: "test"
+
+# models will always be saved in wandb, but this option controls whether they are also saved to disk
+save_to_disk: false
+
+amp: true

--- a/src/probly_benchmark/configs/calibration/none.yaml
+++ b/src/probly_benchmark/configs/calibration/none.yaml
@@ -1,3 +1,4 @@
 # @package calibration
 name: "none"
+use-val-as-cal: true
 params: {}

--- a/src/probly_benchmark/configs/calibration/none.yaml
+++ b/src/probly_benchmark/configs/calibration/none.yaml
@@ -1,0 +1,3 @@
+# @package calibration
+name: "none"
+params: {}

--- a/src/probly_benchmark/configs/calibration/temperature_scaling.yaml
+++ b/src/probly_benchmark/configs/calibration/temperature_scaling.yaml
@@ -1,0 +1,3 @@
+# @package calibration
+name: "temperature_scaling"
+params: {}

--- a/src/probly_benchmark/configs/calibration/temperature_scaling.yaml
+++ b/src/probly_benchmark/configs/calibration/temperature_scaling.yaml
@@ -1,3 +1,4 @@
 # @package calibration
 name: "temperature_scaling"
+use-val-as-cal: true
 params: {}

--- a/src/probly_benchmark/configs/calibration/vector_scaling.yaml
+++ b/src/probly_benchmark/configs/calibration/vector_scaling.yaml
@@ -1,0 +1,4 @@
+# @package calibration
+name: "vector_scaling"
+use-val-as-cal: true
+params: {}

--- a/src/probly_benchmark/configs/conformal/lac.yaml
+++ b/src/probly_benchmark/configs/conformal/lac.yaml
@@ -1,0 +1,5 @@
+# @package conformal
+name: "conformal_lac"
+alpha: 0.1
+use-val-as-cal: true
+params: {}

--- a/src/probly_benchmark/configs/conformal/none.yaml
+++ b/src/probly_benchmark/configs/conformal/none.yaml
@@ -1,3 +1,3 @@
-# @package calibration
+# @package conformal
 name: "none"
 params: {}

--- a/src/probly_benchmark/configs/conformalize.yaml
+++ b/src/probly_benchmark/configs/conformalize.yaml
@@ -2,17 +2,17 @@ defaults:
   - _self_
   - supervised_loss: cross_entropy
   - calibration: none
-  - conformal: none
+  - conformal: lac
   - recipe: ???
   - method: ???
 
-dataset: "cifar10"
-ood_dataset: "cifar100"
-base_model: "resnet18"
 seed: 1
-batch_size: 512
-amp: true
 wandb:
   enabled: true
   entity: "probly"
   project: "test"
+
+# models will always be saved in wandb, but this option controls whether they are also saved to disk
+save_to_disk: false
+
+amp: true

--- a/src/probly_benchmark/configs/method/base.yaml
+++ b/src/probly_benchmark/configs/method/base.yaml
@@ -1,0 +1,2 @@
+# @package method
+name: "base"

--- a/src/probly_benchmark/configs/ood_detection.yaml
+++ b/src/probly_benchmark/configs/ood_detection.yaml
@@ -1,6 +1,7 @@
 defaults:
   - _self_
   - supervised_loss: cross_entropy
+  - calibration: none
   - recipe: ???
   - method: ???
 

--- a/src/probly_benchmark/configs/ood_detection.yaml
+++ b/src/probly_benchmark/configs/ood_detection.yaml
@@ -1,5 +1,6 @@
 defaults:
   - _self_
+  - supervised_loss: cross_entropy
   - recipe: ???
   - method: ???
 

--- a/src/probly_benchmark/configs/selective_prediction.yaml
+++ b/src/probly_benchmark/configs/selective_prediction.yaml
@@ -1,6 +1,7 @@
 defaults:
   - _self_
   - supervised_loss: cross_entropy
+  - calibration: none
   - recipe: ???
   - method: ???
 

--- a/src/probly_benchmark/configs/selective_prediction.yaml
+++ b/src/probly_benchmark/configs/selective_prediction.yaml
@@ -1,5 +1,6 @@
 defaults:
   - _self_
+  - supervised_loss: cross_entropy
   - recipe: ???
   - method: ???
 

--- a/src/probly_benchmark/configs/selective_prediction.yaml
+++ b/src/probly_benchmark/configs/selective_prediction.yaml
@@ -2,6 +2,7 @@ defaults:
   - _self_
   - supervised_loss: cross_entropy
   - calibration: none
+  - conformal: none
   - recipe: ???
   - method: ???
 

--- a/src/probly_benchmark/configs/supervised_loss/cross_entropy.yaml
+++ b/src/probly_benchmark/configs/supervised_loss/cross_entropy.yaml
@@ -1,0 +1,3 @@
+# @package supervised_loss
+name: "cross_entropy"
+params: {}

--- a/src/probly_benchmark/configs/supervised_loss/label_relaxation.yaml
+++ b/src/probly_benchmark/configs/supervised_loss/label_relaxation.yaml
@@ -1,0 +1,4 @@
+# @package supervised_loss
+name: "label_relaxation"
+params:
+  alpha: 0.1

--- a/src/probly_benchmark/configs/supervised_loss/label_smoothing.yaml
+++ b/src/probly_benchmark/configs/supervised_loss/label_smoothing.yaml
@@ -1,0 +1,4 @@
+# @package supervised_loss
+name: "label_smoothing"
+params:
+  epsilon: 0.1

--- a/src/probly_benchmark/configs/train.yaml
+++ b/src/probly_benchmark/configs/train.yaml
@@ -1,5 +1,6 @@
 defaults:
   - _self_
+  - supervised_loss: cross_entropy
   - method: ??? # user must specify a method.
   - recipe: ??? # user must specify a recipe.
 

--- a/src/probly_benchmark/configs/train.yaml
+++ b/src/probly_benchmark/configs/train.yaml
@@ -1,6 +1,7 @@
 defaults:
   - _self_
   - supervised_loss: cross_entropy
+  - conformal: none
   - method: ??? # user must specify a method.
   - recipe: ??? # user must specify a recipe.
 

--- a/src/probly_benchmark/conformal.py
+++ b/src/probly_benchmark/conformal.py
@@ -1,0 +1,186 @@
+"""Benchmark split-conformal registry."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, cast
+
+from probly.calibrator import calibrate
+from probly.method.calibration import torch_identity_logit_model
+from probly.method.conformal import conformal_lac
+from probly.predictor import predict
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
+
+    from omegaconf import DictConfig
+    import torch
+
+
+DEFAULT_CONFORMAL = "none"
+CONFORMAL_ARTIFACT_TYPE = "split_conformal"
+CONFORMAL_STATE_DICT_KEY = "conformal_state_dict"
+SOURCE_ARTIFACT_KEY = "source_artifact"
+SOURCE_RUN_ID_KEY = "source_run_id"
+
+
+@dataclass(frozen=True)
+class ConformalSpec:
+    """Benchmark metadata for a split-conformal method.
+
+    Attributes:
+        transform: Function that wraps a predictor with a conformal method.
+        supported_methods: Benchmark methods this conformal method is currently allowed for.
+        state_keys: Conformal state keys expected in saved conformal artifacts.
+        metric_extractors: Functions that extract conformal-method-specific metrics.
+    """
+
+    transform: Callable[..., torch.nn.Module]
+    supported_methods: frozenset[str]
+    state_keys: frozenset[str]
+    metric_extractors: tuple[Callable[[torch.nn.Module], dict[str, float]], ...] = ()
+
+
+def _conformal_lac(model: torch.nn.Module, **_: Any) -> torch.nn.Module:  # noqa: ANN401
+    """Wrap a torch model with LAC split-conformal prediction."""
+    return cast("torch.nn.Module", conformal_lac(model))
+
+
+def _quantile_metrics(conformalizer: torch.nn.Module) -> dict[str, float]:
+    """Extract the calibrated conformal quantile."""
+    quantile = getattr(conformalizer, "conformal_quantile", None)
+    if quantile is None:
+        return {}
+    return {"quantile": float(quantile)}
+
+
+CONFORMAL_METHODS = {
+    "conformal_lac": ConformalSpec(
+        transform=_conformal_lac,
+        supported_methods=frozenset({"base"}),
+        state_keys=frozenset({"_conformal_quantile"}),
+        metric_extractors=(_quantile_metrics,),
+    ),
+}
+"""Registry of split-conformal methods supported by the benchmark."""
+
+
+def get_conformal_name(cfg: DictConfig | dict) -> str:
+    """Return the configured conformal method name."""
+    conformal = cfg.get("conformal", None)
+    if not conformal:
+        return DEFAULT_CONFORMAL
+    return str(conformal.get("name", DEFAULT_CONFORMAL)).lower()
+
+
+def validate_conformal_config(cfg: DictConfig | dict, *, allow_none: bool = True) -> None:
+    """Validate that the configured conformal method is supported for the benchmark method."""
+    name = get_conformal_name(cfg)
+    if name == DEFAULT_CONFORMAL:
+        if allow_none:
+            return
+        msg = "conformal=none cannot be used by conformalize.py; choose a split-conformal method."
+        raise ValueError(msg)
+
+    spec = CONFORMAL_METHODS.get(name)
+    if spec is None:
+        supported = ", ".join(sorted(CONFORMAL_METHODS))
+        msg = f"Unknown conformal method {name!r}; supported conformal methods: {supported}."
+        raise ValueError(msg)
+
+    method_name = str(cfg.get("method", {}).get("name"))
+    if method_name not in spec.supported_methods:
+        supported_methods = ", ".join(sorted(spec.supported_methods))
+        msg = (
+            f"conformal.name={name!r} is only supported for benchmark methods "
+            f"({supported_methods}); got method={method_name!r}."
+        )
+        raise ValueError(msg)
+
+
+def get_conformal_spec(cfg: DictConfig | dict) -> ConformalSpec:
+    """Return the configured conformal spec."""
+    name = get_conformal_name(cfg)
+    if name == DEFAULT_CONFORMAL:
+        msg = "conformal=none has no ConformalSpec."
+        raise ValueError(msg)
+    spec = CONFORMAL_METHODS.get(name)
+    if spec is None:
+        supported = ", ".join(sorted(CONFORMAL_METHODS))
+        msg = f"Unknown conformal method {name!r}; supported conformal methods: {supported}."
+        raise ValueError(msg)
+    return spec
+
+
+def conformal_params(cfg: DictConfig | dict) -> dict[str, Any]:
+    """Return conformal method constructor parameters as a plain dictionary."""
+    conformal_cfg = cfg.get("conformal", {})
+    return dict(conformal_cfg.get("params") or {})
+
+
+def conformal_alpha(cfg: DictConfig | dict) -> float:
+    """Return the split-conformal miscoverage level."""
+    conformal_cfg = cfg.get("conformal", {})
+    if "alpha" not in conformal_cfg:
+        msg = "Split-conformal methods require `conformal.alpha`."
+        raise ValueError(msg)
+    return float(conformal_cfg["alpha"])
+
+
+def apply_conformal(model: torch.nn.Module, cfg: DictConfig | dict) -> torch.nn.Module:
+    """Wrap a model with the configured conformal method."""
+    name = get_conformal_name(cfg)
+    if name == DEFAULT_CONFORMAL:
+        return model
+    spec = get_conformal_spec(cfg)
+    return spec.transform(model, **conformal_params(cfg))
+
+
+def build_logit_conformalizer(cfg: DictConfig | dict) -> torch.nn.Module:
+    """Build a conformal wrapper around an identity logit model for direct logit fitting."""
+    return apply_conformal(torch_identity_logit_model(), cfg)
+
+
+def fit_logit_conformalizer(
+    cfg: DictConfig | dict,
+    logits: torch.Tensor,
+    targets: torch.Tensor,
+) -> torch.nn.Module:
+    """Fit the configured conformal method directly on logits and labels."""
+    logit_conformalizer = build_logit_conformalizer(cfg)
+    calibrate(logit_conformalizer, conformal_alpha(cfg), targets, logits)
+    return logit_conformalizer
+
+
+def predict_conformal_sets(conformalizer: torch.nn.Module, logits: torch.Tensor) -> Any:  # noqa: ANN401
+    """Apply a fitted logit conformalizer to logits."""
+    return predict(conformalizer, logits)
+
+
+def extract_conformal_metrics(cfg: DictConfig | dict, conformalizer: torch.nn.Module) -> dict[str, float]:
+    """Extract conformal-method-specific metrics from a fitted conformalizer."""
+    metrics: dict[str, float] = {}
+    for extractor in get_conformal_spec(cfg).metric_extractors:
+        metrics.update(extractor(conformalizer))
+    return metrics
+
+
+def load_conformal_state(
+    model: torch.nn.Module,
+    cfg: DictConfig | dict,
+    state_dict: Mapping[str, Any],
+) -> torch.nn.Module:
+    """Load conformal-only state into a conformal model wrapper."""
+    spec = get_conformal_spec(cfg)
+    missing_state_keys = spec.state_keys.difference(state_dict)
+    if missing_state_keys:
+        missing = ", ".join(sorted(missing_state_keys))
+        msg = f"Conformal artifact is missing required state keys: {missing}."
+        raise RuntimeError(msg)
+
+    load_result = model.load_state_dict(state_dict, strict=False)
+    if load_result.unexpected_keys:
+        unexpected = ", ".join(load_result.unexpected_keys)
+        msg = f"Conformal artifact contains unexpected state keys: {unexpected}."
+        raise RuntimeError(msg)
+    return model

--- a/src/probly_benchmark/conformalize.py
+++ b/src/probly_benchmark/conformalize.py
@@ -1,4 +1,4 @@
-"""Post-hoc calibration script for benchmark models."""
+"""Split-conformalization script for benchmark models."""
 
 from __future__ import annotations
 
@@ -9,11 +9,10 @@ from typing import Any, cast
 import hydra
 from omegaconf import DictConfig, OmegaConf
 import torch
-from torch.nn import functional as F
 import wandb
 import wandb.util
 
-from probly.train.calibration.torch import ExpectedCalibrationError
+from probly.metrics import average_set_size, empirical_coverage_classification
 from probly_benchmark import calibration, conformal, data, utils
 from probly_benchmark.paths import CHECKPOINT_PATH
 
@@ -25,35 +24,22 @@ def _log_artifact_file(path: pathlib.Path, artifact_name: str, metadata: dict[st
     wandb.log_artifact(artifact)
 
 
-def _classification_metrics(logits: torch.Tensor, targets: torch.Tensor) -> dict[str, float]:
-    """Compute calibration metrics from logits and class labels."""
-    targets = targets.long()
-    probs = torch.softmax(logits, dim=1)
-    return {
-        "val_nll": float(F.cross_entropy(logits, targets).item()),
-        "val_ece": float(ExpectedCalibrationError()(probs, targets).item()),
-    }
-
-
-def _save_calibrated_artifact(
-    logit_calibrator: torch.nn.Module,
+def _save_conformal_artifact(
+    logit_conformalizer: torch.nn.Module,
     cfg: DictConfig,
     metrics: dict[str, float],
+    source_artifact: str,
     source_run_id: str,
 ) -> None:
-    """Save and log the calibration-only checkpoint artifact."""
+    """Save and log the conformal-only checkpoint artifact."""
     metadata = cast("dict[str, Any]", OmegaConf.to_container(cfg, resolve=True, throw_on_missing=True))
     checkpoint = {
-        "artifact_type": calibration.CALIBRATION_ARTIFACT_TYPE,
-        calibration.CALIBRATION_STATE_DICT_KEY: logit_calibrator.state_dict(),
+        "artifact_type": conformal.CONFORMAL_ARTIFACT_TYPE,
+        conformal.CONFORMAL_STATE_DICT_KEY: logit_conformalizer.state_dict(),
         "config": metadata,
         "metrics": metrics,
-        calibration.SOURCE_ARTIFACT_KEY: utils.resolve_artifact_name(
-            cfg,
-            include_calibration=False,
-            include_conformal=False,
-        ),
-        calibration.SOURCE_RUN_ID_KEY: source_run_id,
+        conformal.SOURCE_ARTIFACT_KEY: source_artifact,
+        conformal.SOURCE_RUN_ID_KEY: source_run_id,
     }
     artifact_name = utils.resolve_artifact_name(cfg)
 
@@ -69,30 +55,26 @@ def _save_calibrated_artifact(
 
 
 def _validate_selected_split(cfg: DictConfig) -> tuple[bool, str]:
-    """Validate and return the split selected for post-hoc calibration."""
-    use_val_as_cal = cfg.calibration.get("use-val-as-cal", True)
+    """Validate and return the split selected for conformal calibration."""
+    use_val_as_cal = cfg.conformal.get("use-val-as-cal", False)
     split_name = "val_split" if use_val_as_cal else "cal_split"
     split_value = cfg.val_split if use_val_as_cal else cfg.get("cal_split", 0.0)
     if split_value <= 0:
-        msg = f"Post-hoc calibration requires `{split_name} > 0` when `calibration.use-val-as-cal={use_val_as_cal}`."
+        msg = (
+            f"Split-conformal prediction requires `{split_name} > 0` when `conformal.use-val-as-cal={use_val_as_cal}`."
+        )
         raise ValueError(msg)
     return use_val_as_cal, split_name
 
 
-@hydra.main(version_base=None, config_path="configs/", config_name="calibrate")
+@hydra.main(version_base=None, config_path="configs/", config_name="conformalize")
 def main(cfg: DictConfig) -> None:
-    """Run post-hoc calibration for a trained benchmark model."""
-    print("=== Calibration configuration ===")
+    """Run split-conformalization for a trained benchmark model."""
+    print("=== Conformalization configuration ===")
     print(OmegaConf.to_yaml(cfg))
 
-    calibration.validate_calibration_config(cfg, allow_none=False)
-    conformal_name = conformal.get_conformal_name(cfg)
-    if conformal_name != conformal.DEFAULT_CONFORMAL:
-        msg = (
-            f"calibrate.py only supports conformal=none, got conformal.name={conformal_name!r}. "
-            "Apply split-conformal methods later with conformalize.py."
-        )
-        raise ValueError(msg)
+    calibration.validate_calibration_config(cfg)
+    conformal.validate_conformal_config(cfg, allow_none=False)
     use_val_as_cal, split_name = _validate_selected_split(cfg)
 
     seed = cfg.get("seed", None)
@@ -101,7 +83,10 @@ def main(cfg: DictConfig) -> None:
     run_id = wandb.util.generate_id()
     loss_suffix = utils.supervised_loss_name_suffix(cfg)
     calibration_suffix = utils.calibration_name_suffix(cfg)
-    run_name = f"{cfg.method.name}_{cfg.base_model}_{cfg.dataset}{loss_suffix}{calibration_suffix}_{run_id}"
+    conformal_suffix = utils.conformal_name_suffix(cfg)
+    run_name = (
+        f"{cfg.method.name}_{cfg.base_model}_{cfg.dataset}{loss_suffix}{calibration_suffix}{conformal_suffix}_{run_id}"
+    )
     run = wandb.init(
         id=run_id,
         name=run_name,
@@ -116,7 +101,7 @@ def main(cfg: DictConfig) -> None:
     device = utils.get_device(cfg.get("device", None))
     print(f"Running on device: {device}")
 
-    source_artifact = utils.resolve_artifact_name(cfg, include_calibration=False, include_conformal=False)
+    source_artifact = utils.resolve_artifact_name(cfg, include_conformal=False)
     model, _, source_run_id = utils.load_model_from_wandb(
         source_artifact,
         cfg.wandb.entity,
@@ -139,30 +124,25 @@ def main(cfg: DictConfig) -> None:
     )
     cal_loader = loaders.validation if use_val_as_cal else loaders.calibration
     if cal_loader is None:
-        msg = f"Post-hoc calibration requires `{split_name} > 0` when `calibration.use-val-as-cal={use_val_as_cal}`."
+        msg = (
+            f"Split-conformal prediction requires `{split_name} > 0` when `conformal.use-val-as-cal={use_val_as_cal}`."
+        )
         raise ValueError(msg)
 
     logits, targets = utils.collect_outputs_targets_raw(model, cal_loader, device, cfg.get("amp", False))
-    metrics_before = _classification_metrics(logits, targets)
+    logit_conformalizer = conformal.fit_logit_conformalizer(cfg, logits, targets)
+    conformal_sets = conformal.predict_conformal_sets(logit_conformalizer, logits)
 
-    logit_calibrator = calibration.fit_logit_calibrator(cfg, logits, targets)
-    calibrated_logits = calibration.predict_calibrated_logits(logit_calibrator, logits)
-    metrics = _classification_metrics(calibrated_logits, targets)
-    metrics.update(calibration.extract_calibration_metrics(cfg, logit_calibrator))
-
-    log_metrics = {
-        "calibration/val_nll_before": metrics_before["val_nll"],
-        "calibration/val_ece_before": metrics_before["val_ece"],
-        "calibration/val_nll": metrics["val_nll"],
-        "calibration/val_ece": metrics["val_ece"],
+    metrics = {
+        "coverage": float(empirical_coverage_classification(conformal_sets, targets)),
+        "average_set_size": float(average_set_size(conformal_sets)),
     }
-    for key, value in metrics.items():
-        if key not in {"val_nll", "val_ece"}:
-            log_metrics[f"calibration/{key}"] = value
+    metrics.update(conformal.extract_conformal_metrics(cfg, logit_conformalizer))
+    log_metrics = {f"conformal/{key}": value for key, value in metrics.items()}
 
     run.summary.update(log_metrics)
     run.log(data=log_metrics)
-    _save_calibrated_artifact(logit_calibrator, cfg, log_metrics, source_run_id)
+    _save_conformal_artifact(logit_conformalizer, cfg, log_metrics, source_artifact, source_run_id)
     run.finish()
 
 

--- a/src/probly_benchmark/ood_detection.py
+++ b/src/probly_benchmark/ood_detection.py
@@ -11,8 +11,7 @@ import wandb
 from probly.evaluation.ood import out_of_distribution_detection_auroc
 from probly.quantification import quantify
 from probly.representer import representer
-from probly_benchmark import data, utils
-from probly_benchmark.utils import load_model_from_wandb, resolve_artifact_name
+from probly_benchmark import calibration, data, utils
 
 
 @hydra.main(version_base=None, config_path="configs/", config_name="ood_detection")
@@ -25,9 +24,10 @@ def main(cfg: DictConfig) -> None:
     print(f"Running on device: {device}")
 
     utils.set_seed(cfg.seed)
+    calibration.validate_calibration_config(cfg)
 
-    artifact_name = resolve_artifact_name(cfg)
-    model, _, run_id = load_model_from_wandb(
+    artifact_name = utils.resolve_artifact_name(cfg)
+    model, _, run_id = utils.load_model_from_wandb(
         artifact_name,
         cfg.wandb.entity,
         cfg.wandb.project,

--- a/src/probly_benchmark/selective_prediction.py
+++ b/src/probly_benchmark/selective_prediction.py
@@ -12,8 +12,7 @@ from probly.evaluation.tasks import selective_prediction
 from probly.quantification import quantify
 from probly.representation._helpers import compute_mean_probs
 from probly.representer import representer
-from probly_benchmark import data, utils
-from probly_benchmark.utils import load_model_from_wandb, resolve_artifact_name
+from probly_benchmark import calibration, data, utils
 
 
 @hydra.main(version_base=None, config_path="configs/", config_name="selective_prediction")
@@ -26,9 +25,10 @@ def main(cfg: DictConfig) -> None:
     print(f"Running on device: {device}")
 
     utils.set_seed(cfg.seed)
+    calibration.validate_calibration_config(cfg)
 
-    artifact_name = resolve_artifact_name(cfg)
-    model, _, run_id = load_model_from_wandb(
+    artifact_name = utils.resolve_artifact_name(cfg)
+    model, _, run_id = utils.load_model_from_wandb(
         artifact_name,
         cfg.wandb.entity,
         cfg.wandb.project,

--- a/src/probly_benchmark/train.py
+++ b/src/probly_benchmark/train.py
@@ -74,6 +74,34 @@ def _get_state_dict(model: nn.Module | list[nn.Module]) -> dict | list[dict]:
     return model.state_dict()
 
 
+def _log_artifact_file(path: pathlib.Path, artifact_name: str, metadata: dict[str, Any]) -> None:
+    """Log a checkpoint file as a wandb model artifact."""
+    artifact = wandb.Artifact(name=artifact_name, type="model", metadata=metadata)
+    artifact.add_file(str(path))
+    wandb.log_artifact(artifact)
+
+
+def _save_checkpoint_artifact(model: nn.Module, cfg: DictConfig, test_metrics: dict[str, float]) -> None:
+    """Save and log the trained model checkpoint artifact."""
+    metadata = cast("dict[str, Any]", OmegaConf.to_container(cfg, resolve=True, throw_on_missing=True))
+    checkpoint = {
+        "model_state_dict": _get_state_dict(model),
+        "config": metadata,
+        "metrics": test_metrics,
+    }
+    artifact_name = utils.resolve_artifact_name(cfg)
+
+    if cfg.save_to_disk:
+        path = pathlib.Path(CHECKPOINT_PATH).joinpath(f"{artifact_name}.pt")
+        torch.save(checkpoint, path)
+        _log_artifact_file(path, artifact_name, metadata)
+    else:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = pathlib.Path(tmp).joinpath(f"{artifact_name}.pt")
+            torch.save(checkpoint, path)
+            _log_artifact_file(path, artifact_name, metadata)
+
+
 def get_optimizer(
     name: str,
     params: Iterable[nn.Parameter] | list[dict[str, Any]],
@@ -123,6 +151,48 @@ SCHEDULERS: dict[str, Callable[..., optim.lr_scheduler.LRScheduler] | None] = {
     "plateau": optim.lr_scheduler.ReduceLROnPlateau,
     "warmup_cosine": _make_warmup_cosine,
 }
+
+SUPERVISED_LOSS_METHODS = {
+    "batchensemble",
+    "credal_ensembling",
+    "credal_wrapper",
+    "dropconnect",
+    "dropout",
+    "efficient_credal_prediction",
+    "ensemble",
+    "het_nets",
+    "subensemble",
+}
+"""The set of method names that support non-default supervised losses."""
+
+
+def _validate_supervised_loss_config(cfg: DictConfig) -> None:
+    """Validate that non-default supervised losses are only used with supported methods."""
+    supervised_loss_name = utils.get_supervised_loss_name(cfg)
+    if supervised_loss_name == utils.DEFAULT_SUPERVISED_LOSS:
+        return
+    if cfg.method.name not in SUPERVISED_LOSS_METHODS:
+        supported = ", ".join(sorted(SUPERVISED_LOSS_METHODS))
+        msg = (
+            f"supervised_loss.name={supervised_loss_name!r} is only supported for CE-compatible methods "
+            f"({supported}); got method={cfg.method.name!r}."
+        )
+        raise ValueError(msg)
+
+
+def _build_train_kwargs(cfg: DictConfig) -> dict[str, Any]:
+    """Build keyword arguments forwarded to method-specific training and evaluation functions."""
+    train_kwargs: dict[str, Any] = (
+        OmegaConf.to_container(cfg.method.train, resolve=True) if cfg.method.get("train") else {}
+    )  # ty: ignore[invalid-assignment]
+    if cfg.method.name in SUPERVISED_LOSS_METHODS:
+        train_kwargs["supervised_loss"] = OmegaConf.to_container(cfg.supervised_loss, resolve=True)
+    return train_kwargs
+
+
+def _build_method_kwargs(cfg: DictConfig) -> dict[str, Any]:
+    """Build keyword arguments forwarded to the method constructor."""
+    return OmegaConf.to_container(cfg.method.params, resolve=True) if cfg.method.get("params") else {}  # ty: ignore
 
 
 def get_scheduler(
@@ -849,20 +919,23 @@ def _adjust_batch_size_for_method(cfg: DictConfig) -> None:
 
 
 @hydra.main(version_base=None, config_path="configs/", config_name="train")
-def main(cfg: DictConfig) -> None:  # noqa: PLR0915
+def main(cfg: DictConfig) -> None:
     """Run the training script."""
     _adjust_batch_size_for_method(cfg)
 
     print("=== Training configuration ===")
     print(OmegaConf.to_yaml(cfg))
 
+    _validate_supervised_loss_config(cfg)
+
     run_id = wandb.util.generate_id()
     seed = cfg.get("seed", None)
     utils.set_seed(seed)
 
+    run_name = f"{cfg.method.name}_{cfg.base_model}_{cfg.dataset}{utils.supervised_loss_name_suffix(cfg)}_{run_id}"
     run = wandb.init(
         id=run_id,
-        name=f"{cfg.method.name}_{cfg.base_model}_{cfg.dataset}_{run_id}",
+        name=run_name,
         entity=cfg.wandb.get("entity", None),
         project=cfg.wandb.project,
         config=OmegaConf.to_container(cfg, resolve=True, throw_on_missing=True),  # ty: ignore
@@ -892,12 +965,8 @@ def main(cfg: DictConfig) -> None:  # noqa: PLR0915
 
     num_classes = metadata.DATASETS[cfg.dataset].num_classes
 
-    method_kwargs: dict[str, Any] = (
-        OmegaConf.to_container(cfg.method.params, resolve=True) if cfg.method.get("params") else {}
-    )  # ty: ignore[invalid-assignment]
-    train_kwargs: dict[str, Any] = (
-        OmegaConf.to_container(cfg.method.train, resolve=True) if cfg.method.get("train") else {}
-    )  # ty: ignore[invalid-assignment]
+    method_kwargs = _build_method_kwargs(cfg)
+    train_kwargs = _build_train_kwargs(cfg)
 
     context = BuildContext(
         base_model_name=cfg.base_model,
@@ -930,37 +999,7 @@ def main(cfg: DictConfig) -> None:  # noqa: PLR0915
     run.summary.update(test_metrics)
     run.log(data=test_metrics)
 
-    checkpoint = {
-        "model_state_dict": _get_state_dict(model),
-        "config": OmegaConf.to_container(cfg, resolve=True, throw_on_missing=True),
-        "metrics": test_metrics,
-    }
-
-    artifact_name = f"{cfg.method.name}_{cfg.base_model}_{cfg.dataset}_{seed}"
-
-    if cfg.save_to_disk:
-        path = pathlib.Path(CHECKPOINT_PATH).joinpath(f"{artifact_name}.pt")
-        torch.save(checkpoint, path)
-
-        artifact = wandb.Artifact(
-            name=artifact_name,
-            type="model",
-            metadata=OmegaConf.to_container(cfg, resolve=True, throw_on_missing=True),  # ty: ignore
-        )
-        artifact.add_file(str(path))
-        wandb.log_artifact(artifact)
-    else:
-        with tempfile.TemporaryDirectory() as tmp:
-            path = pathlib.Path(tmp).joinpath(f"{artifact_name}.pt")
-            torch.save(checkpoint, path)
-
-            artifact = wandb.Artifact(
-                name=artifact_name,
-                type="model",
-                metadata=OmegaConf.to_container(cfg, resolve=True, throw_on_missing=True),  # ty: ignore
-            )
-            artifact.add_file(str(path))
-            wandb.log_artifact(artifact)
+    _save_checkpoint_artifact(model, cfg, test_metrics)
 
     run.finish()
 

--- a/src/probly_benchmark/train.py
+++ b/src/probly_benchmark/train.py
@@ -41,7 +41,7 @@ from probly.method.dare import DarePredictor
 from probly.method.ddu import DDUPredictor
 from probly.method.ensemble import EnsemblePredictor
 from probly.method.subensemble import SubensemblePredictor
-from probly_benchmark import data, metadata, utils
+from probly_benchmark import conformal, data, metadata, utils
 from probly_benchmark.builders import BuildContext, build_model
 from probly_benchmark.paths import CHECKPOINT_PATH
 from probly_benchmark.train_funcs import (
@@ -179,6 +179,19 @@ def _validate_supervised_loss_config(cfg: DictConfig) -> None:
             f"({supported}); got method={cfg.method.name!r}."
         )
         raise ValueError(msg)
+
+
+def _validate_conformal_config(cfg: DictConfig) -> None:
+    """Reject split-conformal methods during training."""
+    conformal_name = conformal.get_conformal_name(cfg)
+    if conformal_name == conformal.DEFAULT_CONFORMAL:
+        return
+    conformal.validate_conformal_config(cfg)
+    msg = (
+        f"conformal.name={conformal_name!r} is a split-conformal post-hoc method. "
+        "Train the base model first, then apply split-conformal prediction with conformalize.py."
+    )
+    raise ValueError(msg)
 
 
 def _build_train_kwargs(cfg: DictConfig) -> dict[str, Any]:
@@ -928,6 +941,7 @@ def main(cfg: DictConfig) -> None:
     print(OmegaConf.to_yaml(cfg))
 
     _validate_supervised_loss_config(cfg)
+    _validate_conformal_config(cfg)
 
     run_id = wandb.util.generate_id()
     seed = cfg.get("seed", None)

--- a/src/probly_benchmark/train.py
+++ b/src/probly_benchmark/train.py
@@ -153,6 +153,7 @@ SCHEDULERS: dict[str, Callable[..., optim.lr_scheduler.LRScheduler] | None] = {
 }
 
 SUPERVISED_LOSS_METHODS = {
+    "base",  # Special "method" for training a predictor without applying a method.
     "batchensemble",
     "credal_ensembling",
     "credal_wrapper",

--- a/src/probly_benchmark/train_funcs.py
+++ b/src/probly_benchmark/train_funcs.py
@@ -28,7 +28,7 @@ from probly.method.natural_posterior_network import NaturalPosteriorNetworkPredi
 from probly.method.posterior_network import PosteriorNetworkPredictor
 from probly.method.subensemble import SubensemblePredictor
 from probly.train.bayesian.torch import ELBOLoss, collect_kl_divergence
-from probly.train.calibration.torch import ExpectedCalibrationError, LabelRelaxationLoss
+from probly.train.calibration.torch import ExpectedCalibrationError, LabelRelaxationLoss, LabelSmoothingLoss
 from probly.train.dare.torch import dare_regularizer
 from probly.train.evidential.torch import (
     evidential_ce_loss,
@@ -64,6 +64,8 @@ def _get_supervised_criterion(supervised_loss: dict[str, Any] | None = None) -> 
             return nn.CrossEntropyLoss(**params)
         case "label_relaxation":
             return LabelRelaxationLoss(**params)
+        case "label_smoothing":
+            return LabelSmoothingLoss(**params)
         case _:
             msg = f"Unknown supervised loss: {name}"
             raise ValueError(msg)

--- a/src/probly_benchmark/train_funcs.py
+++ b/src/probly_benchmark/train_funcs.py
@@ -28,7 +28,7 @@ from probly.method.natural_posterior_network import NaturalPosteriorNetworkPredi
 from probly.method.posterior_network import PosteriorNetworkPredictor
 from probly.method.subensemble import SubensemblePredictor
 from probly.train.bayesian.torch import ELBOLoss, collect_kl_divergence
-from probly.train.calibration.torch import ExpectedCalibrationError
+from probly.train.calibration.torch import ExpectedCalibrationError, LabelRelaxationLoss
 from probly.train.dare.torch import dare_regularizer
 from probly.train.evidential.torch import (
     evidential_ce_loss,
@@ -49,6 +49,23 @@ EVIDENTIAL_LOSSES = {
     "ce": evidential_ce_loss,
     "log": evidential_log_loss,
 }
+
+
+def _get_supervised_criterion(supervised_loss: dict[str, Any] | None = None) -> nn.Module:
+    """Build the training criterion for CE-compatible supervised classifiers."""
+    if supervised_loss is None:
+        return nn.CrossEntropyLoss()
+    name = supervised_loss.get("name", "cross_entropy").lower()
+    params = dict(supervised_loss.get("params") or {})
+    match name:
+        case "cross_entropy":
+            params.pop("alpha", None)
+            return nn.CrossEntropyLoss(**params)
+        case "label_relaxation":
+            return LabelRelaxationLoss(**params)
+        case _:
+            msg = f"Unknown supervised loss: {name}"
+            raise ValueError(msg)
 
 
 def _evidential_lambda_t(kl_weight: float, annealing_epochs: int, epoch: int) -> float:
@@ -113,16 +130,17 @@ def train_epoch_batchensemble(
     grad_clip_norm: float | None = None,
     amp_enabled: bool = False,
     scaler: GradScaler | None = None,
+    supervised_loss: dict[str, Any] | None = None,
     **kwargs: Any,  # noqa: ANN401, ARG001
 ) -> torch.Tensor | float:
-    """Train a BatchEnsemble predictor for one step with per-member cross-entropy on a tiled batch.
+    """Train a BatchEnsemble predictor for one step with the configured supervised loss.
 
     Mirrors the imagenet baseline: tile ``inputs`` by ``num_members``, run the forward,
-    take mean CE on the ``[E*B, num_classes]`` output. Called directly (not via ``predict``)
-    so the loss operates on a plain tensor.
+    take the mean supervised loss on the ``[E*B, num_classes]`` output. Called directly
+    (not via ``predict``) so the loss operates on a plain tensor.
     """
     num_members = int(model.num_members)  # ty: ignore[unresolved-attribute]
-    criterion = nn.CrossEntropyLoss()
+    criterion = _get_supervised_criterion(supervised_loss)
     optimizer.zero_grad()
     with autocast(inputs.device.type, enabled=amp_enabled):
         inputs_tiled = torch.tile(inputs, (num_members,) + (1,) * (inputs.dim() - 1))
@@ -152,10 +170,11 @@ def train_epoch_cross_entropy(
     grad_clip_norm: float | None = None,
     amp_enabled: bool = False,
     scaler: GradScaler | None = None,
+    supervised_loss: dict[str, Any] | None = None,
     **kwargs: Any,  # noqa: ANN401, ARG001
 ) -> torch.Tensor | float:
-    """Train a stochastic NN (dropout/dropconnect) for one epoch with cross-entropy."""
-    criterion = nn.CrossEntropyLoss()
+    """Train a stochastic NN with the configured CE-compatible supervised loss."""
+    criterion = _get_supervised_criterion(supervised_loss)
     optimizer.zero_grad()
     with autocast(inputs.device.type, enabled=amp_enabled):
         outputs = model(inputs)  # ty: ignore[call-non-callable]

--- a/src/probly_benchmark/train_funcs.py
+++ b/src/probly_benchmark/train_funcs.py
@@ -37,6 +37,7 @@ from probly.train.evidential.torch import (
     evidential_mse_loss,
     postnet_loss,
 )
+from probly_benchmark.base import BasePredictor
 
 if TYPE_CHECKING:
     from torch.utils.data import DataLoader
@@ -161,7 +162,9 @@ def train_epoch_batchensemble(
     return loss.item()
 
 
-@train_epoch.register((DropConnectPredictor, DropoutPredictor, EfficientCredalPredictor, HetNetsPredictor))
+@train_epoch.register(
+    (BasePredictor, DropConnectPredictor, DropoutPredictor, EfficientCredalPredictor, HetNetsPredictor)
+)
 def train_epoch_cross_entropy(
     model: Predictor,
     inputs: torch.Tensor,
@@ -459,7 +462,7 @@ def validate_batchensemble(
     return val_loss, val_acc
 
 
-@validate.register((DropConnectPredictor, DropoutPredictor, EfficientCredalPredictor, HetNetsPredictor))
+@validate.register((BasePredictor, DropConnectPredictor, DropoutPredictor, EfficientCredalPredictor, HetNetsPredictor))
 @torch.no_grad()
 def validate_cross_entropy(
     model: Predictor,
@@ -646,7 +649,7 @@ def _(
     return _compute_metrics(probs, labels, n_bins)
 
 
-@evaluate.register((EfficientCredalPredictor, HetNetsPredictor))
+@evaluate.register((BasePredictor, EfficientCredalPredictor, HetNetsPredictor))
 @torch.no_grad()
 def evaluate_single_model(
     model: Predictor,

--- a/src/probly_benchmark/utils.py
+++ b/src/probly_benchmark/utils.py
@@ -24,6 +24,9 @@ if TYPE_CHECKING:
     from probly.representer import Representer
 
 
+DEFAULT_SUPERVISED_LOSS = "cross_entropy"
+
+
 def set_seed(seed: int | None) -> None:
     """Set seed for reproducibility.
 
@@ -142,12 +145,38 @@ def collect_outputs_targets_raw(
     return torch.cat(outputs), torch.cat(targets)
 
 
+def get_supervised_loss_name(cfg: DictConfig) -> str:
+    """Return the configured supervised loss name."""
+    supervised_loss = cfg.get("supervised_loss", None)
+    if not supervised_loss:
+        return DEFAULT_SUPERVISED_LOSS
+    return str(supervised_loss.get("name", DEFAULT_SUPERVISED_LOSS)).lower()
+
+
+def _safe_artifact_token(value: object) -> str:
+    """Make a value safe for use in a wandb artifact name segment."""
+    return "".join(char if char.isalnum() or char in "._-" else "_" for char in str(value))
+
+
+def supervised_loss_name_suffix(cfg: DictConfig) -> str:
+    """Return the name suffix for non-default supervised training losses."""
+    name = get_supervised_loss_name(cfg)
+    if name == DEFAULT_SUPERVISED_LOSS:
+        return ""
+    supervised_loss = cfg.get("supervised_loss", {})
+    params = supervised_loss.get("params") or {}
+    parts = [_safe_artifact_token(name)]
+    for key, value in sorted(params.items()):
+        parts.append(f"{_safe_artifact_token(key)}{_safe_artifact_token(value)}")
+    return f"_{'_'.join(parts)}"
+
+
 def resolve_artifact_name(cfg: DictConfig) -> str:
     """Build the wandb artifact name from config fields.
 
     Matches the naming convention used in train.py.
     """
-    return f"{cfg.method.name}_{cfg.base_model}_{cfg.dataset}_{cfg.seed}"
+    return f"{cfg.method.name}_{cfg.base_model}_{cfg.dataset}_{cfg.seed}{supervised_loss_name_suffix(cfg)}"
 
 
 def load_model_from_wandb(

--- a/src/probly_benchmark/utils.py
+++ b/src/probly_benchmark/utils.py
@@ -171,6 +171,14 @@ def supervised_loss_name_suffix(cfg: DictConfig) -> str:
     return f"_{'_'.join(parts)}"
 
 
+def cal_split_name_suffix(cfg: DictConfig | dict) -> str:
+    """Return the artifact name suffix for a calibration holdout split."""
+    cal_split = float(cfg.get("cal_split", 0.0) or 0.0)
+    if cal_split <= 0:
+        return ""
+    return f"_cal_split{_safe_artifact_token(cal_split)}"
+
+
 def calibration_name_suffix(cfg: DictConfig | dict) -> str:
     """Return the artifact name suffix for post-hoc calibration."""
     name = calibration.get_calibration_name(cfg)
@@ -190,7 +198,12 @@ def resolve_artifact_name(cfg: DictConfig, *, include_calibration: bool = True) 
     Matches the naming convention used in train.py.
     """
     suffix = calibration_name_suffix(cfg) if include_calibration else ""
-    return f"{cfg.method.name}_{cfg.base_model}_{cfg.dataset}_{cfg.seed}{supervised_loss_name_suffix(cfg)}{suffix}"
+    return (
+        f"{cfg.method.name}_{cfg.base_model}_{cfg.dataset}_{cfg.seed}"
+        f"{cal_split_name_suffix(cfg)}"
+        f"{supervised_loss_name_suffix(cfg)}"
+        f"{suffix}"
+    )
 
 
 def _download_checkpoint_from_wandb(

--- a/src/probly_benchmark/utils.py
+++ b/src/probly_benchmark/utils.py
@@ -12,7 +12,7 @@ import torch
 from tqdm import tqdm
 import wandb
 
-from probly_benchmark import calibration, metadata
+from probly_benchmark import calibration, conformal, metadata
 from probly_benchmark.builders import BuildContext, build_model
 
 if TYPE_CHECKING:
@@ -192,17 +192,40 @@ def calibration_name_suffix(cfg: DictConfig | dict) -> str:
     return f"_{'_'.join(parts)}"
 
 
-def resolve_artifact_name(cfg: DictConfig, *, include_calibration: bool = True) -> str:
+def conformal_name_suffix(cfg: DictConfig | dict) -> str:
+    """Return the artifact name suffix for split-conformal prediction."""
+    name = conformal.get_conformal_name(cfg)
+    if name == conformal.DEFAULT_CONFORMAL:
+        return ""
+    conformal_cfg = cfg.get("conformal", {})
+    params = conformal_cfg.get("params") or {}
+    parts = [_safe_artifact_token(name)]
+    alpha = conformal_cfg.get("alpha", None)
+    if alpha is not None:
+        parts.append(f"alpha{_safe_artifact_token(alpha)}")
+    for key, value in sorted(params.items()):
+        parts.append(f"{_safe_artifact_token(key)}{_safe_artifact_token(value)}")
+    return f"_{'_'.join(parts)}"
+
+
+def resolve_artifact_name(
+    cfg: DictConfig,
+    *,
+    include_calibration: bool = True,
+    include_conformal: bool = True,
+) -> str:
     """Build the wandb artifact name from config fields.
 
     Matches the naming convention used in train.py.
     """
-    suffix = calibration_name_suffix(cfg) if include_calibration else ""
+    calibration_suffix = calibration_name_suffix(cfg) if include_calibration else ""
+    conformal_suffix = conformal_name_suffix(cfg) if include_conformal else ""
     return (
         f"{cfg.method.name}_{cfg.base_model}_{cfg.dataset}_{cfg.seed}"
         f"{cal_split_name_suffix(cfg)}"
         f"{supervised_loss_name_suffix(cfg)}"
-        f"{suffix}"
+        f"{calibration_suffix}"
+        f"{conformal_suffix}"
     )
 
 
@@ -286,6 +309,47 @@ def _build_calibrated_model_from_checkpoint(
     return calibrated_model, cfg
 
 
+def _build_conformal_model_from_checkpoint(
+    checkpoint: dict[str, Any],
+    entity: str,
+    project: str,
+    device: torch.device,
+) -> tuple[torch.nn.Module, dict[str, Any]]:
+    """Reconstruct a conformal model from source artifact plus conformal-only state."""
+    cfg = checkpoint["config"]
+    source_artifact = checkpoint[conformal.SOURCE_ARTIFACT_KEY]
+    source_checkpoint, _ = _download_checkpoint_from_wandb(source_artifact, entity, project, device)
+    if source_checkpoint.get("artifact_type") == conformal.CONFORMAL_ARTIFACT_TYPE:
+        msg = f"Conformal source artifact {source_artifact!r} is itself a conformal artifact."
+        raise RuntimeError(msg)
+
+    source_model, _ = _build_model_from_checkpoint(source_checkpoint, entity, project, device)
+    conformal_model = conformal.apply_conformal(source_model, cfg)
+    conformal.load_conformal_state(
+        conformal_model,
+        cfg,
+        checkpoint[conformal.CONFORMAL_STATE_DICT_KEY],
+    )
+    conformal_model.to(device)
+    conformal_model.eval()
+    return conformal_model, cfg
+
+
+def _build_model_from_checkpoint(
+    checkpoint: dict[str, Any],
+    entity: str,
+    project: str,
+    device: torch.device,
+) -> tuple[torch.nn.Module, dict[str, Any]]:
+    """Reconstruct a benchmark model from any supported checkpoint artifact."""
+    artifact_type = checkpoint.get("artifact_type")
+    if artifact_type == calibration.CALIBRATION_ARTIFACT_TYPE:
+        return _build_calibrated_model_from_checkpoint(checkpoint, entity, project, device)
+    if artifact_type == conformal.CONFORMAL_ARTIFACT_TYPE:
+        return _build_conformal_model_from_checkpoint(checkpoint, entity, project, device)
+    return _build_uncalibrated_model_from_checkpoint(checkpoint, device)
+
+
 def load_model_from_wandb(
     artifact_name: str,
     entity: str,
@@ -310,10 +374,5 @@ def load_model_from_wandb(
             - run_id: The ID of the run that logged ``artifact_name``.
     """
     checkpoint, run_id = _download_checkpoint_from_wandb(artifact_name, entity, project, device)
-
-    if checkpoint.get("artifact_type") == calibration.CALIBRATION_ARTIFACT_TYPE:
-        model, cfg = _build_calibrated_model_from_checkpoint(checkpoint, entity, project, device)
-    else:
-        model, cfg = _build_uncalibrated_model_from_checkpoint(checkpoint, device)
-
+    model, cfg = _build_model_from_checkpoint(checkpoint, entity, project, device)
     return model, cfg, run_id

--- a/src/probly_benchmark/utils.py
+++ b/src/probly_benchmark/utils.py
@@ -12,7 +12,7 @@ import torch
 from tqdm import tqdm
 import wandb
 
-from probly_benchmark import metadata
+from probly_benchmark import calibration, metadata
 from probly_benchmark.builders import BuildContext, build_model
 
 if TYPE_CHECKING:
@@ -171,34 +171,35 @@ def supervised_loss_name_suffix(cfg: DictConfig) -> str:
     return f"_{'_'.join(parts)}"
 
 
-def resolve_artifact_name(cfg: DictConfig) -> str:
+def calibration_name_suffix(cfg: DictConfig | dict) -> str:
+    """Return the artifact name suffix for post-hoc calibration."""
+    name = calibration.get_calibration_name(cfg)
+    if name == calibration.DEFAULT_CALIBRATION:
+        return ""
+    calibration_cfg = cfg.get("calibration", {})
+    params = calibration_cfg.get("params") or {}
+    parts = [_safe_artifact_token(name)]
+    for key, value in sorted(params.items()):
+        parts.append(f"{_safe_artifact_token(key)}{_safe_artifact_token(value)}")
+    return f"_{'_'.join(parts)}"
+
+
+def resolve_artifact_name(cfg: DictConfig, *, include_calibration: bool = True) -> str:
     """Build the wandb artifact name from config fields.
 
     Matches the naming convention used in train.py.
     """
-    return f"{cfg.method.name}_{cfg.base_model}_{cfg.dataset}_{cfg.seed}{supervised_loss_name_suffix(cfg)}"
+    suffix = calibration_name_suffix(cfg) if include_calibration else ""
+    return f"{cfg.method.name}_{cfg.base_model}_{cfg.dataset}_{cfg.seed}{supervised_loss_name_suffix(cfg)}{suffix}"
 
 
-def load_model_from_wandb(
+def _download_checkpoint_from_wandb(
     artifact_name: str,
     entity: str,
     project: str,
     device: torch.device,
-) -> tuple[torch.nn.Module, dict[str, Any], str]:
-    """Download a model artifact from wandb and reconstruct the model.
-
-    Args:
-        artifact_name: Name of the wandb artifact (without version tag).
-        entity: Wandb entity.
-        project: Wandb project.
-        device: Device to load the model onto.
-
-    Returns:
-        A tuple containing:
-            - model: The reconstructed model in eval mode.
-            - cfg: The saved training config dict.
-            - run_id: The ID of the original training run.
-    """
+) -> tuple[dict[str, Any], str]:
+    """Download a wandb checkpoint artifact."""
     api = wandb.Api()
     full_name = f"{entity}/{project}/{artifact_name}:latest"
 
@@ -219,6 +220,15 @@ def load_model_from_wandb(
         raise RuntimeError(msg)
 
     checkpoint = torch.load(pt_files[0], map_location=device, weights_only=False)
+    run_id = artifact.logged_by().id
+    return checkpoint, run_id
+
+
+def _build_uncalibrated_model_from_checkpoint(
+    checkpoint: dict[str, Any],
+    device: torch.device,
+) -> tuple[torch.nn.Module, dict[str, Any]]:
+    """Reconstruct an uncalibrated benchmark model from a training checkpoint."""
     cfg = checkpoint["config"]
 
     num_classes = metadata.DATASETS[cfg["dataset"]].num_classes
@@ -234,7 +244,63 @@ def load_model_from_wandb(
     model.load_state_dict(checkpoint["model_state_dict"])
     model.to(device)
     model.eval()
+    return model, cfg
 
-    run_id = artifact.logged_by().id
+
+def _build_calibrated_model_from_checkpoint(
+    checkpoint: dict[str, Any],
+    entity: str,
+    project: str,
+    device: torch.device,
+) -> tuple[torch.nn.Module, dict[str, Any]]:
+    """Reconstruct a calibrated model from source weights plus calibration-only state."""
+    cfg = checkpoint["config"]
+    source_artifact = checkpoint[calibration.SOURCE_ARTIFACT_KEY]
+    source_checkpoint, _ = _download_checkpoint_from_wandb(source_artifact, entity, project, device)
+    if source_checkpoint.get("artifact_type") == calibration.CALIBRATION_ARTIFACT_TYPE:
+        msg = f"Calibration source artifact {source_artifact!r} is itself a calibration artifact."
+        raise RuntimeError(msg)
+
+    model, _ = _build_uncalibrated_model_from_checkpoint(source_checkpoint, device)
+    calibrated_model = calibration.apply_calibration(model, cfg)
+    calibration.load_calibration_state(
+        calibrated_model,
+        cfg,
+        checkpoint[calibration.CALIBRATION_STATE_DICT_KEY],
+    )
+    calibrated_model.to(device)
+    calibrated_model.eval()
+    return calibrated_model, cfg
+
+
+def load_model_from_wandb(
+    artifact_name: str,
+    entity: str,
+    project: str,
+    device: torch.device,
+) -> tuple[torch.nn.Module, dict[str, Any], str]:
+    """Download a model artifact from wandb and reconstruct the model.
+
+    Calibration artifacts are restored by first loading their source model artifact,
+    then applying the configured calibration wrapper and loading calibration-only state.
+
+    Args:
+        artifact_name: Name of the wandb artifact (without version tag).
+        entity: Wandb entity.
+        project: Wandb project.
+        device: Device to load the model onto.
+
+    Returns:
+        A tuple containing:
+            - model: The reconstructed model in eval mode.
+            - cfg: The saved checkpoint config dict.
+            - run_id: The ID of the run that logged ``artifact_name``.
+    """
+    checkpoint, run_id = _download_checkpoint_from_wandb(artifact_name, entity, project, device)
+
+    if checkpoint.get("artifact_type") == calibration.CALIBRATION_ARTIFACT_TYPE:
+        model, cfg = _build_calibrated_model_from_checkpoint(checkpoint, entity, project, device)
+    else:
+        model, cfg = _build_uncalibrated_model_from_checkpoint(checkpoint, device)
 
     return model, cfg, run_id

--- a/tests/flextype/test_singledispatch.py
+++ b/tests/flextype/test_singledispatch.py
@@ -508,6 +508,224 @@ class TestRegistryMetaDispatch:
         with pytest.raises(RuntimeError, match="Ambiguous dispatch"):
             f(candidate)
 
+    def test_registry_meta_instance_ambiguity_same_function_matches_functools(self) -> None:
+        class RegistryA(metaclass=RegistryMeta):
+            pass
+
+        class RegistryB(metaclass=RegistryMeta):
+            pass
+
+        class Candidate:
+            pass
+
+        candidate = Candidate()
+        RegistryA.register_instance(candidate)
+        RegistryB.register_instance(candidate)
+
+        @flexdispatch
+        def f(value: object) -> str:
+            del value
+            return "object"
+
+        def shared(value: object) -> str:
+            del value
+            return "shared"
+
+        f.register(RegistryA | RegistryB, shared)
+
+        with pytest.raises(RuntimeError, match="Ambiguous dispatch"):
+            f(candidate)
+
+    def test_registry_meta_regular_multiple_inheritance_same_function_matches_functools(self) -> None:
+        class RegistryA(metaclass=RegistryMeta):
+            pass
+
+        class RegistryB(metaclass=RegistryMeta):
+            pass
+
+        class Candidate(RegistryA, RegistryB):  # ty: ignore[conflicting-metaclass]
+            pass
+
+        @functools_singledispatch
+        def ref(value: object) -> str:
+            del value
+            return "object"
+
+        @flexdispatch
+        def got(value: object) -> str:
+            del value
+            return "object"
+
+        def shared(value: object) -> str:
+            del value
+            return "shared"
+
+        ref.register(RegistryA | RegistryB, shared)
+        got.register(RegistryA | RegistryB, shared)
+
+        assert ref(Candidate()) == "shared"
+        assert got(Candidate()) == "shared"
+
+    def test_registry_meta_regular_multiple_inheritance_mro_matches_functools(self) -> None:
+        class RegistryA(metaclass=RegistryMeta):
+            pass
+
+        class RegistryB(metaclass=RegistryMeta):
+            pass
+
+        class Candidate(RegistryA, RegistryB):  # ty: ignore[conflicting-metaclass]
+            pass
+
+        @functools_singledispatch
+        def ref(value: object) -> str:
+            del value
+            return "object"
+
+        @ref.register(RegistryA)
+        def _ref_a(value: RegistryA) -> str:
+            del value
+            return "A"
+
+        @ref.register(RegistryB)
+        def _ref_b(value: RegistryB) -> str:
+            del value
+            return "B"
+
+        @flexdispatch
+        def got(value: object) -> str:
+            del value
+            return "object"
+
+        @got.register(RegistryA)
+        def _got_a(value: RegistryA) -> str:
+            del value
+            return "A"
+
+        @got.register(RegistryB)
+        def _got_b(value: RegistryB) -> str:
+            del value
+            return "B"
+
+        assert ref(Candidate()) == "A"
+        assert got(Candidate()) == ref(Candidate())
+
+    def test_registry_meta_regular_multiple_inheritance_reverse_mro_matches_functools(self) -> None:
+        class RegistryA(metaclass=RegistryMeta):
+            pass
+
+        class RegistryB(metaclass=RegistryMeta):
+            pass
+
+        class Candidate(RegistryB, RegistryA):  # ty: ignore[conflicting-metaclass]
+            pass
+
+        @functools_singledispatch
+        def ref(value: object) -> str:
+            del value
+            return "object"
+
+        @ref.register(RegistryA)
+        def _ref_a(value: RegistryA) -> str:
+            del value
+            return "A"
+
+        @ref.register(RegistryB)
+        def _ref_b(value: RegistryB) -> str:
+            del value
+            return "B"
+
+        @flexdispatch
+        def got(value: object) -> str:
+            del value
+            return "object"
+
+        @got.register(RegistryA)
+        def _got_a(value: RegistryA) -> str:
+            del value
+            return "A"
+
+        @got.register(RegistryB)
+        def _got_b(value: RegistryB) -> str:
+            del value
+            return "B"
+
+        assert ref(Candidate()) == "B"
+        assert got(Candidate()) == ref(Candidate())
+
+    def test_registry_meta_regular_subclass_chain_matches_functools(self) -> None:
+        class RegistryBase(metaclass=RegistryMeta):
+            pass
+
+        class RegistrySub(RegistryBase):
+            pass
+
+        class Candidate(RegistrySub):
+            pass
+
+        @functools_singledispatch
+        def ref(value: object) -> str:
+            del value
+            return "object"
+
+        @ref.register(RegistryBase)
+        def _ref_base(value: RegistryBase) -> str:
+            del value
+            return "base"
+
+        @ref.register(RegistrySub)
+        def _ref_sub(value: RegistrySub) -> str:
+            del value
+            return "sub"
+
+        @flexdispatch
+        def got(value: object) -> str:
+            del value
+            return "object"
+
+        @got.register(RegistryBase)
+        def _got_base(value: RegistryBase) -> str:
+            del value
+            return "base"
+
+        @got.register(RegistrySub)
+        def _got_sub(value: RegistrySub) -> str:
+            del value
+            return "sub"
+
+        assert ref(Candidate()) == "sub"
+        assert got(Candidate()) == ref(Candidate())
+
+    def test_registry_meta_instance_match_still_conflicts_with_regular_type_match(self) -> None:
+        class RegistryA(metaclass=RegistryMeta):
+            pass
+
+        class RegistryB(metaclass=RegistryMeta):
+            pass
+
+        class Candidate(RegistryA):
+            pass
+
+        candidate = Candidate()
+        RegistryB.register_instance(candidate)
+
+        @flexdispatch
+        def f(value: object) -> str:
+            del value
+            return "object"
+
+        @f.register(RegistryA)
+        def _a_impl(value: RegistryA) -> str:
+            del value
+            return "A"
+
+        @f.register(RegistryB)
+        def _b_impl(value: RegistryB) -> str:
+            del value
+            return "B"
+
+        with pytest.raises(RuntimeError, match="Ambiguous dispatch"):
+            f(candidate)
+
     def test_regular_type_dispatch_more_specific_than_registry_match_wins(self) -> None:
         class RegistryType(metaclass=RegistryMeta):
             pass

--- a/tests/probly/train/calibration/test_torch.py
+++ b/tests/probly/train/calibration/test_torch.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from probly.train.calibration.torch import ExpectedCalibrationError, FocalLoss, LabelRelaxationLoss
+from probly.train.calibration.torch import ExpectedCalibrationError, FocalLoss, LabelRelaxationLoss, LabelSmoothingLoss
 from tests.probly.torch_utils import validate_loss
 
 torch = pytest.importorskip("torch")
@@ -43,3 +43,24 @@ def test_label_relaxation_loss(
     criterion = LabelRelaxationLoss(alpha=1.0)
     loss = criterion(outputs, targets)
     validate_loss(loss)
+
+
+def test_label_smoothing_loss(
+    sample_outputs: tuple[Tensor, Tensor],
+) -> None:
+    outputs, targets = sample_outputs
+    criterion = LabelSmoothingLoss()
+    loss = criterion(outputs, targets)
+    validate_loss(loss)
+
+    expected = torch.nn.CrossEntropyLoss(label_smoothing=0.1)(outputs, targets)
+    torch.testing.assert_close(loss, expected)
+
+
+def test_label_smoothing_loss_without_smoothing(
+    sample_outputs: tuple[Tensor, Tensor],
+) -> None:
+    outputs, targets = sample_outputs
+    loss = LabelSmoothingLoss(epsilon=0.0)(outputs, targets)
+    expected = torch.nn.CrossEntropyLoss()(outputs, targets)
+    torch.testing.assert_close(loss, expected)


### PR DESCRIPTION
- Added a `base` method which trains a model without applying any method
- Label relaxation and label smoothing can now be used as alternative loss functions for all methods that use CE by default (to evaluate a "pure" label relaxation/smoothing approach, simply combine `method=base` with `supervised_loss=label_relaxation`/`supervised_loss=label_smoothing`)
- added a separate `calibrate.py` script which takes a pretrained model, wraps it with a post-hoc calibration method (currently only temp scaling supported), computes the calibration params based on the validation data and stores the calibration params as a separate artifact (downstream tasks can then load either the calibrated or uncalibrated model - can be set via `calibration=temperature_scaling`)
- CP is also in there, but "incorrectly" uses val for calibration right now, since we don't want to retrain all models just for CP. since CP won't be used for OOD and selective prediction, most likely this does not matter.