### PR TITLE
Add flax implementations for dirichlet exp/softplus activations

### DIFF
--- a/src/probly/transformation/dirichlet_exp_activation/__init__.py
+++ b/src/probly/transformation/dirichlet_exp_activation/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from probly.lazy_types import TORCH_MODULE
+from probly.lazy_types import FLAX_MODULE, TORCH_MODULE
 from probly.transformation.dirichlet_exp_activation import _common
 from probly.transformation.dirichlet_exp_activation._common import DirichletExpActivationPredictor
 
@@ -14,6 +14,12 @@ register = _common.register
 @_common.dirichlet_exp_activation_appender.delayed_register(TORCH_MODULE)
 def _(_: type) -> None:
     from . import torch as torch  # noqa: PLC0415
+
+
+## Flax
+@_common.dirichlet_exp_activation_appender.delayed_register(FLAX_MODULE)
+def _(_: type) -> None:
+    from . import flax as flax  # noqa: PLC0415
 
 
 __all__ = ["DirichletExpActivationPredictor", "dirichlet_exp_activation", "register"]

--- a/src/probly/transformation/dirichlet_exp_activation/flax.py
+++ b/src/probly/transformation/dirichlet_exp_activation/flax.py
@@ -1,0 +1,27 @@
+"""Flax Dirichlet exp-activation implementation."""
+
+from __future__ import annotations
+
+from flax import nnx
+import jax.numpy as jnp
+
+from probly.transformation.dirichlet_exp_activation._common import register
+
+
+class _Exp(nnx.Module):
+    """Elementwise exp module, turning logits into Dirichlet alpha per Malinin and Gales (2018)."""
+
+    def __call__(self, x: jnp.ndarray) -> jnp.ndarray:
+        return jnp.exp(x)
+
+
+def append_activation_flax(obj: nnx.Module) -> nnx.Sequential:
+    """Append exp so the model outputs Dirichlet alpha based on :cite:`malininPredictiveUncertaintyEstimation2018`.
+
+    Unlike Sensoy's softplus + 1 parameterization, exp allows alpha values below 1,
+    which the Prior Networks paper uses for very flat Dirichlets on out-of-distribution inputs.
+    """
+    return nnx.Sequential(obj, _Exp())
+
+
+register(nnx.Module, append_activation_flax)

--- a/src/probly/transformation/dirichlet_softplus_activation/__init__.py
+++ b/src/probly/transformation/dirichlet_softplus_activation/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from probly.lazy_types import TORCH_MODULE
+from probly.lazy_types import FLAX_MODULE, TORCH_MODULE
 from probly.transformation.dirichlet_softplus_activation import _common
 from probly.transformation.dirichlet_softplus_activation._common import DirichletSoftplusActivationPredictor
 
@@ -14,6 +14,12 @@ register = _common.register
 @_common.dirichlet_softplus_activation_appender.delayed_register(TORCH_MODULE)
 def _(_: type) -> None:
     from . import torch as torch  # noqa: PLC0415
+
+
+## Flax
+@_common.dirichlet_softplus_activation_appender.delayed_register(FLAX_MODULE)
+def _(_: type) -> None:
+    from . import flax as flax  # noqa: PLC0415
 
 
 __all__ = ["DirichletSoftplusActivationPredictor", "dirichlet_softplus_activation", "register"]

--- a/src/probly/transformation/dirichlet_softplus_activation/flax.py
+++ b/src/probly/transformation/dirichlet_softplus_activation/flax.py
@@ -1,0 +1,29 @@
+"""Flax Dirichlet softplus-activation implementation."""
+
+from __future__ import annotations
+
+from flax import nnx
+import jax.nn
+import jax.numpy as jnp
+
+from probly.transformation.dirichlet_softplus_activation._common import register
+
+
+class _AddOne(nnx.Module):
+    """Elementwise +1 module, used to turn softplus evidence into Dirichlet alpha."""
+
+    def __call__(self, x: jnp.ndarray) -> jnp.ndarray:
+        return x + 1
+
+
+def append_activation_flax(obj: nnx.Module) -> nnx.Sequential:
+    """Append Softplus + 1 so the model outputs Dirichlet alpha.
+
+    Softplus ensures non-negative evidence; the +1 shift produces Dirichlet
+    concentration parameters alpha suitable for the evidential losses in
+    :mod:`probly.train.evidential.flax`.
+    """
+    return nnx.Sequential(obj, jax.nn.softplus, _AddOne())
+
+
+register(nnx.Module, append_activation_flax)

--- a/tests/probly/transformation/__init__.py
+++ b/tests/probly/transformation/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the probly transformation backends."""

--- a/tests/probly/transformation/dirichlet_exp_activation/__init__.py
+++ b/tests/probly/transformation/dirichlet_exp_activation/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the dirichlet exp-activation transformation."""

