### PR TITLE
Add flax implementations for het_net and normal_inverse_gamma_head

### DIFF
--- a/src/probly/layers/flax.py
+++ b/src/probly/layers/flax.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from typing import Any, Literal
 
 from flax import nnx
@@ -478,3 +479,263 @@ class BatchEnsembleConv(nnx.Conv):
             bias_dim = (slice(None),) + (None,) * (y.ndim - 2) + (slice(None),)
             y = y + self.bias[bias_dim]
         return y.reshape(eb, *y.shape[2:])
+
+
+class HeteroscedasticLayer(nnx.Module):
+    """A unified Flax implementation of the Heteroscedastic layer based on :cite:`collier2021hetnets`.
+
+    Attributes:
+        in_features: int, number of input features.
+        num_classes: int, number of classes.
+        num_factors: int, number of factors.
+        temperature: float, temperature scaling.
+        is_parameter_efficient: bool, whether to use parameter efficient routing.
+        mu_layer: nnx.Linear, deterministic mean parameter transformation.
+        diag_layer: nnx.Linear, diagonal correction variance transformation.
+        v_layer: nnx.Linear, covariance factor parameterization routing.
+        V_matrix: nnx.Param, global homoscedastic matrix (if parameter efficient).
+        rngs: rnglib.Rngs or rnglib.RngStream or None, rng key used to draw
+            standard-normal samples at call time.
+    """
+
+    def __init__(
+        self,
+        in_features: int,
+        num_classes: int,
+        num_factors: int = 15,
+        temperature: float = 1.0,
+        is_parameter_efficient: bool = False,
+        rngs: rnglib.Rngs | rnglib.RngStream | int = 1,
+    ) -> None:
+        """Initialize the HeteroscedasticLayer.
+
+        Args:
+            in_features: Number of input features.
+            num_classes: Number of classes.
+            num_factors: Number of low-rank covariance factors.
+            temperature: Temperature scaling applied to the sampled utilities.
+            is_parameter_efficient: Whether to use the parameter-efficient routing.
+            rngs: ``nnx.Rngs``, ``RngStream`` or integer seed used both to initialize the
+                sub-layers and to draw standard-normal samples at call time. May also be
+                overridden per call.
+        """
+        if isinstance(rngs, (int, rnglib.RngStream)):
+            rngs = nnx.Rngs(rngs)
+        self.in_features = in_features
+        self.num_classes = num_classes
+        self.num_factors = num_factors
+        self.temperature = temperature
+        self.is_parameter_efficient = is_parameter_efficient
+
+        xavier_uniform = jax.nn.initializers.xavier_uniform()
+        zeros = jax.nn.initializers.zeros
+        diag_bias_value = math.log(math.exp(1.0) - 1.0)
+
+        def constant_init(value: float):  # noqa: ANN202
+            def init_fn(_key: jax.Array, shape: tuple[int, ...], dtype: Any) -> jax.Array:  # noqa: ANN401
+                return jnp.full(shape, value, dtype=dtype)
+
+            return init_fn
+
+        self.mu_layer = nnx.Linear(
+            in_features,
+            num_classes,
+            kernel_init=xavier_uniform,
+            bias_init=zeros,
+            rngs=rngs,
+        )
+        self.diag_layer = nnx.Linear(
+            in_features,
+            num_classes,
+            kernel_init=xavier_uniform,
+            bias_init=constant_init(diag_bias_value),
+            rngs=rngs,
+        )
+
+        if is_parameter_efficient:
+            self.v_layer = nnx.Linear(
+                in_features,
+                num_factors,
+                kernel_init=xavier_uniform,
+                bias_init=zeros,
+                rngs=rngs,
+            )
+            v_matrix_key = rngs.params()
+            self.V_matrix = nnx.Param(
+                jax.nn.initializers.xavier_normal()(v_matrix_key, (num_classes, num_factors), jnp.float32),
+            )
+        else:
+            self.v_layer = nnx.Linear(
+                in_features,
+                num_classes * num_factors,
+                kernel_init=xavier_uniform,
+                bias_init=zeros,
+                rngs=rngs,
+            )
+
+        if isinstance(rngs, rnglib.Rngs):
+            self.rngs = rngs["het_net"].fork()
+        elif isinstance(rngs, rnglib.RngStream):
+            self.rngs = rngs.fork()
+        else:
+            self.rngs = nnx.data(None)
+
+    def __call__(
+        self,
+        x: jax.Array,
+        *,
+        rngs: rnglib.Rngs | rnglib.RngStream | jax.Array | None = None,
+    ) -> jax.Array:
+        """Draw a single utility sample and return temperature-scaled logits.
+
+        Samples once from a multivariate normal whose covariance is parameterized by a low-rank
+        factor plus a diagonal term derived from the input. Each call yields a different sample
+        because the noise is drawn freshly from the supplied ``rngs``; the outer sampler turns
+        repeated calls into a Monte Carlo sample of categorical distributions.
+
+        Args:
+            x: Input array of shape ``(batch_size, in_features)``.
+            rngs: Optional override of the rng source for sampling.
+
+        Returns:
+            Temperature-scaled utility logits of shape ``(batch_size, num_classes)``.
+        """
+        rng_source = first_from(
+            rngs,
+            self.rngs,
+            error_msg=(
+                "No `rngs` argument was provided to HeteroscedasticLayer "
+                "as either a __call__ argument or class attribute."
+            ),
+        )
+
+        if isinstance(rng_source, rnglib.Rngs):
+            key = rng_source["het_net"]()
+        elif isinstance(rng_source, rnglib.RngStream):
+            key = rng_source()
+        elif isinstance(rng_source, jax.Array):
+            key = rng_source
+        else:
+            msg = f"rngs must be Rngs, RngStream or jax.Array, but got {type(rng_source)}"
+            raise TypeError(msg)
+
+        key_k, key_r = jax.random.split(key)
+        batch_size = x.shape[0]
+
+        mu = self.mu_layer(x)
+        diag_scale = jax.nn.softplus(self.diag_layer(x))
+
+        eps_k = jax.random.normal(key_k, (batch_size, self.num_classes), dtype=x.dtype)
+        eps_r = jax.random.normal(key_r, (batch_size, self.num_factors), dtype=x.dtype)
+
+        if self.is_parameter_efficient:
+            v_x = self.v_layer(x)
+            scaled_eps_r = (eps_r * v_x)[..., None]
+            low_rank_noise = jnp.matmul(self.V_matrix.value, scaled_eps_r).squeeze(-1)
+        else:
+            v_x_full = self.v_layer(x).reshape(batch_size, self.num_classes, self.num_factors)
+            low_rank_noise = jnp.matmul(v_x_full, eps_r[..., None]).squeeze(-1)
+
+        utilities = mu + diag_scale * eps_k + low_rank_noise
+        return utilities / self.temperature
+
+
+class NormalInverseGammaLinear(nnx.Module):
+    """Custom Linear layer for a normal-inverse-gamma distribution based on :cite:`aminiDeepEvidential2020`.
+
+    Outputs four heads parameterizing the mean of a normal distribution and the parameters
+    of an inverse-gamma distribution over its variance, in the form
+    ``{"gamma": ..., "nu": ..., "alpha": ..., "beta": ...}``.
+
+    Attributes:
+        gamma: nnx.Param of shape ``(in_features, out_features)``, the mean of the normal distribution.
+        nu: nnx.Param of shape ``(in_features, out_features)``, parameter of the normal distribution.
+        alpha: nnx.Param of shape ``(in_features, out_features)``, parameter of the inverse-gamma distribution.
+        beta: nnx.Param of shape ``(in_features, out_features)``, parameter of the inverse-gamma distribution.
+        gamma_bias: nnx.Param of shape ``(out_features,)`` (or None), bias for the mean head.
+        nu_bias: nnx.Param of shape ``(out_features,)`` (or None), bias for the nu head.
+        alpha_bias: nnx.Param of shape ``(out_features,)`` (or None), bias for the alpha head.
+        beta_bias: nnx.Param of shape ``(out_features,)`` (or None), bias for the beta head.
+        in_features: int, number of input features.
+        out_features: int, number of output features.
+        use_bias: bool, whether the layer carries bias parameters.
+        param_dtype: dtype, parameter dtype.
+    """
+
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        rngs: nnx.Rngs | rnglib.RngStream | int = 1,
+        *,
+        use_bias: bool = True,
+        param_dtype: Any = jnp.float32,  # noqa: ANN401
+    ) -> None:
+        """Initialize a NormalInverseGammaLinear layer.
+
+        Args:
+            in_features: Number of input features.
+            out_features: Number of output features.
+            rngs: ``nnx.Rngs``, ``RngStream`` or integer seed used to initialize parameters.
+            use_bias: Whether to include bias parameters for each head. Defaults to True.
+            param_dtype: Parameter dtype. Defaults to ``jnp.float32``.
+        """
+        if isinstance(rngs, (int, rnglib.RngStream)):
+            rngs = nnx.Rngs(rngs)
+
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_bias = use_bias
+        self.param_dtype = param_dtype
+
+        kernel_shape = (in_features, out_features)
+        # Match torch's kaiming_uniform with a=sqrt(5), which is equivalent to
+        # uniform(-1/sqrt(in_features), 1/sqrt(in_features)) per the torch docs.
+        bound = 1.0 / math.sqrt(in_features) if in_features > 0 else 0.0
+
+        def _uniform_init(shape: tuple[int, ...]) -> jax.Array:
+            return jax.random.uniform(rngs.params(), shape, dtype=param_dtype, minval=-bound, maxval=bound)
+
+        self.gamma = nnx.Param(_uniform_init(kernel_shape))
+        self.nu = nnx.Param(_uniform_init(kernel_shape))
+        self.alpha = nnx.Param(_uniform_init(kernel_shape))
+        self.beta = nnx.Param(_uniform_init(kernel_shape))
+
+        if use_bias:
+            self.gamma_bias = nnx.Param(_uniform_init((out_features,)))
+            self.nu_bias = nnx.Param(_uniform_init((out_features,)))
+            self.alpha_bias = nnx.Param(_uniform_init((out_features,)))
+            self.beta_bias = nnx.Param(_uniform_init((out_features,)))
+        else:
+            self.gamma_bias = None
+            self.nu_bias = None
+            self.alpha_bias = None
+            self.beta_bias = None
+
+    def __call__(self, x: jax.Array) -> dict[str, jax.Array]:
+        """Forward pass of the NormalInverseGamma layer.
+
+        Args:
+            x: Input array of shape ``(batch_size, in_features)``.
+
+        Returns:
+            Dict mapping ``{"gamma", "nu", "alpha", "beta"}`` to the corresponding head outputs.
+        """
+        gamma = jnp.matmul(x, self.gamma.value)
+        nu_pre = jnp.matmul(x, self.nu.value)
+        alpha_pre = jnp.matmul(x, self.alpha.value)
+        beta_pre = jnp.matmul(x, self.beta.value)
+        if (
+            self.gamma_bias is not None
+            and self.nu_bias is not None
+            and self.alpha_bias is not None
+            and self.beta_bias is not None
+        ):
+            gamma = gamma + self.gamma_bias.value
+            nu_pre = nu_pre + self.nu_bias.value
+            alpha_pre = alpha_pre + self.alpha_bias.value
+            beta_pre = beta_pre + self.beta_bias.value
+        nu = jax.nn.softplus(nu_pre)
+        alpha = jax.nn.softplus(alpha_pre) + 1
+        beta = jax.nn.softplus(beta_pre)
+        return {"gamma": gamma, "nu": nu, "alpha": alpha, "beta": beta}

