### PR TITLE
Fix: Current code crashes with non-image data

### DIFF
--- a/src/probly_benchmark/train.py
+++ b/src/probly_benchmark/train.py
@@ -334,7 +334,7 @@ def _training_loop(  # noqa: PLR0912, PLR0915
         running_loss = 0.0
         for inputs_, targets_ in tqdm(train_loader):
             inputs = inputs_.to(device, non_blocking=True)
-            if device.type == "cuda":
+            if device.type == "cuda" and inputs.ndim >= 4:
                 inputs = inputs.contiguous(memory_format=torch.channels_last)
             targets = targets_.to(device, non_blocking=True)
             running_loss += train_fn(
@@ -594,7 +594,7 @@ def _training_loop_relative_likelihood(  # noqa: PLR0912, PLR0915
         running_loss = 0.0
         for inputs_, targets_ in tqdm(train_loader):
             inputs = inputs_.to(device, non_blocking=True)
-            if device.type == "cuda":
+            if device.type == "cuda" and inputs.ndim >= 4:
                 inputs = inputs.contiguous(memory_format=torch.channels_last)
             targets = targets_.to(device, non_blocking=True)
             running_loss += train_fn(
@@ -767,7 +767,7 @@ def _fit_ddu_density_head(
     all_labels: list[torch.Tensor] = []
     for inputs_, targets_ in tqdm(train_loader, desc="Fitting DDU density head"):
         inputs = inputs_.to(device, non_blocking=True)
-        if device.type == "cuda":
+        if device.type == "cuda" and inputs.ndim >= 4:
             inputs = inputs.contiguous(memory_format=torch.channels_last)
         targets = targets_.to(device, non_blocking=True)
         with torch.amp.autocast(device.type, enabled=amp_enabled):


### PR DESCRIPTION
## Issue
Active learning fails on non-image data. The contiguous(memory_format=torch.channels_last) is only supported for images and video. 

Alternatively, we could look into whether other coniguous enforcements formats are supported for tabular data / any others. But I believe that the change proposed here is the safest.

## Public API Changes

-   [x] No Public API changes
-   [ ] Yes, Public API changes (Details below)

## Checklist

-   [x] The changes have been tested locally.
-   [ ] Documentation has been updated (if the public API or usage changes).
-   [ ] A entry has been added to [`CHANGELOG.md`](https://github.com/pwhofman/probly/blob/main/CHANGELOG.md) (if relevant for users).
-   [x] The code follows the project's [style guidelines](https://github.com/pwhofman/probly/blob/main/.github/CONTRIBUTING.md) and passes minimal code style checks.
-   [x] I have considered the impact of these changes on the public API.

---
