### PR TITLE
Add flax implementations for dirichlet_exp/softplus_activation, het_n…

### DIFF
--- a/src/probly/layers/flax.py
+++ b/src/probly/layers/flax.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from typing import Any, Literal
 
 from flax import nnx
@@ -478,3 +479,263 @@ class BatchEnsembleConv(nnx.Conv):
             bias_dim = (slice(None),) + (None,) * (y.ndim - 2) + (slice(None),)
             y = y + self.bias[bias_dim]
         return y.reshape(eb, *y.shape[2:])
+
+
+class HeteroscedasticLayer(nnx.Module):
+    """A unified Flax implementation of the Heteroscedastic layer based on :cite:`collier2021hetnets`.
+
+    Attributes:
+        in_features: int, number of input features.
+        num_classes: int, number of classes.
+        num_factors: int, number of factors.
+        temperature: float, temperature scaling.
+        is_parameter_efficient: bool, whether to use parameter efficient routing.
+        mu_layer: nnx.Linear, deterministic mean parameter transformation.
+        diag_layer: nnx.Linear, diagonal correction variance transformation.
+        v_layer: nnx.Linear, covariance factor parameterization routing.
+        V_matrix: nnx.Param, global homoscedastic matrix (if parameter efficient).
+        rngs: rnglib.Rngs or rnglib.RngStream or None, rng key used to draw
+            standard-normal samples at call time.
+    """
+
+    def __init__(
+        self,
+        in_features: int,
+        num_classes: int,
+        num_factors: int = 15,
+        temperature: float = 1.0,
+        is_parameter_efficient: bool = False,
+        rngs: rnglib.Rngs | rnglib.RngStream | int = 1,
+    ) -> None:
+        """Initialize the HeteroscedasticLayer.
+
+        Args:
+            in_features: Number of input features.
+            num_classes: Number of classes.
+            num_factors: Number of low-rank covariance factors.
+            temperature: Temperature scaling applied to the sampled utilities.
+            is_parameter_efficient: Whether to use the parameter-efficient routing.
+            rngs: ``nnx.Rngs``, ``RngStream`` or integer seed used both to initialize the
+                sub-layers and to draw standard-normal samples at call time. May also be
+                overridden per call.
+        """
+        if isinstance(rngs, (int, rnglib.RngStream)):
+            rngs = nnx.Rngs(rngs)
+        self.in_features = in_features
+        self.num_classes = num_classes
+        self.num_factors = num_factors
+        self.temperature = temperature
+        self.is_parameter_efficient = is_parameter_efficient
+
+        xavier_uniform = jax.nn.initializers.xavier_uniform()
+        zeros = jax.nn.initializers.zeros
+        diag_bias_value = math.log(math.exp(1.0) - 1.0)
+
+        def constant_init(value: float):  # noqa: ANN202
+            def init_fn(_key: jax.Array, shape: tuple[int, ...], dtype: Any) -> jax.Array:  # noqa: ANN401
+                return jnp.full(shape, value, dtype=dtype)
+
+            return init_fn
+
+        self.mu_layer = nnx.Linear(
+            in_features,
+            num_classes,
+            kernel_init=xavier_uniform,
+            bias_init=zeros,
+            rngs=rngs,
+        )
+        self.diag_layer = nnx.Linear(
+            in_features,
+            num_classes,
+            kernel_init=xavier_uniform,
+            bias_init=constant_init(diag_bias_value),
+            rngs=rngs,
+        )
+
+        if is_parameter_efficient:
+            self.v_layer = nnx.Linear(
+                in_features,
+                num_factors,
+                kernel_init=xavier_uniform,
+                bias_init=zeros,
+                rngs=rngs,
+            )
+            v_matrix_key = rngs.params()
+            self.V_matrix = nnx.Param(
+                jax.nn.initializers.xavier_normal()(v_matrix_key, (num_classes, num_factors), jnp.float32),
+            )
+        else:
+            self.v_layer = nnx.Linear(
+                in_features,
+                num_classes * num_factors,
+                kernel_init=xavier_uniform,
+                bias_init=zeros,
+                rngs=rngs,
+            )
+
+        if isinstance(rngs, rnglib.Rngs):
+            self.rngs = rngs["het_net"].fork()
+        elif isinstance(rngs, rnglib.RngStream):
+            self.rngs = rngs.fork()
+        else:
+            self.rngs = nnx.data(None)
+
+    def __call__(
+        self,
+        x: jax.Array,
+        *,
+        rngs: rnglib.Rngs | rnglib.RngStream | jax.Array | None = None,
+    ) -> jax.Array:
+        """Draw a single utility sample and return temperature-scaled logits.
+
+        Samples once from a multivariate normal whose covariance is parameterized by a low-rank
+        factor plus a diagonal term derived from the input. Each call yields a different sample
+        because the noise is drawn freshly from the supplied ``rngs``; the outer sampler turns
+        repeated calls into a Monte Carlo sample of categorical distributions.
+
+        Args:
+            x: Input array of shape ``(batch_size, in_features)``.
+            rngs: Optional override of the rng source for sampling.
+
+        Returns:
+            Temperature-scaled utility logits of shape ``(batch_size, num_classes)``.
+        """
+        rng_source = first_from(
+            rngs,
+            self.rngs,
+            error_msg=(
+                "No `rngs` argument was provided to HeteroscedasticLayer "
+                "as either a __call__ argument or class attribute."
+            ),
+        )
+
+        if isinstance(rng_source, rnglib.Rngs):
+            key = rng_source["het_net"]()
+        elif isinstance(rng_source, rnglib.RngStream):
+            key = rng_source()
+        elif isinstance(rng_source, jax.Array):
+            key = rng_source
+        else:
+            msg = f"rngs must be Rngs, RngStream or jax.Array, but got {type(rng_source)}"
+            raise TypeError(msg)
+
+        key_k, key_r = jax.random.split(key)
+        batch_size = x.shape[0]
+
+        mu = self.mu_layer(x)
+        diag_scale = jax.nn.softplus(self.diag_layer(x))
+
+        eps_k = jax.random.normal(key_k, (batch_size, self.num_classes), dtype=x.dtype)
+        eps_r = jax.random.normal(key_r, (batch_size, self.num_factors), dtype=x.dtype)
+
+        if self.is_parameter_efficient:
+            v_x = self.v_layer(x)
+            scaled_eps_r = (eps_r * v_x)[..., None]
+            low_rank_noise = jnp.matmul(self.V_matrix.value, scaled_eps_r).squeeze(-1)
+        else:
+            v_x_full = self.v_layer(x).reshape(batch_size, self.num_classes, self.num_factors)
+            low_rank_noise = jnp.matmul(v_x_full, eps_r[..., None]).squeeze(-1)
+
+        utilities = mu + diag_scale * eps_k + low_rank_noise
+        return utilities / self.temperature
+
+
+class NormalInverseGammaLinear(nnx.Module):
+    """Custom Linear layer for a normal-inverse-gamma distribution based on :cite:`aminiDeepEvidential2020`.
+
+    Outputs four heads parameterizing the mean of a normal distribution and the parameters
+    of an inverse-gamma distribution over its variance, in the form
+    ``{"gamma": ..., "nu": ..., "alpha": ..., "beta": ...}``.
+
+    Attributes:
+        gamma: nnx.Param of shape ``(in_features, out_features)``, the mean of the normal distribution.
+        nu: nnx.Param of shape ``(in_features, out_features)``, parameter of the normal distribution.
+        alpha: nnx.Param of shape ``(in_features, out_features)``, parameter of the inverse-gamma distribution.
+        beta: nnx.Param of shape ``(in_features, out_features)``, parameter of the inverse-gamma distribution.
+        gamma_bias: nnx.Param of shape ``(out_features,)`` (or None), bias for the mean head.
+        nu_bias: nnx.Param of shape ``(out_features,)`` (or None), bias for the nu head.
+        alpha_bias: nnx.Param of shape ``(out_features,)`` (or None), bias for the alpha head.
+        beta_bias: nnx.Param of shape ``(out_features,)`` (or None), bias for the beta head.
+        in_features: int, number of input features.
+        out_features: int, number of output features.
+        use_bias: bool, whether the layer carries bias parameters.
+        param_dtype: dtype, parameter dtype.
+    """
+
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        rngs: nnx.Rngs | rnglib.RngStream | int = 1,
+        *,
+        use_bias: bool = True,
+        param_dtype: Any = jnp.float32,  # noqa: ANN401
+    ) -> None:
+        """Initialize a NormalInverseGammaLinear layer.
+
+        Args:
+            in_features: Number of input features.
+            out_features: Number of output features.
+            rngs: ``nnx.Rngs``, ``RngStream`` or integer seed used to initialize parameters.
+            use_bias: Whether to include bias parameters for each head. Defaults to True.
+            param_dtype: Parameter dtype. Defaults to ``jnp.float32``.
+        """
+        if isinstance(rngs, (int, rnglib.RngStream)):
+            rngs = nnx.Rngs(rngs)
+
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_bias = use_bias
+        self.param_dtype = param_dtype
+
+        kernel_shape = (in_features, out_features)
+        # Match torch's kaiming_uniform with a=sqrt(5), which is equivalent to
+        # uniform(-1/sqrt(in_features), 1/sqrt(in_features)) per the torch docs.
+        bound = 1.0 / math.sqrt(in_features) if in_features > 0 else 0.0
+
+        def _uniform_init(shape: tuple[int, ...]) -> jax.Array:
+            return jax.random.uniform(rngs.params(), shape, dtype=param_dtype, minval=-bound, maxval=bound)
+
+        self.gamma = nnx.Param(_uniform_init(kernel_shape))
+        self.nu = nnx.Param(_uniform_init(kernel_shape))
+        self.alpha = nnx.Param(_uniform_init(kernel_shape))
+        self.beta = nnx.Param(_uniform_init(kernel_shape))
+
+        if use_bias:
+            self.gamma_bias = nnx.Param(_uniform_init((out_features,)))
+            self.nu_bias = nnx.Param(_uniform_init((out_features,)))
+            self.alpha_bias = nnx.Param(_uniform_init((out_features,)))
+            self.beta_bias = nnx.Param(_uniform_init((out_features,)))
+        else:
+            self.gamma_bias = None
+            self.nu_bias = None
+            self.alpha_bias = None
+            self.beta_bias = None
+
+    def __call__(self, x: jax.Array) -> dict[str, jax.Array]:
+        """Forward pass of the NormalInverseGamma layer.
+
+        Args:
+            x: Input array of shape ``(batch_size, in_features)``.
+
+        Returns:
+            Dict mapping ``{"gamma", "nu", "alpha", "beta"}`` to the corresponding head outputs.
+        """
+        gamma = jnp.matmul(x, self.gamma.value)
+        nu_pre = jnp.matmul(x, self.nu.value)
+        alpha_pre = jnp.matmul(x, self.alpha.value)
+        beta_pre = jnp.matmul(x, self.beta.value)
+        if (
+            self.gamma_bias is not None
+            and self.nu_bias is not None
+            and self.alpha_bias is not None
+            and self.beta_bias is not None
+        ):
+            gamma = gamma + self.gamma_bias.value
+            nu_pre = nu_pre + self.nu_bias.value
+            alpha_pre = alpha_pre + self.alpha_bias.value
+            beta_pre = beta_pre + self.beta_bias.value
+        nu = jax.nn.softplus(nu_pre)
+        alpha = jax.nn.softplus(alpha_pre) + 1
+        beta = jax.nn.softplus(beta_pre)
+        return {"gamma": gamma, "nu": nu, "alpha": alpha, "beta": beta}