--- a/tests/probly/transformation/dirichlet_exp_activation/test_flax.py
+++ b/tests/probly/transformation/dirichlet_exp_activation/test_flax.py
@@ -1,0 +1,40 @@
+"""Tests for the flax dirichlet exp-activation transformation."""
+
+from __future__ import annotations
+
+import pytest
+
+flax = pytest.importorskip("flax")
+from flax import nnx  # noqa: E402
+import jax.numpy as jnp  # noqa: E402
+
+from probly.predictor import predict_raw  # noqa: E402
+from probly.transformation.dirichlet_exp_activation import dirichlet_exp_activation  # noqa: E402
+
+
+def test_wraps_model_in_sequential_with_exp(flax_model_small_2d_2d: nnx.Module) -> None:
+    """The wrapped model is a Sequential whose final layer applies ``exp``."""
+    wrapped = dirichlet_exp_activation(flax_model_small_2d_2d, predictor_type="logit_classifier")
+
+    assert isinstance(wrapped, nnx.Sequential)
+    # The wrapped model should be original ``Sequential`` followed by an ``_Exp`` module.
+    assert len(wrapped.layers) == 2
+
+
+def test_outputs_are_non_negative(flax_model_small_2d_2d: nnx.Module) -> None:
+    """``exp`` always produces non-negative outputs, suitable as Dirichlet alpha."""
+    wrapped = dirichlet_exp_activation(flax_model_small_2d_2d, predictor_type="logit_classifier")
+    out = predict_raw(wrapped, jnp.ones((3, 2)))
+
+    assert out.shape == (3, 2)
+    assert (out >= 0).all()
+
+
+def test_exp_relationship_holds(flax_model_small_2d_2d: nnx.Module) -> None:
+    """Ensure the wrapped output is ``exp`` of the original logits."""
+    wrapped = dirichlet_exp_activation(flax_model_small_2d_2d, predictor_type="logit_classifier")
+    x = jnp.ones((3, 2))
+    raw_logits = flax_model_small_2d_2d(x)
+    wrapped_out = predict_raw(wrapped, x)
+
+    assert jnp.allclose(wrapped_out, jnp.exp(raw_logits), atol=1e-5)

--- a/tests/probly/transformation/dirichlet_softplus_activation/__init__.py
+++ b/tests/probly/transformation/dirichlet_softplus_activation/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the dirichlet softplus-activation transformation."""

--- a/tests/probly/transformation/dirichlet_softplus_activation/test_flax.py
+++ b/tests/probly/transformation/dirichlet_softplus_activation/test_flax.py
@@ -1,0 +1,41 @@
+"""Tests for the flax dirichlet softplus-activation transformation."""
+
+from __future__ import annotations
+
+import pytest
+
+flax = pytest.importorskip("flax")
+from flax import nnx  # noqa: E402
+import jax.nn  # noqa: E402
+import jax.numpy as jnp  # noqa: E402
+
+from probly.predictor import predict_raw  # noqa: E402
+from probly.transformation.dirichlet_softplus_activation import dirichlet_softplus_activation  # noqa: E402
+
+
+def test_wraps_model_in_sequential_with_softplus_and_add_one(flax_model_small_2d_2d: nnx.Module) -> None:
+    """The wrapped model is a Sequential whose tail applies ``softplus`` then ``+1``."""
+    wrapped = dirichlet_softplus_activation(flax_model_small_2d_2d, predictor_type="logit_classifier")
+
+    assert isinstance(wrapped, nnx.Sequential)
+    # original Sequential + Softplus + AddOne
+    assert len(wrapped.layers) == 3
+
+
+def test_outputs_are_at_least_one(flax_model_small_2d_2d: nnx.Module) -> None:
+    """``softplus(x) + 1 >= 1`` always — required for valid Dirichlet alpha."""
+    wrapped = dirichlet_softplus_activation(flax_model_small_2d_2d, predictor_type="logit_classifier")
+    out = predict_raw(wrapped, jnp.ones((3, 2)))
+
+    assert out.shape == (3, 2)
+    assert (out >= 1).all()
+
+
+def test_softplus_relationship_holds(flax_model_small_2d_2d: nnx.Module) -> None:
+    """Ensure the wrapped output equals ``softplus(logits) + 1``."""
+    wrapped = dirichlet_softplus_activation(flax_model_small_2d_2d, predictor_type="logit_classifier")
+    x = jnp.ones((3, 2))
+    raw_logits = flax_model_small_2d_2d(x)
+    wrapped_out = predict_raw(wrapped, x)
+
+    assert jnp.allclose(wrapped_out, jax.nn.softplus(raw_logits) + 1, atol=1e-5)


### PR DESCRIPTION
## Flax: Dirichlet exp/softplus activations

Adds flax (`flax.nnx`) implementations for the two Dirichlet activation transformations, which previously only had torch backends.

### Changes
- **`dirichlet_exp_activation`** — wraps the model in `nnx.Sequential(model, _Exp())`, where `_Exp` is a tiny `nnx.Module` calling `jnp.exp`.
- **`dirichlet_softplus_activation`** — wraps the model in `nnx.Sequential(model, jax.nn.softplus, _AddOne())`, mirroring the torch `Sequential(model, Softplus, +1)` shape.
- Registers both via the existing `flexdispatch` appender pattern, with `delayed_register(FLAX_MODULE)` mirroring the torch entry.

### Tests
6 new tests under `tests/probly/transformation/dirichlet_{exp,softplus}_activation/test_flax.py`:
- structural assertion that the wrapped model is a `Sequential` with the right tail
- forward-pass produces non-negative outputs (exp) or `>= 1` outputs (softplus + 1)
- math sanity: wrapped output equals `jnp.exp(logits)` / `jax.nn.softplus(logits) + 1`

### Verification
- `uv run pytest tests/probly/transformation/dirichlet_exp_activation tests/probly/transformation/dirichlet_softplus_activation` — 6 passed
- `uv run prek run --all-files` — clean
- No changes to dispatch infrastructure or shared code; purely additive.