--- a/src/probly/method/het_net/__init__.py
+++ b/src/probly/method/het_net/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from probly.lazy_types import TORCH_MODULE
+from probly.lazy_types import FLAX_MODULE, TORCH_MODULE
 
 from ._common import (
     HetNetPredictor,
@@ -17,6 +17,11 @@ from ._common import (
 @het_net_traverser.delayed_register(TORCH_MODULE)
 def _(_: type) -> None:
     from . import torch as torch  # noqa: PLC0415
+
+
+@het_net_traverser.delayed_register(FLAX_MODULE)
+def _(_: type) -> None:
+    from . import flax as flax  # noqa: PLC0415
 
 
 __all__ = [

--- a/src/probly/method/het_net/_common.py
+++ b/src/probly/method/het_net/_common.py
@@ -19,6 +19,8 @@ from pytraverse import CLONE, TRAVERSE_REVERSED, GlobalVariable, flexdispatch_tr
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
+    from flax.nnx.rnglib import Rngs, RngStream
+
 
 class HetNetRepresentation[T: CategoricalDistribution](CategoricalDistributionSample[T]):
     """A sample of categorical distributions produced by a HetNets model.
@@ -35,10 +37,13 @@ class HetNetPredictor[**In, Out: CategoricalDistribution](RandomPredictor[In, Ou
 
 het_net_traverser = flexdispatch_traverser[object](name="het_nets_traverser")
 
+type RNG = int | Rngs | RngStream
+
 LAST_LAYER = GlobalVariable[bool]("LAST_LAYER")
 NUM_FACTORS = GlobalVariable[int]("NUM_FACTORS")
 TEMPERATURE = GlobalVariable[float]("TEMPERATURE")
 IS_PARAMETER_EFFICIENT = GlobalVariable[bool]("IS_PARAMETER_EFFICIENT")
+RNGS = GlobalVariable[RNG]("RNGS", "rngs for flax HeteroscedasticLayer initialization.", default=1)
 
 
 @predictor_transformation(
@@ -54,6 +59,7 @@ def het_net[**In, Out: CategoricalDistribution](
     num_factors: int = 10,
     temperature: float = 1.0,
     is_parameter_efficient: bool = False,
+    rngs: RNG = 1,
 ) -> HetNetPredictor[In, Out]:
     """Create a HetNets predictor from a base predictor base on :cite:`collier2021hetnets`.
 
@@ -62,6 +68,9 @@ def het_net[**In, Out: CategoricalDistribution](
         num_factors: The rank of the low-rank covariance parametrization.
         temperature: The temperature parameter for scaling the utility.
         is_parameter_efficient: Whether to use the parameter-efficient version.
+        rngs: Optional rngs for the flax HeteroscedasticLayer initialization (types:
+            ``rnglib.Rngs | rnglib.RngStream | int``). Ignored by the torch backend.
+            Default is ``1``.
 
     Returns:
         The HetNets predictor.
@@ -76,6 +85,7 @@ def het_net[**In, Out: CategoricalDistribution](
             NUM_FACTORS: num_factors,
             TEMPERATURE: temperature,
             IS_PARAMETER_EFFICIENT: is_parameter_efficient,
+            RNGS: rngs,
         },
     )
 

--- a/src/probly/method/het_net/flax.py
+++ b/src/probly/method/het_net/flax.py
@@ -1,0 +1,75 @@
+"""Flax implementation of HetNets."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from flax import nnx
+import jax
+
+from probly.layers.flax import HeteroscedasticLayer
+
+from ._common import (
+    IS_PARAMETER_EFFICIENT,
+    LAST_LAYER,
+    NUM_FACTORS,
+    RNGS,
+    TEMPERATURE,
+    het_net_traverser,
+)
+
+if TYPE_CHECKING:
+    from pytraverse import State
+
+
+# Identity-matched callables that are equivalent to a torch ``nn.Softmax`` tail
+# and that the het_net transformation should strip from a trailing position
+# (the HeteroscedasticLayer applies its own activation internally, so leaving a
+# softmax behind would double-activate the output).
+_SOFTMAX_TAILS: frozenset[object] = frozenset(
+    {
+        jax.nn.softmax,
+        jax.nn.log_softmax,
+        nnx.softmax,
+        nnx.log_softmax,
+    }
+)
+
+
+@het_net_traverser.register(nnx.Module)
+def skip_layer(obj: nnx.Module, state: State) -> tuple[nnx.Module, State]:
+    """Traverser for unchanged flax layers."""
+    return obj, state
+
+
+@het_net_traverser.register(nnx.Linear)
+def drop_in_place_het_layer(obj: nnx.Linear, state: State) -> tuple[nnx.Module, State]:
+    """Replace the last linear layer with a HeteroscedasticLayer."""
+    if state[LAST_LAYER]:
+        state[LAST_LAYER] = False
+        return HeteroscedasticLayer(
+            in_features=obj.in_features,
+            num_classes=obj.out_features,
+            num_factors=state[NUM_FACTORS],
+            temperature=state[TEMPERATURE],
+            is_parameter_efficient=state[IS_PARAMETER_EFFICIENT],
+            rngs=state[RNGS],
+        ), state
+    return obj, state
+
+
+@het_net_traverser.register(nnx.Sequential)
+def strip_trailing_softmax(obj: nnx.Sequential, state: State) -> tuple[nnx.Module, State]:
+    """Strip a trailing softmax-like callable from the end of a ``Sequential``.
+
+    Mirrors the torch handler that replaces a trailing ``nn.Softmax`` with
+    ``nn.Identity`` -- the HeteroscedasticLayer applies its own activation, so a
+    bare ``jax.nn.softmax`` (or sibling) at the tail would double-activate.
+
+    Matching is by identity against a small allowlist of known callables; an
+    arbitrary callable in the tail position is left untouched.
+    """
+    layers = list(obj.layers)
+    if layers and layers[-1] in _SOFTMAX_TAILS:
+        return nnx.Sequential(*layers[:-1]), state
+    return obj, state

--- a/src/probly/transformation/normal_inverse_gamma_head/__init__.py
+++ b/src/probly/transformation/normal_inverse_gamma_head/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from probly.lazy_types import TORCH_MODULE
+from probly.lazy_types import FLAX_MODULE, TORCH_MODULE
 from probly.transformation.normal_inverse_gamma_head import _common
 
 normal_inverse_gamma_head = _common.normal_inverse_gamma_head
@@ -13,6 +13,12 @@ register = _common.register
 @_common.normal_inverse_gamma_head_traverser.delayed_register(TORCH_MODULE)
 def _(_: type) -> None:
     from . import torch as torch  # noqa: PLC0415
+
+
+## Flax
+@_common.normal_inverse_gamma_head_traverser.delayed_register(FLAX_MODULE)
+def _(_: type) -> None:
+    from . import flax as flax  # noqa: PLC0415
 
 
 __all__ = ["normal_inverse_gamma_head", "register"]

--- a/src/probly/transformation/normal_inverse_gamma_head/_common.py
+++ b/src/probly/transformation/normal_inverse_gamma_head/_common.py
@@ -8,6 +8,8 @@ from probly.traverse_nn import nn_compose
 from pytraverse import CLONE, TRAVERSE_REVERSED, GlobalVariable, flexdispatch_traverser, traverse
 
 if TYPE_CHECKING:
+    from flax.nnx.rnglib import Rngs, RngStream
+
     from flextype.isinstance import LazyType
     from probly.predictor import Predictor
     from pytraverse.composition import RegisteredLooseTraverser
@@ -16,6 +18,14 @@ REPLACED_LAST_LINEAR = GlobalVariable[bool](
     "REPLACED_LAST_LINEAR",
     "Whether the last linear layer has been replaced with a NormalInverseGammaLinear layer.",
     default=False,
+)
+
+type RNG = int | Rngs | RngStream
+
+RNGS = GlobalVariable[RNG](
+    "NIG_RNGS",
+    "rngs used to initialize the flax NormalInverseGammaLinear replacement layer.",
+    default=1,
 )
 
 normal_inverse_gamma_head_traverser = flexdispatch_traverser[object](name="normal_inverse_gamma_head_traverser")
@@ -28,13 +38,20 @@ def register(cls: LazyType, traverser: RegisteredLooseTraverser) -> None:
     )
 
 
-def normal_inverse_gamma_head[T: Predictor](base: T) -> T:
+def normal_inverse_gamma_head[T: Predictor](base: T, rngs: RNG = 1) -> T:
     """Replace the final linear layer with a Normal-Inverse-Gamma head.
 
     Args:
         base: Predictor, The base model to be transformed.
+        rngs: Optional rngs for the flax NormalInverseGammaLinear initialization
+            (types: ``rnglib.Rngs | rnglib.RngStream | int``). Ignored by the torch
+            backend. Default is ``1``.
 
     Returns:
         Predictor, The transformed predictor.
     """
-    return traverse(base, nn_compose(normal_inverse_gamma_head_traverser), init={TRAVERSE_REVERSED: True, CLONE: True})
+    return traverse(
+        base,
+        nn_compose(normal_inverse_gamma_head_traverser),
+        init={TRAVERSE_REVERSED: True, CLONE: True, RNGS: rngs},
+    )

--- a/src/probly/transformation/normal_inverse_gamma_head/flax.py
+++ b/src/probly/transformation/normal_inverse_gamma_head/flax.py
@@ -1,0 +1,32 @@
+"""Flax normal-inverse-gamma head implementation."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from flax import nnx
+
+from probly.layers.flax import NormalInverseGammaLinear
+from probly.transformation.normal_inverse_gamma_head._common import REPLACED_LAST_LINEAR, RNGS, register
+
+if TYPE_CHECKING:
+    from pytraverse import State, TraverserResult
+
+
+def replace_last_flax_nig(obj: nnx.Linear, state: State) -> TraverserResult:
+    """Register a class to be replaced by the NormalInverseGammaLinear layer based on :cite:`aminiDeepEvidential2020`.
+
+    This layer outputs the parameters of a Normal Inverse Gamma distribution, which is central to evidential
+    regression.
+    """
+    state[REPLACED_LAST_LINEAR] = True
+    return NormalInverseGammaLinear(
+        obj.in_features,
+        obj.out_features,
+        rngs=state[RNGS],
+        use_bias=obj.use_bias,
+        param_dtype=obj.param_dtype,
+    ), state
+
+
+register(nnx.Linear, replace_last_flax_nig)

--- a/src/probly_benchmark/method_scripts/het_net.py
+++ b/src/probly_benchmark/method_scripts/het_net.py
@@ -15,7 +15,7 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 model = LeNet(n_classes=5)
-cep = het_net(model, predictor_type="probabilistic_classifier")  # ty:ignore[unknown-argument, invalid-argument-type]
+cep = het_net(model, predictor_type="probabilistic_classifier")
 rep = representer(cep, num_samples=10)
 logger.info(rep)
 inputs = torch.randn(3, 1, 28, 28)

--- a/tests/probly/method/het_nets/test_flax.py
+++ b/tests/probly/method/het_nets/test_flax.py
@@ -1,0 +1,112 @@
+"""Tests for flax HetNets transformation."""
+
+from __future__ import annotations
+
+from typing import cast
+
+import pytest
+
+flax = pytest.importorskip("flax")
+from flax import nnx  # noqa: E402
+import jax  # noqa: E402
+import jax.numpy as jnp  # noqa: E402
+
+from probly.layers.flax import HeteroscedasticLayer  # noqa: E402
+from probly.method.het_net import het_net  # noqa: E402
+from tests.probly.flax_utils import count_layers  # noqa: E402
+
+
+class TestHetNetLayerReplacement:
+    """Tests for the structural changes het_net applies to a flax model."""
+
+    def test_replaces_last_linear_with_heteroscedastic_layer(self, flax_model_small_2d_2d: nnx.Module) -> None:
+        """Verify the final ``nnx.Linear`` is replaced and other linears are untouched."""
+        original = flax_model_small_2d_2d
+        original_linear_count = count_layers(original, nnx.Linear)
+
+        new_model = cast("nnx.Module", het_net(original, num_factors=2, predictor_type="logit_classifier"))
+
+        new_linear_count = count_layers(new_model, nnx.Linear)
+        het_count = count_layers(new_model, HeteroscedasticLayer)
+
+        assert het_count == 1
+        # Each HeteroscedasticLayer contains 3 sub nnx.Linear instances (mu, diag, v).
+        # The traversal therefore reports the original count - 1 + 3 = original + 2 linears.
+        assert new_linear_count == original_linear_count + 2
+
+    def test_returns_a_clone(self, flax_model_small_2d_2d: nnx.Module) -> None:
+        """Ensure het_net does not mutate the input model."""
+        new_model = het_net(flax_model_small_2d_2d, num_factors=2, predictor_type="logit_classifier")
+        assert new_model is not flax_model_small_2d_2d
+
+
+class TestHetNetForwardPass:
+    """Tests that the transformed model produces logits of the expected shape."""
+
+    def test_forward_pass_shape(self, flax_regression_model_2d: nnx.Module) -> None:
+        """Verify the wrapped model returns ``(batch, num_classes)`` logits."""
+        new_model = het_net(flax_regression_model_2d, num_factors=3, predictor_type="logit_classifier")
+        out = new_model(jnp.ones((5, 4)))
+        assert out.shape == (5, 2)
+
+    def test_parameter_efficient_variant(self, flax_regression_model_2d: nnx.Module) -> None:
+        """Verify the parameter-efficient routing also produces logits of the expected shape."""
+        new_model = het_net(
+            flax_regression_model_2d,
+            num_factors=3,
+            is_parameter_efficient=True,
+            predictor_type="logit_classifier",
+        )
+        out = new_model(jnp.ones((5, 4)))
+        assert out.shape == (5, 2)
+
+
+class TestHetNetSoftmaxTailStripping:
+    """Tests that het_net strips a trailing softmax callable from a ``Sequential``."""
+
+    def test_trailing_jax_softmax_is_removed(self, flax_rngs: nnx.Rngs) -> None:
+        """A trailing ``jax.nn.softmax`` is dropped so the HeteroscedasticLayer is the tail."""
+        model = nnx.Sequential(
+            nnx.Linear(4, 2, rngs=flax_rngs),
+            jax.nn.softmax,
+        )
+        new_model = cast(
+            "nnx.Sequential",
+            het_net(model, num_factors=2, predictor_type="logit_classifier"),
+        )
+
+        assert len(new_model.layers) == 1
+        assert isinstance(new_model.layers[0], HeteroscedasticLayer)
+
+
+class TestHetNetRngsParameter:
+    """Tests that distinct ``rngs`` arguments produce distinct HeteroscedasticLayer params."""
+
+    def _find_het_layer(self, model: nnx.Module) -> HeteroscedasticLayer:
+        """Locate the single ``HeteroscedasticLayer`` in a transformed model."""
+        seq = cast("nnx.Sequential", model)
+        for layer in seq.layers:
+            if isinstance(layer, HeteroscedasticLayer):
+                return layer
+        msg = "no HeteroscedasticLayer found in transformed model"
+        raise AssertionError(msg)
+
+    def test_distinct_rngs_yield_distinct_layers(self, flax_regression_model_2d: nnx.Module) -> None:
+        """Different ``rngs`` seeds produce distinct ``mu_layer.kernel`` initializations."""
+        m1 = het_net(
+            flax_regression_model_2d,
+            num_factors=2,
+            rngs=nnx.Rngs(0),
+            predictor_type="logit_classifier",
+        )
+        m2 = het_net(
+            flax_regression_model_2d,
+            num_factors=2,
+            rngs=nnx.Rngs(42),
+            predictor_type="logit_classifier",
+        )
+
+        het1 = self._find_het_layer(cast("nnx.Module", m1))
+        het2 = self._find_het_layer(cast("nnx.Module", m2))
+
+        assert not jnp.allclose(het1.mu_layer.kernel.value, het2.mu_layer.kernel.value)

--- a/tests/probly/transformation/__init__.py
+++ b/tests/probly/transformation/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the probly transformation backends."""

--- a/tests/probly/transformation/normal_inverse_gamma_head/__init__.py
+++ b/tests/probly/transformation/normal_inverse_gamma_head/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the normal-inverse-gamma head transformation."""

--- a/tests/probly/transformation/normal_inverse_gamma_head/test_flax.py
+++ b/tests/probly/transformation/normal_inverse_gamma_head/test_flax.py
@@ -1,0 +1,78 @@
+"""Tests for the flax normal-inverse-gamma head transformation."""
+
+from __future__ import annotations
+
+from typing import cast
+
+import pytest
+
+flax = pytest.importorskip("flax")
+from flax import nnx  # noqa: E402
+import jax.numpy as jnp  # noqa: E402
+
+from probly.layers.flax import NormalInverseGammaLinear  # noqa: E402
+from probly.transformation.normal_inverse_gamma_head import normal_inverse_gamma_head  # noqa: E402
+from tests.probly.flax_utils import count_layers  # noqa: E402
+
+
+def test_returns_a_clone(flax_regression_model_2d: nnx.Module) -> None:
+    """normal_inverse_gamma_head returns a clone, leaving the original untouched."""
+    new_model = normal_inverse_gamma_head(flax_regression_model_2d)
+
+    assert new_model is not flax_regression_model_2d
+
+
+def test_replaces_only_last_linear_layer(flax_regression_model_2d: nnx.Module) -> None:
+    """Exactly one ``NormalInverseGammaLinear`` is inserted, and one ``nnx.Linear`` removed."""
+    original = flax_regression_model_2d
+    original_linear_count = count_layers(original, nnx.Linear)
+
+    new_model = normal_inverse_gamma_head(original)
+    new_linear_count = count_layers(new_model, nnx.Linear)
+    nig_count = count_layers(new_model, NormalInverseGammaLinear)
+
+    assert nig_count == 1
+    assert new_linear_count == original_linear_count - 1
+
+
+def test_forward_pass_returns_nig_dict(flax_regression_model_2d: nnx.Module) -> None:
+    """The transformed model returns the four NIG parameter heads with consistent shapes."""
+    new_model = normal_inverse_gamma_head(flax_regression_model_2d)
+    out = new_model(jnp.ones((3, 4)))
+
+    assert isinstance(out, dict)
+    assert set(out.keys()) == {"gamma", "nu", "alpha", "beta"}
+
+    expected_shape = (3, 2)
+    for value in out.values():
+        assert value.shape == expected_shape
+
+    # nu, beta are softplus → non-negative; alpha is softplus + 1 → at least one
+    assert (out["nu"] >= 0).all()
+    assert (out["beta"] >= 0).all()
+    assert (out["alpha"] >= 1).all()
+
+
+def test_distinct_rngs_yield_distinct_layers(flax_regression_model_2d: nnx.Module) -> None:
+    """Different ``rngs`` seeds produce distinct ``NormalInverseGammaLinear`` parameters."""
+    m1 = normal_inverse_gamma_head(flax_regression_model_2d, rngs=nnx.Rngs(0))
+    m2 = normal_inverse_gamma_head(flax_regression_model_2d, rngs=nnx.Rngs(42))
+
+    seq1 = cast("nnx.Sequential", m1)
+    seq2 = cast("nnx.Sequential", m2)
+    nig1 = next(layer for layer in seq1.layers if isinstance(layer, NormalInverseGammaLinear))
+    nig2 = next(layer for layer in seq2.layers if isinstance(layer, NormalInverseGammaLinear))
+
+    assert not jnp.allclose(nig1.gamma.value, nig2.gamma.value)
+
+
+def test_earlier_layers_unchanged(flax_regression_model_2d: nnx.Module) -> None:
+    """Layers before the replaced final ``Linear`` retain their original types."""
+    original = cast("nnx.Sequential", flax_regression_model_2d)
+    new_model = cast("nnx.Sequential", normal_inverse_gamma_head(flax_regression_model_2d))
+
+    last_layer_index = len(original.layers) - 1
+    for i in range(last_layer_index):
+        assert type(original.layers[i]) is type(new_model.layers[i])
+
+    assert isinstance(new_model.layers[last_layer_index], NormalInverseGammaLinear)


### PR DESCRIPTION
## Flax: HetNets and Normal-Inverse-Gamma head

Adds flax (`flax.nnx`) implementations for two layer-replacement methods that share the same porting recipe (custom torch layer → equivalent nnx layer + thin flax traverser).

### Changes

**New flax layers in `src/probly/layers/flax.py`**
- `HeteroscedasticLayer` — flax counterpart to the torch `HeteroscedasticLayer` from :cite:`collier2021hetnets`. Supports both the full-rank and parameter-efficient routings; matches the torch initializer choices (`xavier_uniform`, zero biases, `log(e-1)` constant for diag bias, `xavier_normal` for the global V matrix). Uses the established `DropConnectLinear` RNG idiom: `rngs` accepted at init or call time via `first_from`, with the call-time argument winning.
- `NormalInverseGammaLinear` — flax counterpart to the torch NIG head from :cite:`aminiDeepEvidential2020`. Returns the four-parameter dict `{gamma, nu, alpha, beta}` with `softplus` / `softplus + 1` activations matching torch. Uses `uniform(-1/sqrt(in), 1/sqrt(in))` initialization (equivalent to torch's `kaiming_uniform(a=sqrt(5))`).

**New flax traversers**
- `src/probly/method/het_net/flax.py` — replaces the last `nnx.Linear` with `HeteroscedasticLayer`. Includes an `nnx.Sequential` handler that strips a trailing `jax.nn.softmax` / `nnx.softmax` (or log variants) so the HetNet output is not double-activated, mirroring the torch handler's `nn.Softmax → nn.Identity` swap.
- `src/probly/transformation/normal_inverse_gamma_head/flax.py` — replaces the last `nnx.Linear` with `NormalInverseGammaLinear`.

Both `_common.py` files plumb `rngs: int | Rngs | RngStream = 1` through to the flax handler; the torch backend ignores it.

Removes a now-stale `# ty:ignore` from `src/probly_benchmark/method_scripts/het_net.py`.

### Tests
~10 new tests under `tests/probly/method/het_nets/test_flax.py` and `tests/probly/transformation/normal_inverse_gamma_head/test_flax.py`:
- structural assertions on layer counts after transformation
- forward-pass shapes (incl. the parameter-efficient HetNet variant)
- distinct `rngs` produce distinct parameter values
- earlier layers in the model are left untouched
- trailing `jax.nn.softmax` is stripped from het_net Sequential models

### Verification
- `uv run pytest tests/probly/method/het_nets tests/probly/transformation/normal_inverse_gamma_head tests/probly/method/evidential` — 23 passed
- `uv run prek run --all-files` — clean
- No changes to existing torch implementations or shared dispatch infrastructure.