--- a/src/probly/method/het_net/__init__.py
+++ b/src/probly/method/het_net/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from probly.lazy_types import TORCH_MODULE
+from probly.lazy_types import FLAX_MODULE, TORCH_MODULE
 
 from ._common import (
     HetNetPredictor,
@@ -17,6 +17,11 @@ from ._common import (
 @het_net_traverser.delayed_register(TORCH_MODULE)
 def _(_: type) -> None:
     from . import torch as torch  # noqa: PLC0415
+
+
+@het_net_traverser.delayed_register(FLAX_MODULE)
+def _(_: type) -> None:
+    from . import flax as flax  # noqa: PLC0415
 
 
 __all__ = [

--- a/src/probly/method/het_net/_common.py
+++ b/src/probly/method/het_net/_common.py
@@ -19,6 +19,8 @@ from pytraverse import CLONE, TRAVERSE_REVERSED, GlobalVariable, flexdispatch_tr
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
+    from flax.nnx.rnglib import Rngs, RngStream
+
 
 class HetNetRepresentation[T: CategoricalDistribution](CategoricalDistributionSample[T]):
     """A sample of categorical distributions produced by a HetNets model.
@@ -35,10 +37,13 @@ class HetNetPredictor[**In, Out: CategoricalDistribution](RandomPredictor[In, Ou
 
 het_net_traverser = flexdispatch_traverser[object](name="het_nets_traverser")
 
+type RNG = int | Rngs | RngStream
+
 LAST_LAYER = GlobalVariable[bool]("LAST_LAYER")
 NUM_FACTORS = GlobalVariable[int]("NUM_FACTORS")
 TEMPERATURE = GlobalVariable[float]("TEMPERATURE")
 IS_PARAMETER_EFFICIENT = GlobalVariable[bool]("IS_PARAMETER_EFFICIENT")
+RNGS = GlobalVariable[RNG]("RNGS", "rngs for flax HeteroscedasticLayer initialization.", default=1)
 
 
 @predictor_transformation(
@@ -54,6 +59,7 @@ def het_net[**In, Out: CategoricalDistribution](
     num_factors: int = 10,
     temperature: float = 1.0,
     is_parameter_efficient: bool = False,
+    rngs: RNG = 1,
 ) -> HetNetPredictor[In, Out]:
     """Create a HetNets predictor from a base predictor base on :cite:`collier2021hetnets`.
 
@@ -62,6 +68,9 @@ def het_net[**In, Out: CategoricalDistribution](
         num_factors: The rank of the low-rank covariance parametrization.
         temperature: The temperature parameter for scaling the utility.
         is_parameter_efficient: Whether to use the parameter-efficient version.
+        rngs: Optional rngs for the flax HeteroscedasticLayer initialization (types:
+            ``rnglib.Rngs | rnglib.RngStream | int``). Ignored by the torch backend.
+            Default is ``1``.
 
     Returns:
         The HetNets predictor.
@@ -76,6 +85,7 @@ def het_net[**In, Out: CategoricalDistribution](
             NUM_FACTORS: num_factors,
             TEMPERATURE: temperature,
             IS_PARAMETER_EFFICIENT: is_parameter_efficient,
+            RNGS: rngs,
         },
     )
 

--- a/src/probly/method/het_net/flax.py
+++ b/src/probly/method/het_net/flax.py
@@ -1,0 +1,43 @@
+"""Flax implementation of HetNets."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from flax import nnx
+
+from probly.layers.flax import HeteroscedasticLayer
+
+from ._common import (
+    IS_PARAMETER_EFFICIENT,
+    LAST_LAYER,
+    NUM_FACTORS,
+    RNGS,
+    TEMPERATURE,
+    het_net_traverser,
+)
+
+if TYPE_CHECKING:
+    from pytraverse import State
+
+
+@het_net_traverser.register(nnx.Module)
+def skip_layer(obj: nnx.Module, state: State) -> tuple[nnx.Module, State]:
+    """Traverser for unchanged flax layers."""
+    return obj, state
+
+
+@het_net_traverser.register(nnx.Linear)
+def drop_in_place_het_layer(obj: nnx.Linear, state: State) -> tuple[nnx.Module, State]:
+    """Replace the last linear layer with a HeteroscedasticLayer."""
+    if state[LAST_LAYER]:
+        state[LAST_LAYER] = False
+        return HeteroscedasticLayer(
+            in_features=obj.in_features,
+            num_classes=obj.out_features,
+            num_factors=state[NUM_FACTORS],
+            temperature=state[TEMPERATURE],
+            is_parameter_efficient=state[IS_PARAMETER_EFFICIENT],
+            rngs=state[RNGS],
+        ), state
+    return obj, state

--- a/src/probly/method/het_net/flax.py
+++ b/src/probly/method/het_net/flax.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from flax import nnx
+import jax
 
 from probly.layers.flax import HeteroscedasticLayer
 
@@ -19,6 +20,20 @@ from ._common import (
 
 if TYPE_CHECKING:
     from pytraverse import State
+
+
+# Identity-matched callables that are equivalent to a torch ``nn.Softmax`` tail
+# and that the het_net transformation should strip from a trailing position
+# (the HeteroscedasticLayer applies its own activation internally, so leaving a
+# softmax behind would double-activate the output).
+_SOFTMAX_TAILS: frozenset[object] = frozenset(
+    {
+        jax.nn.softmax,
+        jax.nn.log_softmax,
+        nnx.softmax,
+        nnx.log_softmax,
+    }
+)
 
 
 @het_net_traverser.register(nnx.Module)
@@ -40,4 +55,21 @@ def drop_in_place_het_layer(obj: nnx.Linear, state: State) -> tuple[nnx.Module, 
             is_parameter_efficient=state[IS_PARAMETER_EFFICIENT],
             rngs=state[RNGS],
         ), state
+    return obj, state
+
+
+@het_net_traverser.register(nnx.Sequential)
+def strip_trailing_softmax(obj: nnx.Sequential, state: State) -> tuple[nnx.Module, State]:
+    """Strip a trailing softmax-like callable from the end of a ``Sequential``.
+
+    Mirrors the torch handler that replaces a trailing ``nn.Softmax`` with
+    ``nn.Identity`` -- the HeteroscedasticLayer applies its own activation, so a
+    bare ``jax.nn.softmax`` (or sibling) at the tail would double-activate.
+
+    Matching is by identity against a small allowlist of known callables; an
+    arbitrary callable in the tail position is left untouched.
+    """
+    layers = list(obj.layers)
+    if layers and layers[-1] in _SOFTMAX_TAILS:
+        return nnx.Sequential(*layers[:-1]), state
     return obj, state

--- a/src/probly/transformation/class_bias_ensemble/__init__.py
+++ b/src/probly/transformation/class_bias_ensemble/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from probly.lazy_types import TORCH_MODULE
+from probly.lazy_types import FLAX_MODULE, TORCH_MODULE
 
 from ._common import ClassBiasEnsemblePredictor, class_bias_ensemble, class_bias_ensemble_traverser
 
@@ -11,6 +11,12 @@ from ._common import ClassBiasEnsemblePredictor, class_bias_ensemble, class_bias
 @class_bias_ensemble_traverser.delayed_register(TORCH_MODULE)
 def _(_: type) -> None:
     from . import torch as torch  # noqa: PLC0415
+
+
+## Flax
+@class_bias_ensemble_traverser.delayed_register(FLAX_MODULE)
+def _(_: type) -> None:
+    from . import flax as flax  # noqa: PLC0415
 
 
 __all__ = [

--- a/src/probly/transformation/class_bias_ensemble/_common.py
+++ b/src/probly/transformation/class_bias_ensemble/_common.py
@@ -54,10 +54,8 @@ def class_bias_ensemble[**In, Out](
     """
     if reset_params:
         traverser = nn_compose(reset_traverser, class_bias_ensemble_traverser)
-        coerced_rngs = _coerce_rngs(rngs)
     else:
         traverser = nn_compose(class_bias_ensemble_traverser)
-        coerced_rngs = rngs
     members = [
         traverse(
             base,
@@ -68,24 +66,9 @@ def class_bias_ensemble[**In, Out](
                 INITIALIZED: False,
                 RESET_PARAMS: reset_params,
                 TRAVERSE_REVERSED: True,
-                RESET_RNGS: coerced_rngs,
+                RESET_RNGS: rngs,
             },
         )
         for i in range(num_members)
     ]
     return members  # ty:ignore[invalid-return-type]
-
-
-def _coerce_rngs(rngs: int | Rngs | RngStream) -> int | Rngs | RngStream:
-    """Coerce an int seed into an :class:`nnx.Rngs` once so members share an advancing stream.
-
-    If flax is unavailable (torch-only environments), returns the seed unchanged — the torch
-    ``reset_traverser`` ignores rngs anyway.
-    """
-    if isinstance(rngs, int):
-        try:
-            from flax import nnx  # noqa: PLC0415
-        except ImportError:
-            return rngs
-        return nnx.Rngs(rngs)
-    return rngs

--- a/src/probly/transformation/class_bias_ensemble/_common.py
+++ b/src/probly/transformation/class_bias_ensemble/_common.py
@@ -8,9 +8,12 @@ from probly.predictor import LogitClassifier
 from probly.transformation.ensemble import EnsemblePredictor, register_ensemble_members
 from probly.transformation.transformation import predictor_transformation
 from probly.traverse_nn import nn_compose, reset_traverser
+from probly.traverse_nn.reset_traverser import RNGS as RESET_RNGS
 from pytraverse import TRAVERSE_REVERSED, GlobalVariable, flexdispatch_traverser, traverse
 
 if TYPE_CHECKING:
+    from flax.nnx.rnglib import Rngs, RngStream
+
     from probly.predictor import Predictor
 
 
@@ -29,7 +32,11 @@ class_bias_ensemble_traverser = flexdispatch_traverser[object](name="class_bias_
 @predictor_transformation(permitted_predictor_types=(LogitClassifier,), post_transform=register_ensemble_members)
 @ClassBiasEnsemblePredictor.register_factory(autocast_builtins=True)
 def class_bias_ensemble[**In, Out](
-    base: Predictor[In, Out], num_members: int, reset_params: bool = True, tobias_value: int = 100
+    base: Predictor[In, Out],
+    num_members: int,
+    reset_params: bool = True,
+    tobias_value: int = 100,
+    rngs: int | Rngs | RngStream = 1,
 ) -> ClassBiasEnsemblePredictor[In, Out]:
     """Create an ensemble with class-specific final-layer bias initialization.
 
@@ -38,14 +45,19 @@ def class_bias_ensemble[**In, Out](
         num_members: The number of members in the class-bias ensemble.
         reset_params: Whether to reset the parameters of each member.
         tobias_value: The value to use for the class bias initialization.
+        rngs: Optional rngs used by the flax backend when ``reset_params=True`` to draw
+            fresh keys for re-initialized parameters (types: ``rnglib.Rngs | rnglib.RngStream | int``).
+            Ignored by the torch backend. Default is ``1``.
 
     Returns:
         The class-bias ensemble predictor.
     """
     if reset_params:
         traverser = nn_compose(reset_traverser, class_bias_ensemble_traverser)
+        coerced_rngs = _coerce_rngs(rngs)
     else:
         traverser = nn_compose(class_bias_ensemble_traverser)
+        coerced_rngs = rngs
     members = [
         traverse(
             base,
@@ -56,8 +68,24 @@ def class_bias_ensemble[**In, Out](
                 INITIALIZED: False,
                 RESET_PARAMS: reset_params,
                 TRAVERSE_REVERSED: True,
+                RESET_RNGS: coerced_rngs,
             },
         )
         for i in range(num_members)
     ]
     return members  # ty:ignore[invalid-return-type]
+
+
+def _coerce_rngs(rngs: int | Rngs | RngStream) -> int | Rngs | RngStream:
+    """Coerce an int seed into an :class:`nnx.Rngs` once so members share an advancing stream.
+
+    If flax is unavailable (torch-only environments), returns the seed unchanged — the torch
+    ``reset_traverser`` ignores rngs anyway.
+    """
+    if isinstance(rngs, int):
+        try:
+            from flax import nnx  # noqa: PLC0415
+        except ImportError:
+            return rngs
+        return nnx.Rngs(rngs)
+    return rngs

--- a/src/probly/transformation/class_bias_ensemble/flax.py
+++ b/src/probly/transformation/class_bias_ensemble/flax.py
@@ -1,0 +1,45 @@
+"""Flax implementation of class-bias ensembles."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from flax import nnx
+
+from ._common import BIAS_CLS, INITIALIZED, TOBIAS_VALUE, class_bias_ensemble_traverser
+
+if TYPE_CHECKING:
+    from pytraverse.core import State
+
+
+@class_bias_ensemble_traverser.register(nnx.Module)
+def _(obj: nnx.Module, state: State) -> tuple[nnx.Module, State]:
+    """Skip layers if last linear layer is initialized or raise an error."""
+    if not state[INITIALIZED]:
+        msg = (
+            f"Initialization of class-bias ensemble models "
+            f"with last layer not being a linear layer is not possible. "
+            f"Found last layer to be of type {type(obj)}"
+        )
+        raise ValueError(msg)
+    return obj, state
+
+
+@class_bias_ensemble_traverser.register(nnx.Linear)
+def _(obj: nnx.Linear, state: State) -> tuple[nnx.Module, State]:
+    """Initialize the last linear layer with class-specific bias."""
+    if not state[INITIALIZED]:
+        if state[BIAS_CLS] > 0:
+            if obj.bias is None:
+                msg = "class_bias_ensemble requires the final nnx.Linear to have a bias."
+                raise ValueError(msg)
+            idx = (state[BIAS_CLS] - 1) % obj.out_features
+            obj.bias.value = obj.bias.value.at[idx].set(state[TOBIAS_VALUE])
+        state[INITIALIZED] = True
+    return obj, state
+
+
+@class_bias_ensemble_traverser.register(nnx.Sequential)
+def _(obj: nnx.Sequential, state: State) -> tuple[nnx.Module, State]:
+    """Skip sequential containers at the end."""
+    return obj, state

--- a/src/probly/transformation/class_bias_ensemble/flax.py
+++ b/src/probly/transformation/class_bias_ensemble/flax.py
@@ -13,20 +13,18 @@ if TYPE_CHECKING:
 
 
 @class_bias_ensemble_traverser.register(nnx.Module)
-def _(obj: nnx.Module, state: State) -> tuple[nnx.Module, State]:
-    """Skip layers if last linear layer is initialized or raise an error."""
+def skip_or_raise_on_non_linear(obj: nnx.Module, state: State) -> tuple[nnx.Module, State]:
+    """Skip layers once the last linear layer is initialized; otherwise raise an error."""
     if not state[INITIALIZED]:
         msg = (
-            f"Initialization of class-bias ensemble models "
-            f"with last layer not being a linear layer is not possible. "
-            f"Found last layer to be of type {type(obj)}"
+            f"class_bias_ensemble requires the last child of the model to be an nnx.Linear, found {type(obj).__name__}."
         )
         raise ValueError(msg)
     return obj, state
 
 
 @class_bias_ensemble_traverser.register(nnx.Linear)
-def _(obj: nnx.Linear, state: State) -> tuple[nnx.Module, State]:
+def set_class_bias(obj: nnx.Linear, state: State) -> tuple[nnx.Module, State]:
     """Initialize the last linear layer with class-specific bias."""
     if not state[INITIALIZED]:
         if state[BIAS_CLS] > 0:
@@ -40,6 +38,6 @@ def _(obj: nnx.Linear, state: State) -> tuple[nnx.Module, State]:
 
 
 @class_bias_ensemble_traverser.register(nnx.Sequential)
-def _(obj: nnx.Sequential, state: State) -> tuple[nnx.Module, State]:
+def skip_sequential(obj: nnx.Sequential, state: State) -> tuple[nnx.Module, State]:
     """Skip sequential containers at the end."""
     return obj, state

--- a/src/probly/transformation/dirichlet_exp_activation/__init__.py
+++ b/src/probly/transformation/dirichlet_exp_activation/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from probly.lazy_types import TORCH_MODULE
+from probly.lazy_types import FLAX_MODULE, TORCH_MODULE
 from probly.transformation.dirichlet_exp_activation import _common
 from probly.transformation.dirichlet_exp_activation._common import DirichletExpActivationPredictor
 
@@ -14,6 +14,12 @@ register = _common.register
 @_common.dirichlet_exp_activation_appender.delayed_register(TORCH_MODULE)
 def _(_: type) -> None:
     from . import torch as torch  # noqa: PLC0415
+
+
+## Flax
+@_common.dirichlet_exp_activation_appender.delayed_register(FLAX_MODULE)
+def _(_: type) -> None:
+    from . import flax as flax  # noqa: PLC0415
 
 
 __all__ = ["DirichletExpActivationPredictor", "dirichlet_exp_activation", "register"]

--- a/src/probly/transformation/dirichlet_exp_activation/flax.py
+++ b/src/probly/transformation/dirichlet_exp_activation/flax.py
@@ -1,0 +1,27 @@
+"""Flax Dirichlet exp-activation implementation."""
+
+from __future__ import annotations
+
+from flax import nnx
+import jax.numpy as jnp
+
+from probly.transformation.dirichlet_exp_activation._common import register
+
+
+class _Exp(nnx.Module):
+    """Elementwise exp module, turning logits into Dirichlet alpha per Malinin and Gales (2018)."""
+
+    def __call__(self, x: jnp.ndarray) -> jnp.ndarray:
+        return jnp.exp(x)
+
+
+def append_activation_flax(obj: nnx.Module) -> nnx.Sequential:
+    """Append exp so the model outputs Dirichlet alpha based on :cite:`malininPredictiveUncertaintyEstimation2018`.
+
+    Unlike Sensoy's softplus + 1 parameterization, exp allows alpha values below 1,
+    which the Prior Networks paper uses for very flat Dirichlets on out-of-distribution inputs.
+    """
+    return nnx.Sequential(obj, _Exp())
+
+
+register(nnx.Module, append_activation_flax)

--- a/src/probly/transformation/dirichlet_softplus_activation/__init__.py
+++ b/src/probly/transformation/dirichlet_softplus_activation/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from probly.lazy_types import TORCH_MODULE
+from probly.lazy_types import FLAX_MODULE, TORCH_MODULE
 from probly.transformation.dirichlet_softplus_activation import _common
 from probly.transformation.dirichlet_softplus_activation._common import DirichletSoftplusActivationPredictor
 
@@ -14,6 +14,12 @@ register = _common.register
 @_common.dirichlet_softplus_activation_appender.delayed_register(TORCH_MODULE)
 def _(_: type) -> None:
     from . import torch as torch  # noqa: PLC0415
+
+
+## Flax
+@_common.dirichlet_softplus_activation_appender.delayed_register(FLAX_MODULE)
+def _(_: type) -> None:
+    from . import flax as flax  # noqa: PLC0415
 
 
 __all__ = ["DirichletSoftplusActivationPredictor", "dirichlet_softplus_activation", "register"]

--- a/src/probly/transformation/dirichlet_softplus_activation/flax.py
+++ b/src/probly/transformation/dirichlet_softplus_activation/flax.py
@@ -9,13 +9,6 @@ import jax.numpy as jnp
 from probly.transformation.dirichlet_softplus_activation._common import register
 
 
-class _Softplus(nnx.Module):
-    """Elementwise softplus module."""
-
-    def __call__(self, x: jnp.ndarray) -> jnp.ndarray:
-        return jax.nn.softplus(x)
-
-
 class _AddOne(nnx.Module):
     """Elementwise +1 module, used to turn softplus evidence into Dirichlet alpha."""
 
@@ -30,7 +23,7 @@ def append_activation_flax(obj: nnx.Module) -> nnx.Sequential:
     concentration parameters alpha suitable for the evidential losses in
     :mod:`probly.train.evidential.flax`.
     """
-    return nnx.Sequential(obj, _Softplus(), _AddOne())
+    return nnx.Sequential(obj, jax.nn.softplus, _AddOne())
 
 
 register(nnx.Module, append_activation_flax)

--- a/src/probly/transformation/dirichlet_softplus_activation/flax.py
+++ b/src/probly/transformation/dirichlet_softplus_activation/flax.py
@@ -1,0 +1,36 @@
+"""Flax Dirichlet softplus-activation implementation."""
+
+from __future__ import annotations
+
+from flax import nnx
+import jax.nn
+import jax.numpy as jnp
+
+from probly.transformation.dirichlet_softplus_activation._common import register
+
+
+class _Softplus(nnx.Module):
+    """Elementwise softplus module."""
+
+    def __call__(self, x: jnp.ndarray) -> jnp.ndarray:
+        return jax.nn.softplus(x)
+
+
+class _AddOne(nnx.Module):
+    """Elementwise +1 module, used to turn softplus evidence into Dirichlet alpha."""
+
+    def __call__(self, x: jnp.ndarray) -> jnp.ndarray:
+        return x + 1
+
+
+def append_activation_flax(obj: nnx.Module) -> nnx.Sequential:
+    """Append Softplus + 1 so the model outputs Dirichlet alpha.
+
+    Softplus ensures non-negative evidence; the +1 shift produces Dirichlet
+    concentration parameters alpha suitable for the evidential losses in
+    :mod:`probly.train.evidential.flax`.
+    """
+    return nnx.Sequential(obj, _Softplus(), _AddOne())
+
+
+register(nnx.Module, append_activation_flax)

--- a/src/probly/transformation/ensemble/_common.py
+++ b/src/probly/transformation/ensemble/_common.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
-from typing import Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 from flextype import flexdispatch
 from probly.predictor import (
@@ -16,6 +16,11 @@ from probly.predictor import (
 )
 from probly.representation.distribution import CategoricalDistribution, DirichletDistribution
 from probly.transformation.transformation import predictor_transformation
+
+if TYPE_CHECKING:
+    from flax.nnx.rnglib import Rngs, RngStream
+
+type RNG = int | Rngs | RngStream
 
 
 @runtime_checkable
@@ -57,7 +62,7 @@ class EnsembleDirichletDistributionPredictor[**In, Out: DirichletDistribution](E
 
 @flexdispatch
 def ensemble_generator[**In, Out](
-    base: Predictor[In, Out], num_members: int, reset_params: bool = True, rngs: object = 1
+    base: Predictor[In, Out], num_members: int, reset_params: bool = True, rngs: RNG = 1
 ) -> EnsemblePredictor[In, Out]:
     """Generate an ensemble from a base model."""
     msg = f"No ensemble generator is registered for type {type(base)}"
@@ -80,7 +85,7 @@ def register_ensemble_members(ensemble: EnsemblePredictor, t: type[Predictor] | 
 )
 @EnsemblePredictor.register_factory(autocast_builtins=True)
 def ensemble[**In, Out](
-    base: Predictor[In, Out], num_members: int, reset_params: bool = True, rngs: object = 1
+    base: Predictor[In, Out], num_members: int, reset_params: bool = True, rngs: RNG = 1
 ) -> EnsemblePredictor[In, Out]:
     """Create an ensemble predictor from a base predictor based on :cite:`lakshminarayananSimpleScalable2017`.
 

--- a/src/probly/transformation/ensemble/_common.py
+++ b/src/probly/transformation/ensemble/_common.py
@@ -57,7 +57,7 @@ class EnsembleDirichletDistributionPredictor[**In, Out: DirichletDistribution](E
 
 @flexdispatch
 def ensemble_generator[**In, Out](
-    base: Predictor[In, Out], num_members: int, reset_params: bool = True
+    base: Predictor[In, Out], num_members: int, reset_params: bool = True, rngs: object = 1
 ) -> EnsemblePredictor[In, Out]:
     """Generate an ensemble from a base model."""
     msg = f"No ensemble generator is registered for type {type(base)}"
@@ -80,7 +80,7 @@ def register_ensemble_members(ensemble: EnsemblePredictor, t: type[Predictor] | 
 )
 @EnsemblePredictor.register_factory(autocast_builtins=True)
 def ensemble[**In, Out](
-    base: Predictor[In, Out], num_members: int, reset_params: bool = True
+    base: Predictor[In, Out], num_members: int, reset_params: bool = True, rngs: object = 1
 ) -> EnsemblePredictor[In, Out]:
     """Create an ensemble predictor from a base predictor based on :cite:`lakshminarayananSimpleScalable2017`.
 
@@ -88,11 +88,14 @@ def ensemble[**In, Out](
         base: Predictor, The base model to be used for the ensemble.
         num_members: The number of members in the ensemble.
         reset_params: Whether to reset the parameters of each member.
+        rngs: Optional rngs used by the flax backend when ``reset_params=True`` to draw fresh
+            keys for re-initialized parameters (types: ``rnglib.Rngs | rnglib.RngStream | int``).
+            Ignored by the torch backend. Default is ``1``.
 
     Returns:
         Predictor, The ensemble predictor.
     """
-    return ensemble_generator(base, num_members=num_members, reset_params=reset_params)
+    return ensemble_generator(base, num_members=num_members, reset_params=reset_params, rngs=rngs)
 
 
 @predict_raw.register(EnsemblePredictor)

--- a/src/probly/transformation/ensemble/flax.py
+++ b/src/probly/transformation/ensemble/flax.py
@@ -2,22 +2,28 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from flax import nnx
 import jax.numpy as jnp
 
 from probly.predictor._common import predict, predict_raw
 from probly.traverse_nn import nn_compose, nn_traverser, reset_traverser
+from probly.traverse_nn.reset_traverser import RNGS as RESET_RNGS
 from pytraverse import CLONE, traverse
 
 from ._common import ensemble_generator
+
+if TYPE_CHECKING:
+    from flax.nnx import rnglib
 
 
 def _clone(obj: nnx.Module) -> nnx.Module:
     return traverse(obj, nn_traverser, init={CLONE: True})
 
 
-def _clone_reset(obj: nnx.Module) -> nnx.Module:
-    return traverse(obj, nn_compose(reset_traverser), init={CLONE: True})
+def _clone_reset(obj: nnx.Module, rngs: nnx.Rngs | rnglib.RngStream | int) -> nnx.Module:
+    return traverse(obj, nn_compose(reset_traverser), init={CLONE: True, RESET_RNGS: rngs})
 
 
 @ensemble_generator.register(nnx.Module)
@@ -25,10 +31,12 @@ def generate_flax_ensemble(
     obj: nnx.Module,
     num_members: int,
     reset_params: bool,
+    rngs: nnx.Rngs | rnglib.RngStream | int = 1,
 ) -> nnx.List:
     """Build a flax ensemble based on :cite:`lakshminarayananSimpleScalable2017`."""
     if reset_params:
-        return nnx.List([_clone_reset(obj) for _ in range(num_members)])
+        coerced = nnx.Rngs(rngs) if isinstance(rngs, int) else rngs
+        return nnx.List([_clone_reset(obj, coerced) for _ in range(num_members)])
     return nnx.List([_clone(obj) for _ in range(num_members)])
 
 

--- a/src/probly/transformation/ensemble/flax.py
+++ b/src/probly/transformation/ensemble/flax.py
@@ -35,8 +35,7 @@ def generate_flax_ensemble(
 ) -> nnx.List:
     """Build a flax ensemble based on :cite:`lakshminarayananSimpleScalable2017`."""
     if reset_params:
-        coerced = nnx.Rngs(rngs) if isinstance(rngs, int) else rngs
-        return nnx.List([_clone_reset(obj, coerced) for _ in range(num_members)])
+        return nnx.List([_clone_reset(obj, rngs) for _ in range(num_members)])
     return nnx.List([_clone(obj) for _ in range(num_members)])
 
 

--- a/src/probly/transformation/ensemble/sklearn.py
+++ b/src/probly/transformation/ensemble/sklearn.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from sklearn.base import BaseEstimator, clone
 
-from ._common import ensemble_generator
+from ._common import RNG, ensemble_generator
 
 
 @ensemble_generator.register(BaseEstimator)
@@ -12,7 +12,7 @@ def generate_sklearn_ensemble(
     obj: BaseEstimator,
     num_members: int,
     reset_params: bool,
-    rngs: object = 1,  # noqa: ARG001
+    rngs: RNG = 1,  # noqa: ARG001
 ) -> list[object]:
     """Generates an ensemble model from a sklearn base estimator."""
     if reset_params:

--- a/src/probly/transformation/ensemble/sklearn.py
+++ b/src/probly/transformation/ensemble/sklearn.py
@@ -8,7 +8,12 @@ from ._common import ensemble_generator
 
 
 @ensemble_generator.register(BaseEstimator)
-def generate_sklearn_ensemble(obj: BaseEstimator, num_members: int, reset_params: bool) -> list[object]:
+def generate_sklearn_ensemble(
+    obj: BaseEstimator,
+    num_members: int,
+    reset_params: bool,
+    rngs: object = 1,  # noqa: ARG001
+) -> list[object]:
     """Generates an ensemble model from a sklearn base estimator."""
     if reset_params:
         obj.__setattr__("random_state", None)

--- a/src/probly/transformation/ensemble/torch.py
+++ b/src/probly/transformation/ensemble/torch.py
@@ -30,6 +30,7 @@ def generate_torch_ensemble(
     obj: nn.Module,
     num_members: int,
     reset_params: bool = True,
+    rngs: object = 1,  # noqa: ARG001
 ) -> nn.ModuleList:
     """Build a torch ensemble based on :cite:`lakshminarayananSimpleScalable2017`."""
     if reset_params:

--- a/src/probly/transformation/ensemble/torch.py
+++ b/src/probly/transformation/ensemble/torch.py
@@ -11,7 +11,7 @@ from probly.predictor._common import predict, predict_raw
 from probly.traverse_nn import nn_compose, nn_traverser, reset_traverser
 from pytraverse import CLONE, traverse
 
-from ._common import ensemble_generator
+from ._common import RNG, ensemble_generator
 
 if TYPE_CHECKING:
     from probly.representation.torch_like import TorchLike
@@ -30,7 +30,7 @@ def generate_torch_ensemble(
     obj: nn.Module,
     num_members: int,
     reset_params: bool = True,
-    rngs: object = 1,  # noqa: ARG001
+    rngs: RNG = 1,  # noqa: ARG001
 ) -> nn.ModuleList:
     """Build a torch ensemble based on :cite:`lakshminarayananSimpleScalable2017`."""
     if reset_params:

--- a/src/probly/transformation/normal_inverse_gamma_head/__init__.py
+++ b/src/probly/transformation/normal_inverse_gamma_head/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from probly.lazy_types import TORCH_MODULE
+from probly.lazy_types import FLAX_MODULE, TORCH_MODULE
 from probly.transformation.normal_inverse_gamma_head import _common
 
 normal_inverse_gamma_head = _common.normal_inverse_gamma_head
@@ -13,6 +13,12 @@ register = _common.register
 @_common.normal_inverse_gamma_head_traverser.delayed_register(TORCH_MODULE)
 def _(_: type) -> None:
     from . import torch as torch  # noqa: PLC0415
+
+
+## Flax
+@_common.normal_inverse_gamma_head_traverser.delayed_register(FLAX_MODULE)
+def _(_: type) -> None:
+    from . import flax as flax  # noqa: PLC0415
 
 
 __all__ = ["normal_inverse_gamma_head", "register"]

--- a/src/probly/transformation/normal_inverse_gamma_head/_common.py
+++ b/src/probly/transformation/normal_inverse_gamma_head/_common.py
@@ -8,6 +8,8 @@ from probly.traverse_nn import nn_compose
 from pytraverse import CLONE, TRAVERSE_REVERSED, GlobalVariable, flexdispatch_traverser, traverse
 
 if TYPE_CHECKING:
+    from flax.nnx.rnglib import Rngs, RngStream
+
     from flextype.isinstance import LazyType
     from probly.predictor import Predictor
     from pytraverse.composition import RegisteredLooseTraverser
@@ -16,6 +18,14 @@ REPLACED_LAST_LINEAR = GlobalVariable[bool](
     "REPLACED_LAST_LINEAR",
     "Whether the last linear layer has been replaced with a NormalInverseGammaLinear layer.",
     default=False,
+)
+
+type RNG = int | Rngs | RngStream
+
+RNGS = GlobalVariable[RNG](
+    "NIG_RNGS",
+    "rngs used to initialize the flax NormalInverseGammaLinear replacement layer.",
+    default=1,
 )
 
 normal_inverse_gamma_head_traverser = flexdispatch_traverser[object](name="normal_inverse_gamma_head_traverser")
@@ -28,13 +38,20 @@ def register(cls: LazyType, traverser: RegisteredLooseTraverser) -> None:
     )
 
 
-def normal_inverse_gamma_head[T: Predictor](base: T) -> T:
+def normal_inverse_gamma_head[T: Predictor](base: T, rngs: RNG = 1) -> T:
     """Replace the final linear layer with a Normal-Inverse-Gamma head.
 
     Args:
         base: Predictor, The base model to be transformed.
+        rngs: Optional rngs for the flax NormalInverseGammaLinear initialization
+            (types: ``rnglib.Rngs | rnglib.RngStream | int``). Ignored by the torch
+            backend. Default is ``1``.
 
     Returns:
         Predictor, The transformed predictor.
     """
-    return traverse(base, nn_compose(normal_inverse_gamma_head_traverser), init={TRAVERSE_REVERSED: True, CLONE: True})
+    return traverse(
+        base,
+        nn_compose(normal_inverse_gamma_head_traverser),
+        init={TRAVERSE_REVERSED: True, CLONE: True, RNGS: rngs},
+    )

--- a/src/probly/transformation/normal_inverse_gamma_head/flax.py
+++ b/src/probly/transformation/normal_inverse_gamma_head/flax.py
@@ -1,0 +1,32 @@
+"""Flax normal-inverse-gamma head implementation."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from flax import nnx
+
+from probly.layers.flax import NormalInverseGammaLinear
+from probly.transformation.normal_inverse_gamma_head._common import REPLACED_LAST_LINEAR, RNGS, register
+
+if TYPE_CHECKING:
+    from pytraverse import State, TraverserResult
+
+
+def replace_last_flax_nig(obj: nnx.Linear, state: State) -> TraverserResult:
+    """Register a class to be replaced by the NormalInverseGammaLinear layer based on :cite:`aminiDeepEvidential2020`.
+
+    This layer outputs the parameters of a Normal Inverse Gamma distribution, which is central to evidential
+    regression.
+    """
+    state[REPLACED_LAST_LINEAR] = True
+    return NormalInverseGammaLinear(
+        obj.in_features,
+        obj.out_features,
+        rngs=state[RNGS],
+        use_bias=obj.use_bias,
+        param_dtype=obj.param_dtype,
+    ), state
+
+
+register(nnx.Linear, replace_last_flax_nig)

--- a/src/probly/traverse_nn/reset_traverser/__init__.py
+++ b/src/probly/traverse_nn/reset_traverser/__init__.py
@@ -1,8 +1,8 @@
 """Reset traverser module."""
 
-from probly.lazy_types import TORCH_MODULE
+from probly.lazy_types import FLAX_MODULE, TORCH_MODULE
 
-from ._common import reset_traverser
+from ._common import RNGS, reset_traverser
 
 
 ## Torch
@@ -11,6 +11,13 @@ def _(_: type) -> None:
     from . import torch as torch  # noqa: PLC0415
 
 
+## Flax
+@reset_traverser.delayed_register(FLAX_MODULE)
+def _(_: type) -> None:
+    from . import flax as flax  # noqa: PLC0415
+
+
 __all__ = [
+    "RNGS",
     "reset_traverser",
 ]

--- a/src/probly/traverse_nn/reset_traverser/_common.py
+++ b/src/probly/traverse_nn/reset_traverser/_common.py
@@ -2,12 +2,31 @@
 
 from __future__ import annotations
 
-from pytraverse import flexdispatch_traverser
+from typing import TYPE_CHECKING
+
+from pytraverse import GlobalVariable, flexdispatch_traverser
+
+if TYPE_CHECKING:
+    from flax.nnx.rnglib import Rngs, RngStream
+
+type RNG = int | Rngs | RngStream
+
+RNGS = GlobalVariable[RNG](
+    "RESET_RNGS",
+    "rngs used to draw fresh keys when re-initializing flax parameters during reset.",
+    default=1,
+)
 
 reset_traverser = flexdispatch_traverser[object](name="reset_traverser")
 
 
 @reset_traverser.register
 def _(obj: object) -> object:
-    msg = f"resetting parameters of {type(obj)} models is not supported yet."
-    raise NotImplementedError(msg)
+    """Default fallback: leave the object unchanged.
+
+    Torch implementations register an explicit ``nn.Module`` handler that opportunistically
+    calls ``reset_parameters`` if it exists; flax implementations register handlers for the
+    layer types that have parameters worth resetting. Anything else (e.g. a jax callable
+    used as a Sequential layer, or a raw ``nnx.Variable``) is passed through untouched.
+    """
+    return obj

--- a/src/probly/traverse_nn/reset_traverser/_common.py
+++ b/src/probly/traverse_nn/reset_traverser/_common.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
 from pytraverse import GlobalVariable, flexdispatch_traverser
@@ -19,6 +20,8 @@ RNGS = GlobalVariable[RNG](
 
 reset_traverser = flexdispatch_traverser[object](name="reset_traverser")
 
+logger = logging.getLogger(__name__)
+
 
 @reset_traverser.register
 def _(obj: object) -> object:
@@ -29,4 +32,5 @@ def _(obj: object) -> object:
     layer types that have parameters worth resetting. Anything else (e.g. a jax callable
     used as a Sequential layer, or a raw ``nnx.Variable``) is passed through untouched.
     """
+    logger.debug("reset_traverser: no handler for %s; skipping", type(obj).__name__)
     return obj

--- a/src/probly/traverse_nn/reset_traverser/flax.py
+++ b/src/probly/traverse_nn/reset_traverser/flax.py
@@ -5,13 +5,14 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from flax import nnx
-from flax.nnx import rnglib
 import jax
 import jax.numpy as jnp
 
 from ._common import RNGS, reset_traverser
 
 if TYPE_CHECKING:
+    from flax.nnx import rnglib
+
     from pytraverse.core import State
 
 
@@ -19,23 +20,15 @@ def _coerce_rngs(rngs: int | nnx.Rngs | rnglib.RngStream) -> nnx.Rngs:
     """Return an :class:`nnx.Rngs` regardless of how the rng source was provided."""
     if isinstance(rngs, nnx.Rngs):
         return rngs
-    if isinstance(rngs, rnglib.RngStream):
-        return nnx.Rngs(rngs)
     return nnx.Rngs(rngs)
 
 
 @reset_traverser.register(cls=nnx.Module)
-def _(obj: nnx.Module, state: State) -> tuple[nnx.Module, State]:
+def skip_module(obj: nnx.Module, state: State) -> tuple[nnx.Module, State]:
     """Default flax reset handler. No-op for modules without trainable params.
 
     Mirrors the torch behavior of only resetting layers that explicitly support it.
     """
-    return obj, state
-
-
-@reset_traverser.register(cls=nnx.Variable)
-def _(obj: nnx.Variable, state: State) -> tuple[nnx.Variable, State]:
-    """No-op for raw flax variables encountered during traversal."""
     return obj, state
 
 
@@ -54,7 +47,7 @@ def _resolve_rngs(state: State) -> nnx.Rngs:
 
 
 @reset_traverser.register(cls=nnx.Linear)
-def _(obj: nnx.Linear, state: State) -> tuple[nnx.Module, State]:
+def reset_linear(obj: nnx.Linear, state: State) -> tuple[nnx.Module, State]:
     """Reset the kernel (and bias if present) of an :class:`nnx.Linear` layer."""
     rngs = _resolve_rngs(state)
     kernel_init = jax.nn.initializers.lecun_normal()
@@ -65,7 +58,7 @@ def _(obj: nnx.Linear, state: State) -> tuple[nnx.Module, State]:
 
 
 @reset_traverser.register(cls=nnx.Conv)
-def _(obj: nnx.Conv, state: State) -> tuple[nnx.Module, State]:
+def reset_conv(obj: nnx.Conv, state: State) -> tuple[nnx.Module, State]:
     """Reset the kernel (and bias if present) of an :class:`nnx.Conv` layer."""
     rngs = _resolve_rngs(state)
     kernel_init = jax.nn.initializers.lecun_normal()

--- a/src/probly/traverse_nn/reset_traverser/flax.py
+++ b/src/probly/traverse_nn/reset_traverser/flax.py
@@ -1,0 +1,75 @@
+"""Flax implementation of the reset traverser."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from flax import nnx
+from flax.nnx import rnglib
+import jax
+import jax.numpy as jnp
+
+from ._common import RNGS, reset_traverser
+
+if TYPE_CHECKING:
+    from pytraverse.core import State
+
+
+def _coerce_rngs(rngs: int | nnx.Rngs | rnglib.RngStream) -> nnx.Rngs:
+    """Return an :class:`nnx.Rngs` regardless of how the rng source was provided."""
+    if isinstance(rngs, nnx.Rngs):
+        return rngs
+    if isinstance(rngs, rnglib.RngStream):
+        return nnx.Rngs(rngs)
+    return nnx.Rngs(rngs)
+
+
+@reset_traverser.register(cls=nnx.Module)
+def _(obj: nnx.Module, state: State) -> tuple[nnx.Module, State]:
+    """Default flax reset handler. No-op for modules without trainable params.
+
+    Mirrors the torch behavior of only resetting layers that explicitly support it.
+    """
+    return obj, state
+
+
+@reset_traverser.register(cls=nnx.Variable)
+def _(obj: nnx.Variable, state: State) -> tuple[nnx.Variable, State]:
+    """No-op for raw flax variables encountered during traversal."""
+    return obj, state
+
+
+def _resolve_rngs(state: State) -> nnx.Rngs:
+    """Coerce the state-provided rng source into a persistent :class:`nnx.Rngs`.
+
+    Stores the coerced ``Rngs`` back into the state so subsequent layer resets advance
+    the same stream rather than sampling deterministically from the same seed.
+    """
+    rngs = state[RNGS]
+    if isinstance(rngs, nnx.Rngs):
+        return rngs
+    coerced = _coerce_rngs(rngs)
+    state[RNGS] = coerced
+    return coerced
+
+
+@reset_traverser.register(cls=nnx.Linear)
+def _(obj: nnx.Linear, state: State) -> tuple[nnx.Module, State]:
+    """Reset the kernel (and bias if present) of an :class:`nnx.Linear` layer."""
+    rngs = _resolve_rngs(state)
+    kernel_init = jax.nn.initializers.lecun_normal()
+    obj.kernel.value = kernel_init(rngs.params(), obj.kernel.value.shape, obj.param_dtype)
+    if obj.use_bias and obj.bias is not None:
+        obj.bias.value = jnp.zeros(obj.bias.value.shape, dtype=obj.param_dtype)
+    return obj, state
+
+
+@reset_traverser.register(cls=nnx.Conv)
+def _(obj: nnx.Conv, state: State) -> tuple[nnx.Module, State]:
+    """Reset the kernel (and bias if present) of an :class:`nnx.Conv` layer."""
+    rngs = _resolve_rngs(state)
+    kernel_init = jax.nn.initializers.lecun_normal()
+    obj.kernel.value = kernel_init(rngs.params(), obj.kernel.value.shape, obj.param_dtype)
+    if obj.use_bias and obj.bias is not None:
+        obj.bias.value = jnp.zeros(obj.bias.value.shape, dtype=obj.param_dtype)
+    return obj, state

--- a/src/probly_benchmark/method_scripts/het_net.py
+++ b/src/probly_benchmark/method_scripts/het_net.py
@@ -15,7 +15,7 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 model = LeNet(n_classes=5)
-cep = het_net(model, predictor_type="probabilistic_classifier")  # ty:ignore[unknown-argument, invalid-argument-type]
+cep = het_net(model, predictor_type="probabilistic_classifier")
 rep = representer(cep, num_samples=10)
 logger.info(rep)
 inputs = torch.randn(3, 1, 28, 28)

--- a/tests/probly/method/ensemble/test_common.py
+++ b/tests/probly/method/ensemble/test_common.py
@@ -38,6 +38,7 @@ def test_registered_generator_called(dummy_predictor: Predictor) -> None:
         dummy_predictor,
         num_members=4,
         reset_params=True,
+        rngs=1,
     )
     assert result is expected_result
 

--- a/tests/probly/method/ensemble/test_flax.py
+++ b/tests/probly/method/ensemble/test_flax.py
@@ -40,11 +40,10 @@ class TestEnsembleAttributes:
                 jax.tree_util.tree_map(jnp.array_equal, original_params, member_params),
             )  # no difference
 
-    @pytest.mark.skip(reason="not implemented yet")
     def test_ensemble_attributes_with_reset(self, flax_model_small_2d_2d) -> None:
         """Tests if the member attributes are not inherited from the base model."""
         num_members = 2
-        ensemble_model = ensemble(flax_model_small_2d_2d, num_members=2, reset_params=True)
+        ensemble_model = ensemble(flax_model_small_2d_2d, num_members=num_members, reset_params=True, rngs=nnx.Rngs(0))
 
         assert ensemble_model is not None
         assert isinstance(ensemble_model, nnx.List)
@@ -122,12 +121,16 @@ class TestEnsembleGeneration:
             count_module_member = count_layers(member, nnx.Module)
             assert count_module_member == count_module_original
 
-    def test_not_implemented_error_with_reset(self, flax_model_small_2d_2d) -> None:
+    def test_reset_params_returns_distinct_members(self, flax_model_small_2d_2d) -> None:
+        """``reset_params=True`` produces independently reinitialized members."""
         num_members = 2
+        ensemble_model = ensemble(flax_model_small_2d_2d, num_members=num_members, reset_params=True, rngs=nnx.Rngs(0))
 
-        msg = "resetting parameters of <class .*> models is not supported yet."
-        with pytest.raises(NotImplementedError, match=msg):
-            ensemble(flax_model_small_2d_2d, num_members=num_members, reset_params=True)
+        assert isinstance(ensemble_model, nnx.List)
+        assert len(ensemble_model) == num_members
+
+        first_kernels = [member.layers[0].kernel.value for member in ensemble_model]
+        assert not jnp.allclose(first_kernels[0], first_kernels[1])
 
 
 class TestEnsembleCalls:
@@ -145,10 +148,9 @@ class TestEnsembleCalls:
             assert custom_model_out.shape == member_out.shape
             assert jnp.equal(custom_model_out, member_out).all()  # no parameter reset
 
-    @pytest.mark.skip(reason="not implemented yet")
     def test_ensemble_flax_custom_model_call_with_reset(self, flax_custom_model) -> None:
         num_members = 2
-        ensemble_model = ensemble(flax_custom_model, num_members=num_members, reset_params=True)
+        ensemble_model = ensemble(flax_custom_model, num_members=num_members, reset_params=True, rngs=nnx.Rngs(0))
 
         x = jnp.ones((2, 1, 10))
         custom_model_out = flax_custom_model(x)

--- a/tests/probly/method/het_nets/test_flax.py
+++ b/tests/probly/method/het_nets/test_flax.py
@@ -8,6 +8,7 @@ import pytest
 
 flax = pytest.importorskip("flax")
 from flax import nnx  # noqa: E402
+import jax  # noqa: E402
 import jax.numpy as jnp  # noqa: E402
 
 from probly.layers.flax import HeteroscedasticLayer  # noqa: E402
@@ -58,3 +59,54 @@ class TestHetNetForwardPass:
         )
         out = new_model(jnp.ones((5, 4)))
         assert out.shape == (5, 2)
+
+
+class TestHetNetSoftmaxTailStripping:
+    """Tests that het_net strips a trailing softmax callable from a ``Sequential``."""
+
+    def test_trailing_jax_softmax_is_removed(self, flax_rngs: nnx.Rngs) -> None:
+        """A trailing ``jax.nn.softmax`` is dropped so the HeteroscedasticLayer is the tail."""
+        model = nnx.Sequential(
+            nnx.Linear(4, 2, rngs=flax_rngs),
+            jax.nn.softmax,
+        )
+        new_model = cast(
+            "nnx.Sequential",
+            het_net(model, num_factors=2, predictor_type="logit_classifier"),
+        )
+
+        assert len(new_model.layers) == 1
+        assert isinstance(new_model.layers[0], HeteroscedasticLayer)
+
+
+class TestHetNetRngsParameter:
+    """Tests that distinct ``rngs`` arguments produce distinct HeteroscedasticLayer params."""
+
+    def _find_het_layer(self, model: nnx.Module) -> HeteroscedasticLayer:
+        """Locate the single ``HeteroscedasticLayer`` in a transformed model."""
+        seq = cast("nnx.Sequential", model)
+        for layer in seq.layers:
+            if isinstance(layer, HeteroscedasticLayer):
+                return layer
+        msg = "no HeteroscedasticLayer found in transformed model"
+        raise AssertionError(msg)
+
+    def test_distinct_rngs_yield_distinct_layers(self, flax_regression_model_2d: nnx.Module) -> None:
+        """Different ``rngs`` seeds produce distinct ``mu_layer.kernel`` initializations."""
+        m1 = het_net(
+            flax_regression_model_2d,
+            num_factors=2,
+            rngs=nnx.Rngs(0),
+            predictor_type="logit_classifier",
+        )
+        m2 = het_net(
+            flax_regression_model_2d,
+            num_factors=2,
+            rngs=nnx.Rngs(42),
+            predictor_type="logit_classifier",
+        )
+
+        het1 = self._find_het_layer(cast("nnx.Module", m1))
+        het2 = self._find_het_layer(cast("nnx.Module", m2))
+
+        assert not jnp.allclose(het1.mu_layer.kernel.value, het2.mu_layer.kernel.value)

--- a/tests/probly/method/het_nets/test_flax.py
+++ b/tests/probly/method/het_nets/test_flax.py
@@ -1,0 +1,60 @@
+"""Tests for flax HetNets transformation."""
+
+from __future__ import annotations
+
+from typing import cast
+
+import pytest
+
+flax = pytest.importorskip("flax")
+from flax import nnx  # noqa: E402
+import jax.numpy as jnp  # noqa: E402
+
+from probly.layers.flax import HeteroscedasticLayer  # noqa: E402
+from probly.method.het_net import het_net  # noqa: E402
+from tests.probly.flax_utils import count_layers  # noqa: E402
+
+
+class TestHetNetLayerReplacement:
+    """Tests for the structural changes het_net applies to a flax model."""
+
+    def test_replaces_last_linear_with_heteroscedastic_layer(self, flax_model_small_2d_2d: nnx.Module) -> None:
+        """Verify the final ``nnx.Linear`` is replaced and other linears are untouched."""
+        original = flax_model_small_2d_2d
+        original_linear_count = count_layers(original, nnx.Linear)
+
+        new_model = cast("nnx.Module", het_net(original, num_factors=2, predictor_type="logit_classifier"))
+
+        new_linear_count = count_layers(new_model, nnx.Linear)
+        het_count = count_layers(new_model, HeteroscedasticLayer)
+
+        assert het_count == 1
+        # Each HeteroscedasticLayer contains 3 sub nnx.Linear instances (mu, diag, v).
+        # The traversal therefore reports the original count - 1 + 3 = original + 2 linears.
+        assert new_linear_count == original_linear_count + 2
+
+    def test_returns_a_clone(self, flax_model_small_2d_2d: nnx.Module) -> None:
+        """Ensure het_net does not mutate the input model."""
+        new_model = het_net(flax_model_small_2d_2d, num_factors=2, predictor_type="logit_classifier")
+        assert new_model is not flax_model_small_2d_2d
+
+
+class TestHetNetForwardPass:
+    """Tests that the transformed model produces logits of the expected shape."""
+
+    def test_forward_pass_shape(self, flax_regression_model_2d: nnx.Module) -> None:
+        """Verify the wrapped model returns ``(batch, num_classes)`` logits."""
+        new_model = het_net(flax_regression_model_2d, num_factors=3, predictor_type="logit_classifier")
+        out = new_model(jnp.ones((5, 4)))
+        assert out.shape == (5, 2)
+
+    def test_parameter_efficient_variant(self, flax_regression_model_2d: nnx.Module) -> None:
+        """Verify the parameter-efficient routing also produces logits of the expected shape."""
+        new_model = het_net(
+            flax_regression_model_2d,
+            num_factors=3,
+            is_parameter_efficient=True,
+            predictor_type="logit_classifier",
+        )
+        out = new_model(jnp.ones((5, 4)))
+        assert out.shape == (5, 2)

--- a/tests/probly/transformation/__init__.py
+++ b/tests/probly/transformation/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the probly transformation backends."""

--- a/tests/probly/transformation/class_bias_ensemble/__init__.py
+++ b/tests/probly/transformation/class_bias_ensemble/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the class-bias ensemble transformation."""

--- a/tests/probly/transformation/class_bias_ensemble/test_flax.py
+++ b/tests/probly/transformation/class_bias_ensemble/test_flax.py
@@ -1,0 +1,78 @@
+"""Tests for the flax class-bias ensemble transformation."""
+
+from __future__ import annotations
+
+from typing import cast
+
+import pytest
+
+flax = pytest.importorskip("flax")
+from flax import nnx  # noqa: E402
+import jax.numpy as jnp  # noqa: E402
+
+from probly.transformation.class_bias_ensemble import class_bias_ensemble  # noqa: E402
+
+
+def _last_linear_bias(model: nnx.Module) -> jnp.ndarray:
+    """Return the bias array of the last ``nnx.Linear`` in ``model``."""
+    seq = cast("nnx.Sequential", model)
+    last = cast("nnx.Linear", seq.layers[-1])
+    assert last.bias is not None
+    return last.bias.value
+
+
+def test_returns_num_members(flax_model_small_2d_2d: nnx.Module) -> None:
+    """class_bias_ensemble returns exactly ``num_members`` cloned models."""
+    members = class_bias_ensemble(
+        flax_model_small_2d_2d,
+        num_members=4,
+        reset_params=False,
+        predictor_type="logit_classifier",
+    )
+
+    assert len(members) == 4
+
+
+def test_first_member_keeps_bias_unchanged(flax_model_small_2d_2d: nnx.Module) -> None:
+    """The first ensemble member (``BIAS_CLS=0``) leaves the final bias untouched."""
+    members = class_bias_ensemble(
+        flax_model_small_2d_2d,
+        num_members=2,
+        reset_params=False,
+        predictor_type="logit_classifier",
+    )
+
+    assert jnp.array_equal(_last_linear_bias(members[0]), _last_linear_bias(flax_model_small_2d_2d))
+
+
+def test_subsequent_members_set_per_class_bias(flax_model_small_2d_2d: nnx.Module) -> None:
+    """Members ``i > 0`` set bias index ``(i-1) % out_features`` to ``tobias_value``."""
+    seq = cast("nnx.Sequential", flax_model_small_2d_2d)
+    out_features = cast("nnx.Linear", seq.layers[-1]).out_features
+    members = class_bias_ensemble(
+        flax_model_small_2d_2d,
+        num_members=out_features + 1,
+        reset_params=False,
+        tobias_value=42,
+        predictor_type="logit_classifier",
+    )
+
+    for i in range(1, out_features + 1):
+        bias = _last_linear_bias(members[i])
+        idx = (i - 1) % out_features
+        assert bias[idx] == 42.0
+
+
+def test_reset_params_true_yields_distinct_kernels(flax_model_small_2d_2d: nnx.Module) -> None:
+    """When ``reset_params=True``, each member gets independently reinitialized weights."""
+    members = class_bias_ensemble(
+        flax_model_small_2d_2d,
+        num_members=3,
+        reset_params=True,
+        rngs=nnx.Rngs(0),
+        predictor_type="logit_classifier",
+    )
+
+    kernels = [m.layers[0].kernel.value for m in members]
+    assert not jnp.allclose(kernels[0], kernels[1])
+    assert not jnp.allclose(kernels[1], kernels[2])

--- a/tests/probly/transformation/dirichlet_exp_activation/__init__.py
+++ b/tests/probly/transformation/dirichlet_exp_activation/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the dirichlet exp-activation transformation."""

--- a/tests/probly/transformation/dirichlet_exp_activation/test_flax.py
+++ b/tests/probly/transformation/dirichlet_exp_activation/test_flax.py
@@ -1,0 +1,40 @@
+"""Tests for the flax dirichlet exp-activation transformation."""
+
+from __future__ import annotations
+
+import pytest
+
+flax = pytest.importorskip("flax")
+from flax import nnx  # noqa: E402
+import jax.numpy as jnp  # noqa: E402
+
+from probly.predictor import predict_raw  # noqa: E402
+from probly.transformation.dirichlet_exp_activation import dirichlet_exp_activation  # noqa: E402
+
+
+def test_wraps_model_in_sequential_with_exp(flax_model_small_2d_2d: nnx.Module) -> None:
+    """The wrapped model is a Sequential whose final layer applies ``exp``."""
+    wrapped = dirichlet_exp_activation(flax_model_small_2d_2d, predictor_type="logit_classifier")
+
+    assert isinstance(wrapped, nnx.Sequential)
+    # The wrapped model should be original ``Sequential`` followed by an ``_Exp`` module.
+    assert len(wrapped.layers) == 2
+
+
+def test_outputs_are_non_negative(flax_model_small_2d_2d: nnx.Module) -> None:
+    """``exp`` always produces non-negative outputs, suitable as Dirichlet alpha."""
+    wrapped = dirichlet_exp_activation(flax_model_small_2d_2d, predictor_type="logit_classifier")
+    out = predict_raw(wrapped, jnp.ones((3, 2)))
+
+    assert out.shape == (3, 2)
+    assert (out >= 0).all()
+
+
+def test_exp_relationship_holds(flax_model_small_2d_2d: nnx.Module) -> None:
+    """Ensure the wrapped output is ``exp`` of the original logits."""
+    wrapped = dirichlet_exp_activation(flax_model_small_2d_2d, predictor_type="logit_classifier")
+    x = jnp.ones((3, 2))
+    raw_logits = flax_model_small_2d_2d(x)
+    wrapped_out = predict_raw(wrapped, x)
+
+    assert jnp.allclose(wrapped_out, jnp.exp(raw_logits), atol=1e-5)

--- a/tests/probly/transformation/dirichlet_softplus_activation/__init__.py
+++ b/tests/probly/transformation/dirichlet_softplus_activation/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the dirichlet softplus-activation transformation."""

--- a/tests/probly/transformation/dirichlet_softplus_activation/test_flax.py
+++ b/tests/probly/transformation/dirichlet_softplus_activation/test_flax.py
@@ -1,0 +1,41 @@
+"""Tests for the flax dirichlet softplus-activation transformation."""
+
+from __future__ import annotations
+
+import pytest
+
+flax = pytest.importorskip("flax")
+from flax import nnx  # noqa: E402
+import jax.nn  # noqa: E402
+import jax.numpy as jnp  # noqa: E402
+
+from probly.predictor import predict_raw  # noqa: E402
+from probly.transformation.dirichlet_softplus_activation import dirichlet_softplus_activation  # noqa: E402
+
+
+def test_wraps_model_in_sequential_with_softplus_and_add_one(flax_model_small_2d_2d: nnx.Module) -> None:
+    """The wrapped model is a Sequential whose tail applies ``softplus`` then ``+1``."""
+    wrapped = dirichlet_softplus_activation(flax_model_small_2d_2d, predictor_type="logit_classifier")
+
+    assert isinstance(wrapped, nnx.Sequential)
+    # original Sequential + Softplus + AddOne
+    assert len(wrapped.layers) == 3
+
+
+def test_outputs_are_at_least_one(flax_model_small_2d_2d: nnx.Module) -> None:
+    """``softplus(x) + 1 >= 1`` always — required for valid Dirichlet alpha."""
+    wrapped = dirichlet_softplus_activation(flax_model_small_2d_2d, predictor_type="logit_classifier")
+    out = predict_raw(wrapped, jnp.ones((3, 2)))
+
+    assert out.shape == (3, 2)
+    assert (out >= 1).all()
+
+
+def test_softplus_relationship_holds(flax_model_small_2d_2d: nnx.Module) -> None:
+    """Ensure the wrapped output equals ``softplus(logits) + 1``."""
+    wrapped = dirichlet_softplus_activation(flax_model_small_2d_2d, predictor_type="logit_classifier")
+    x = jnp.ones((3, 2))
+    raw_logits = flax_model_small_2d_2d(x)
+    wrapped_out = predict_raw(wrapped, x)
+
+    assert jnp.allclose(wrapped_out, jax.nn.softplus(raw_logits) + 1, atol=1e-5)

--- a/tests/probly/transformation/normal_inverse_gamma_head/__init__.py
+++ b/tests/probly/transformation/normal_inverse_gamma_head/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the normal-inverse-gamma head transformation."""

--- a/tests/probly/transformation/normal_inverse_gamma_head/test_flax.py
+++ b/tests/probly/transformation/normal_inverse_gamma_head/test_flax.py
@@ -1,0 +1,51 @@
+"""Tests for the flax normal-inverse-gamma head transformation."""
+
+from __future__ import annotations
+
+import pytest
+
+flax = pytest.importorskip("flax")
+from flax import nnx  # noqa: E402
+import jax.numpy as jnp  # noqa: E402
+
+from probly.layers.flax import NormalInverseGammaLinear  # noqa: E402
+from probly.transformation.normal_inverse_gamma_head import normal_inverse_gamma_head  # noqa: E402
+from tests.probly.flax_utils import count_layers  # noqa: E402
+
+
+def test_returns_a_clone(flax_regression_model_2d: nnx.Module) -> None:
+    """normal_inverse_gamma_head returns a clone, leaving the original untouched."""
+    new_model = normal_inverse_gamma_head(flax_regression_model_2d)
+
+    assert new_model is not flax_regression_model_2d
+
+
+def test_replaces_only_last_linear_layer(flax_regression_model_2d: nnx.Module) -> None:
+    """Exactly one ``NormalInverseGammaLinear`` is inserted, and one ``nnx.Linear`` removed."""
+    original = flax_regression_model_2d
+    original_linear_count = count_layers(original, nnx.Linear)
+
+    new_model = normal_inverse_gamma_head(original)
+    new_linear_count = count_layers(new_model, nnx.Linear)
+    nig_count = count_layers(new_model, NormalInverseGammaLinear)
+
+    assert nig_count == 1
+    assert new_linear_count == original_linear_count - 1
+
+
+def test_forward_pass_returns_nig_dict(flax_regression_model_2d: nnx.Module) -> None:
+    """The transformed model returns the four NIG parameter heads with consistent shapes."""
+    new_model = normal_inverse_gamma_head(flax_regression_model_2d)
+    out = new_model(jnp.ones((3, 4)))
+
+    assert isinstance(out, dict)
+    assert set(out.keys()) == {"gamma", "nu", "alpha", "beta"}
+
+    expected_shape = (3, 2)
+    for value in out.values():
+        assert value.shape == expected_shape
+
+    # nu, beta are softplus → non-negative; alpha is softplus + 1 → at least one
+    assert (out["nu"] >= 0).all()
+    assert (out["beta"] >= 0).all()
+    assert (out["alpha"] >= 1).all()

--- a/tests/probly/transformation/normal_inverse_gamma_head/test_flax.py
+++ b/tests/probly/transformation/normal_inverse_gamma_head/test_flax.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import cast
+
 import pytest
 
 flax = pytest.importorskip("flax")
@@ -49,3 +51,28 @@ def test_forward_pass_returns_nig_dict(flax_regression_model_2d: nnx.Module) -> 
     assert (out["nu"] >= 0).all()
     assert (out["beta"] >= 0).all()
     assert (out["alpha"] >= 1).all()
+
+
+def test_distinct_rngs_yield_distinct_layers(flax_regression_model_2d: nnx.Module) -> None:
+    """Different ``rngs`` seeds produce distinct ``NormalInverseGammaLinear`` parameters."""
+    m1 = normal_inverse_gamma_head(flax_regression_model_2d, rngs=nnx.Rngs(0))
+    m2 = normal_inverse_gamma_head(flax_regression_model_2d, rngs=nnx.Rngs(42))
+
+    seq1 = cast("nnx.Sequential", m1)
+    seq2 = cast("nnx.Sequential", m2)
+    nig1 = next(layer for layer in seq1.layers if isinstance(layer, NormalInverseGammaLinear))
+    nig2 = next(layer for layer in seq2.layers if isinstance(layer, NormalInverseGammaLinear))
+
+    assert not jnp.allclose(nig1.gamma.value, nig2.gamma.value)
+
+
+def test_earlier_layers_unchanged(flax_regression_model_2d: nnx.Module) -> None:
+    """Layers before the replaced final ``Linear`` retain their original types."""
+    original = cast("nnx.Sequential", flax_regression_model_2d)
+    new_model = cast("nnx.Sequential", normal_inverse_gamma_head(flax_regression_model_2d))
+
+    last_layer_index = len(original.layers) - 1
+    for i in range(last_layer_index):
+        assert type(original.layers[i]) is type(new_model.layers[i])
+
+    assert isinstance(new_model.layers[last_layer_index], NormalInverseGammaLinear)


### PR DESCRIPTION
## Flax coverage for 5 torch-only methods

Adds flax (`nnx`) implementations for methods previously torch-only, raising flax coverage from 6/20 to 11/20.

### New flax transformations / methods
- `dirichlet_exp_activation` — wraps model in `nnx.Sequential(model, _Exp())`
- `dirichlet_softplus_activation` — wraps model in `nnx.Sequential(model, _Softplus(), _AddOne())`
- `het_net` — replaces last `nnx.Linear` with new `HeteroscedasticLayer`
- `class_bias_ensemble` — functional bias update via `bias.value.at[idx].set(...)`
- `normal_inverse_gamma_head` — replaces last `nnx.Linear` with new `NormalInverseGammaLinear`

### New flax layers (`src/probly/layers/flax.py`)
- `HeteroscedasticLayer` (with parameter-efficient routing)
- `NormalInverseGammaLinear` (returns `{gamma, nu, alpha, beta}`)

### Reset traverser
- Flax `reset_traverser` now functional: re-inits `nnx.Linear` / `nnx.Conv` kernels with fresh keys
- `ensemble` and `class_bias_ensemble` accept a new `rngs` arg (ignored by torch)
- Previously-skipped flax `ensemble(reset_params=True)` tests now enabled

### Tests
- 5 new flax test files, 17 new tests
- 3 existing ensemble tests updated to assert positive reset behavior
- Full suite: 343 passed, 4 skipped; prek and `sphinx -W` clean