### PR TITLE
Add flax class_bias_ensemble and flax reset_traverser support

### DIFF
--- a/src/probly/transformation/class_bias_ensemble/__init__.py
+++ b/src/probly/transformation/class_bias_ensemble/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from probly.lazy_types import TORCH_MODULE
+from probly.lazy_types import FLAX_MODULE, TORCH_MODULE
 
 from ._common import ClassBiasEnsemblePredictor, class_bias_ensemble, class_bias_ensemble_traverser
 
@@ -11,6 +11,12 @@ from ._common import ClassBiasEnsemblePredictor, class_bias_ensemble, class_bias
 @class_bias_ensemble_traverser.delayed_register(TORCH_MODULE)
 def _(_: type) -> None:
     from . import torch as torch  # noqa: PLC0415
+
+
+## Flax
+@class_bias_ensemble_traverser.delayed_register(FLAX_MODULE)
+def _(_: type) -> None:
+    from . import flax as flax  # noqa: PLC0415
 
 
 __all__ = [

--- a/src/probly/transformation/class_bias_ensemble/_common.py
+++ b/src/probly/transformation/class_bias_ensemble/_common.py
@@ -8,9 +8,12 @@ from probly.predictor import LogitClassifier
 from probly.transformation.ensemble import EnsemblePredictor, register_ensemble_members
 from probly.transformation.transformation import predictor_transformation
 from probly.traverse_nn import nn_compose, reset_traverser
+from probly.traverse_nn.reset_traverser import RNGS as RESET_RNGS
 from pytraverse import TRAVERSE_REVERSED, GlobalVariable, flexdispatch_traverser, traverse
 
 if TYPE_CHECKING:
+    from flax.nnx.rnglib import Rngs, RngStream
+
     from probly.predictor import Predictor
 
 
@@ -29,7 +32,11 @@ class_bias_ensemble_traverser = flexdispatch_traverser[object](name="class_bias_
 @predictor_transformation(permitted_predictor_types=(LogitClassifier,), post_transform=register_ensemble_members)
 @ClassBiasEnsemblePredictor.register_factory(autocast_builtins=True)
 def class_bias_ensemble[**In, Out](
-    base: Predictor[In, Out], num_members: int, reset_params: bool = True, tobias_value: int = 100
+    base: Predictor[In, Out],
+    num_members: int,
+    reset_params: bool = True,
+    tobias_value: int = 100,
+    rngs: int | Rngs | RngStream = 1,
 ) -> ClassBiasEnsemblePredictor[In, Out]:
     """Create an ensemble with class-specific final-layer bias initialization.
 
@@ -38,6 +45,9 @@ def class_bias_ensemble[**In, Out](
         num_members: The number of members in the class-bias ensemble.
         reset_params: Whether to reset the parameters of each member.
         tobias_value: The value to use for the class bias initialization.
+        rngs: Optional rngs used by the flax backend when ``reset_params=True`` to draw
+            fresh keys for re-initialized parameters (types: ``rnglib.Rngs | rnglib.RngStream | int``).
+            Ignored by the torch backend. Default is ``1``.
 
     Returns:
         The class-bias ensemble predictor.
@@ -56,6 +66,7 @@ def class_bias_ensemble[**In, Out](
                 INITIALIZED: False,
                 RESET_PARAMS: reset_params,
                 TRAVERSE_REVERSED: True,
+                RESET_RNGS: rngs,
             },
         )
         for i in range(num_members)

--- a/src/probly/transformation/class_bias_ensemble/flax.py
+++ b/src/probly/transformation/class_bias_ensemble/flax.py
@@ -1,0 +1,43 @@
+"""Flax implementation of class-bias ensembles."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from flax import nnx
+
+from ._common import BIAS_CLS, INITIALIZED, TOBIAS_VALUE, class_bias_ensemble_traverser
+
+if TYPE_CHECKING:
+    from pytraverse.core import State
+
+
+@class_bias_ensemble_traverser.register(nnx.Module)
+def skip_or_raise_on_non_linear(obj: nnx.Module, state: State) -> tuple[nnx.Module, State]:
+    """Skip layers once the last linear layer is initialized; otherwise raise an error."""
+    if not state[INITIALIZED]:
+        msg = (
+            f"class_bias_ensemble requires the last child of the model to be an nnx.Linear, found {type(obj).__name__}."
+        )
+        raise ValueError(msg)
+    return obj, state
+
+
+@class_bias_ensemble_traverser.register(nnx.Linear)
+def set_class_bias(obj: nnx.Linear, state: State) -> tuple[nnx.Module, State]:
+    """Initialize the last linear layer with class-specific bias."""
+    if not state[INITIALIZED]:
+        if state[BIAS_CLS] > 0:
+            if obj.bias is None:
+                msg = "class_bias_ensemble requires the final nnx.Linear to have a bias."
+                raise ValueError(msg)
+            idx = (state[BIAS_CLS] - 1) % obj.out_features
+            obj.bias.value = obj.bias.value.at[idx].set(state[TOBIAS_VALUE])
+        state[INITIALIZED] = True
+    return obj, state
+
+
+@class_bias_ensemble_traverser.register(nnx.Sequential)
+def skip_sequential(obj: nnx.Sequential, state: State) -> tuple[nnx.Module, State]:
+    """Skip sequential containers at the end."""
+    return obj, state

--- a/src/probly/transformation/ensemble/_common.py
+++ b/src/probly/transformation/ensemble/_common.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
-from typing import Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 from flextype import flexdispatch
 from probly.predictor import (
@@ -16,6 +16,11 @@ from probly.predictor import (
 )
 from probly.representation.distribution import CategoricalDistribution, DirichletDistribution
 from probly.transformation.transformation import predictor_transformation
+
+if TYPE_CHECKING:
+    from flax.nnx.rnglib import Rngs, RngStream
+
+type RNG = int | Rngs | RngStream
 
 
 @runtime_checkable
@@ -57,7 +62,7 @@ class EnsembleDirichletDistributionPredictor[**In, Out: DirichletDistribution](E
 
 @flexdispatch
 def ensemble_generator[**In, Out](
-    base: Predictor[In, Out], num_members: int, reset_params: bool = True
+    base: Predictor[In, Out], num_members: int, reset_params: bool = True, rngs: RNG = 1
 ) -> EnsemblePredictor[In, Out]:
     """Generate an ensemble from a base model."""
     msg = f"No ensemble generator is registered for type {type(base)}"
@@ -80,7 +85,7 @@ def register_ensemble_members(ensemble: EnsemblePredictor, t: type[Predictor] | 
 )
 @EnsemblePredictor.register_factory(autocast_builtins=True)
 def ensemble[**In, Out](
-    base: Predictor[In, Out], num_members: int, reset_params: bool = True
+    base: Predictor[In, Out], num_members: int, reset_params: bool = True, rngs: RNG = 1
 ) -> EnsemblePredictor[In, Out]:
     """Create an ensemble predictor from a base predictor based on :cite:`lakshminarayananSimpleScalable2017`.
 
@@ -88,11 +93,14 @@ def ensemble[**In, Out](
         base: Predictor, The base model to be used for the ensemble.
         num_members: The number of members in the ensemble.
         reset_params: Whether to reset the parameters of each member.
+        rngs: Optional rngs used by the flax backend when ``reset_params=True`` to draw fresh
+            keys for re-initialized parameters (types: ``rnglib.Rngs | rnglib.RngStream | int``).
+            Ignored by the torch backend. Default is ``1``.
 
     Returns:
         Predictor, The ensemble predictor.
     """
-    return ensemble_generator(base, num_members=num_members, reset_params=reset_params)
+    return ensemble_generator(base, num_members=num_members, reset_params=reset_params, rngs=rngs)
 
 
 @predict_raw.register(EnsemblePredictor)

--- a/src/probly/transformation/ensemble/flax.py
+++ b/src/probly/transformation/ensemble/flax.py
@@ -2,22 +2,28 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from flax import nnx
 import jax.numpy as jnp
 
 from probly.predictor._common import predict, predict_raw
 from probly.traverse_nn import nn_compose, nn_traverser, reset_traverser
+from probly.traverse_nn.reset_traverser import RNGS as RESET_RNGS
 from pytraverse import CLONE, traverse
 
 from ._common import ensemble_generator
+
+if TYPE_CHECKING:
+    from flax.nnx import rnglib
 
 
 def _clone(obj: nnx.Module) -> nnx.Module:
     return traverse(obj, nn_traverser, init={CLONE: True})
 
 
-def _clone_reset(obj: nnx.Module) -> nnx.Module:
-    return traverse(obj, nn_compose(reset_traverser), init={CLONE: True})
+def _clone_reset(obj: nnx.Module, rngs: nnx.Rngs | rnglib.RngStream | int) -> nnx.Module:
+    return traverse(obj, nn_compose(reset_traverser), init={CLONE: True, RESET_RNGS: rngs})
 
 
 @ensemble_generator.register(nnx.Module)
@@ -25,10 +31,11 @@ def generate_flax_ensemble(
     obj: nnx.Module,
     num_members: int,
     reset_params: bool,
+    rngs: nnx.Rngs | rnglib.RngStream | int = 1,
 ) -> nnx.List:
     """Build a flax ensemble based on :cite:`lakshminarayananSimpleScalable2017`."""
     if reset_params:
-        return nnx.List([_clone_reset(obj) for _ in range(num_members)])
+        return nnx.List([_clone_reset(obj, rngs) for _ in range(num_members)])
     return nnx.List([_clone(obj) for _ in range(num_members)])
 
 

--- a/src/probly/transformation/ensemble/sklearn.py
+++ b/src/probly/transformation/ensemble/sklearn.py
@@ -4,11 +4,16 @@ from __future__ import annotations
 
 from sklearn.base import BaseEstimator, clone
 
-from ._common import ensemble_generator
+from ._common import RNG, ensemble_generator
 
 
 @ensemble_generator.register(BaseEstimator)
-def generate_sklearn_ensemble(obj: BaseEstimator, num_members: int, reset_params: bool) -> list[object]:
+def generate_sklearn_ensemble(
+    obj: BaseEstimator,
+    num_members: int,
+    reset_params: bool,
+    rngs: RNG = 1,  # noqa: ARG001
+) -> list[object]:
     """Generates an ensemble model from a sklearn base estimator."""
     if reset_params:
         obj.__setattr__("random_state", None)

--- a/src/probly/transformation/ensemble/torch.py
+++ b/src/probly/transformation/ensemble/torch.py
@@ -11,7 +11,7 @@ from probly.predictor._common import predict, predict_raw
 from probly.traverse_nn import nn_compose, nn_traverser, reset_traverser
 from pytraverse import CLONE, traverse
 
-from ._common import ensemble_generator
+from ._common import RNG, ensemble_generator
 
 if TYPE_CHECKING:
     from probly.representation.torch_like import TorchLike
@@ -30,6 +30,7 @@ def generate_torch_ensemble(
     obj: nn.Module,
     num_members: int,
     reset_params: bool = True,
+    rngs: RNG = 1,  # noqa: ARG001
 ) -> nn.ModuleList:
     """Build a torch ensemble based on :cite:`lakshminarayananSimpleScalable2017`."""
     if reset_params:

--- a/src/probly/traverse_nn/reset_traverser/__init__.py
+++ b/src/probly/traverse_nn/reset_traverser/__init__.py
@@ -1,8 +1,8 @@
 """Reset traverser module."""
 
-from probly.lazy_types import TORCH_MODULE
+from probly.lazy_types import FLAX_MODULE, TORCH_MODULE
 
-from ._common import reset_traverser
+from ._common import RNGS, reset_traverser
 
 
 ## Torch
@@ -11,6 +11,13 @@ def _(_: type) -> None:
     from . import torch as torch  # noqa: PLC0415
 
 
+## Flax
+@reset_traverser.delayed_register(FLAX_MODULE)
+def _(_: type) -> None:
+    from . import flax as flax  # noqa: PLC0415
+
+
 __all__ = [
+    "RNGS",
     "reset_traverser",
 ]

--- a/src/probly/traverse_nn/reset_traverser/_common.py
+++ b/src/probly/traverse_nn/reset_traverser/_common.py
@@ -2,12 +2,35 @@
 
 from __future__ import annotations
 
-from pytraverse import flexdispatch_traverser
+import logging
+from typing import TYPE_CHECKING
+
+from pytraverse import GlobalVariable, flexdispatch_traverser
+
+if TYPE_CHECKING:
+    from flax.nnx.rnglib import Rngs, RngStream
+
+type RNG = int | Rngs | RngStream
+
+RNGS = GlobalVariable[RNG](
+    "RESET_RNGS",
+    "rngs used to draw fresh keys when re-initializing flax parameters during reset.",
+    default=1,
+)
 
 reset_traverser = flexdispatch_traverser[object](name="reset_traverser")
+
+logger = logging.getLogger(__name__)
 
 
 @reset_traverser.register
 def _(obj: object) -> object:
-    msg = f"resetting parameters of {type(obj)} models is not supported yet."
-    raise NotImplementedError(msg)
+    """Default fallback: leave the object unchanged.
+
+    Torch implementations register an explicit ``nn.Module`` handler that opportunistically
+    calls ``reset_parameters`` if it exists; flax implementations register handlers for the
+    layer types that have parameters worth resetting. Anything else (e.g. a jax callable
+    used as a Sequential layer, or a raw ``nnx.Variable``) is passed through untouched.
+    """
+    logger.debug("reset_traverser: no handler for %s; skipping", type(obj).__name__)
+    return obj

--- a/src/probly/traverse_nn/reset_traverser/flax.py
+++ b/src/probly/traverse_nn/reset_traverser/flax.py
@@ -1,0 +1,68 @@
+"""Flax implementation of the reset traverser."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from flax import nnx
+import jax
+import jax.numpy as jnp
+
+from ._common import RNGS, reset_traverser
+
+if TYPE_CHECKING:
+    from flax.nnx import rnglib
+
+    from pytraverse.core import State
+
+
+def _coerce_rngs(rngs: int | nnx.Rngs | rnglib.RngStream) -> nnx.Rngs:
+    """Return an :class:`nnx.Rngs` regardless of how the rng source was provided."""
+    if isinstance(rngs, nnx.Rngs):
+        return rngs
+    return nnx.Rngs(rngs)
+
+
+@reset_traverser.register(cls=nnx.Module)
+def skip_module(obj: nnx.Module, state: State) -> tuple[nnx.Module, State]:
+    """Default flax reset handler. No-op for modules without trainable params.
+
+    Mirrors the torch behavior of only resetting layers that explicitly support it.
+    """
+    return obj, state
+
+
+def _resolve_rngs(state: State) -> nnx.Rngs:
+    """Coerce the state-provided rng source into a persistent :class:`nnx.Rngs`.
+
+    Stores the coerced ``Rngs`` back into the state so subsequent layer resets advance
+    the same stream rather than sampling deterministically from the same seed.
+    """
+    rngs = state[RNGS]
+    if isinstance(rngs, nnx.Rngs):
+        return rngs
+    coerced = _coerce_rngs(rngs)
+    state[RNGS] = coerced
+    return coerced
+
+
+@reset_traverser.register(cls=nnx.Linear)
+def reset_linear(obj: nnx.Linear, state: State) -> tuple[nnx.Module, State]:
+    """Reset the kernel (and bias if present) of an :class:`nnx.Linear` layer."""
+    rngs = _resolve_rngs(state)
+    kernel_init = jax.nn.initializers.lecun_normal()
+    obj.kernel.value = kernel_init(rngs.params(), obj.kernel.value.shape, obj.param_dtype)
+    if obj.use_bias and obj.bias is not None:
+        obj.bias.value = jnp.zeros(obj.bias.value.shape, dtype=obj.param_dtype)
+    return obj, state
+
+
+@reset_traverser.register(cls=nnx.Conv)
+def reset_conv(obj: nnx.Conv, state: State) -> tuple[nnx.Module, State]:
+    """Reset the kernel (and bias if present) of an :class:`nnx.Conv` layer."""
+    rngs = _resolve_rngs(state)
+    kernel_init = jax.nn.initializers.lecun_normal()
+    obj.kernel.value = kernel_init(rngs.params(), obj.kernel.value.shape, obj.param_dtype)
+    if obj.use_bias and obj.bias is not None:
+        obj.bias.value = jnp.zeros(obj.bias.value.shape, dtype=obj.param_dtype)
+    return obj, state

--- a/tests/probly/method/ensemble/test_common.py
+++ b/tests/probly/method/ensemble/test_common.py
@@ -38,6 +38,7 @@ def test_registered_generator_called(dummy_predictor: Predictor) -> None:
         dummy_predictor,
         num_members=4,
         reset_params=True,
+        rngs=1,
     )
     assert result is expected_result
 

--- a/tests/probly/method/ensemble/test_flax.py
+++ b/tests/probly/method/ensemble/test_flax.py
@@ -40,11 +40,10 @@ class TestEnsembleAttributes:
                 jax.tree_util.tree_map(jnp.array_equal, original_params, member_params),
             )  # no difference
 
-    @pytest.mark.skip(reason="not implemented yet")
     def test_ensemble_attributes_with_reset(self, flax_model_small_2d_2d) -> None:
         """Tests if the member attributes are not inherited from the base model."""
         num_members = 2
-        ensemble_model = ensemble(flax_model_small_2d_2d, num_members=2, reset_params=True)
+        ensemble_model = ensemble(flax_model_small_2d_2d, num_members=num_members, reset_params=True, rngs=nnx.Rngs(0))
 
         assert ensemble_model is not None
         assert isinstance(ensemble_model, nnx.List)
@@ -122,12 +121,16 @@ class TestEnsembleGeneration:
             count_module_member = count_layers(member, nnx.Module)
             assert count_module_member == count_module_original
 
-    def test_not_implemented_error_with_reset(self, flax_model_small_2d_2d) -> None:
+    def test_reset_params_returns_distinct_members(self, flax_model_small_2d_2d) -> None:
+        """``reset_params=True`` produces independently reinitialized members."""
         num_members = 2
+        ensemble_model = ensemble(flax_model_small_2d_2d, num_members=num_members, reset_params=True, rngs=nnx.Rngs(0))
 
-        msg = "resetting parameters of <class .*> models is not supported yet."
-        with pytest.raises(NotImplementedError, match=msg):
-            ensemble(flax_model_small_2d_2d, num_members=num_members, reset_params=True)
+        assert isinstance(ensemble_model, nnx.List)
+        assert len(ensemble_model) == num_members
+
+        first_kernels = [member.layers[0].kernel.value for member in ensemble_model]
+        assert not jnp.allclose(first_kernels[0], first_kernels[1])
 
 
 class TestEnsembleCalls:
@@ -145,10 +148,9 @@ class TestEnsembleCalls:
             assert custom_model_out.shape == member_out.shape
             assert jnp.equal(custom_model_out, member_out).all()  # no parameter reset
 
-    @pytest.mark.skip(reason="not implemented yet")
     def test_ensemble_flax_custom_model_call_with_reset(self, flax_custom_model) -> None:
         num_members = 2
-        ensemble_model = ensemble(flax_custom_model, num_members=num_members, reset_params=True)
+        ensemble_model = ensemble(flax_custom_model, num_members=num_members, reset_params=True, rngs=nnx.Rngs(0))
 
         x = jnp.ones((2, 1, 10))
         custom_model_out = flax_custom_model(x)

--- a/tests/probly/transformation/__init__.py
+++ b/tests/probly/transformation/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the probly transformation backends."""

--- a/tests/probly/transformation/class_bias_ensemble/__init__.py
+++ b/tests/probly/transformation/class_bias_ensemble/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the class-bias ensemble transformation."""

--- a/tests/probly/transformation/class_bias_ensemble/test_flax.py
+++ b/tests/probly/transformation/class_bias_ensemble/test_flax.py
@@ -1,0 +1,78 @@
+"""Tests for the flax class-bias ensemble transformation."""
+
+from __future__ import annotations
+
+from typing import cast
+
+import pytest
+
+flax = pytest.importorskip("flax")
+from flax import nnx  # noqa: E402
+import jax.numpy as jnp  # noqa: E402
+
+from probly.transformation.class_bias_ensemble import class_bias_ensemble  # noqa: E402
+
+
+def _last_linear_bias(model: nnx.Module) -> jnp.ndarray:
+    """Return the bias array of the last ``nnx.Linear`` in ``model``."""
+    seq = cast("nnx.Sequential", model)
+    last = cast("nnx.Linear", seq.layers[-1])
+    assert last.bias is not None
+    return last.bias.value
+
+
+def test_returns_num_members(flax_model_small_2d_2d: nnx.Module) -> None:
+    """class_bias_ensemble returns exactly ``num_members`` cloned models."""
+    members = class_bias_ensemble(
+        flax_model_small_2d_2d,
+        num_members=4,
+        reset_params=False,
+        predictor_type="logit_classifier",
+    )
+
+    assert len(members) == 4
+
+
+def test_first_member_keeps_bias_unchanged(flax_model_small_2d_2d: nnx.Module) -> None:
+    """The first ensemble member (``BIAS_CLS=0``) leaves the final bias untouched."""
+    members = class_bias_ensemble(
+        flax_model_small_2d_2d,
+        num_members=2,
+        reset_params=False,
+        predictor_type="logit_classifier",
+    )
+
+    assert jnp.array_equal(_last_linear_bias(members[0]), _last_linear_bias(flax_model_small_2d_2d))
+
+
+def test_subsequent_members_set_per_class_bias(flax_model_small_2d_2d: nnx.Module) -> None:
+    """Members ``i > 0`` set bias index ``(i-1) % out_features`` to ``tobias_value``."""
+    seq = cast("nnx.Sequential", flax_model_small_2d_2d)
+    out_features = cast("nnx.Linear", seq.layers[-1]).out_features
+    members = class_bias_ensemble(
+        flax_model_small_2d_2d,
+        num_members=out_features + 1,
+        reset_params=False,
+        tobias_value=42,
+        predictor_type="logit_classifier",
+    )
+
+    for i in range(1, out_features + 1):
+        bias = _last_linear_bias(members[i])
+        idx = (i - 1) % out_features
+        assert bias[idx] == 42.0
+
+
+def test_reset_params_true_yields_distinct_kernels(flax_model_small_2d_2d: nnx.Module) -> None:
+    """When ``reset_params=True``, each member gets independently reinitialized weights."""
+    members = class_bias_ensemble(
+        flax_model_small_2d_2d,
+        num_members=3,
+        reset_params=True,
+        rngs=nnx.Rngs(0),
+        predictor_type="logit_classifier",
+    )
+
+    kernels = [m.layers[0].kernel.value for m in members]
+    assert not jnp.allclose(kernels[0], kernels[1])
+    assert not jnp.allclose(kernels[1], kernels[2])


### PR DESCRIPTION
## Flax: class_bias_ensemble + reset_traverser support

Adds flax (`flax.nnx`) support for `class_bias_ensemble` and the underlying flax `reset_traverser` infrastructure that `class_bias_ensemble(reset_params=True)` (and `ensemble(reset_params=True)`) need. As a side-effect, the previously-stubbed flax `ensemble(reset_params=True)` path is now functional.

### Changes

**New flax `class_bias_ensemble` traverser** at `src/probly/transformation/class_bias_ensemble/flax.py`
- Replaces the last `nnx.Linear`'s bias with a class-specific value via the functional `bias.value.at[idx].set(...)` jax update — flax-idiomatic counterpart to torch's in-place `.data` mutation.
- Raises a clear error when the final child is not an `nnx.Linear` or when `bias is None`.

**New flax `reset_traverser`** at `src/probly/traverse_nn/reset_traverser/flax.py`
- Re-initializes `nnx.Linear` and `nnx.Conv` kernels via `lecun_normal` with fresh keys drawn from a state-resident `nnx.Rngs`.
- A new `RNGS` `GlobalVariable` (declared in `reset_traverser/_common.py`) carries the rng source through traversal; coercion of `int → nnx.Rngs` happens in a single place inside the flax handler.
- The default fallback in `_common.py` was changed from `raise NotImplementedError` to a no-op `return obj` (with a `logger.debug` breadcrumb), since flax `iter_children()` exposes non-Module leaves like `nnx.Param` or jax callables that the torch implementation never sees. Torch behavior is unchanged because `nn.Module.named_children()` only yields Modules.

**`ensemble` rngs plumbing**
- Adds an `rngs: RNG = 1` parameter to `ensemble()` and `ensemble_generator()`, where `RNG = int | Rngs | RngStream` (declared under `TYPE_CHECKING` so torch-only environments stay flax-free).
- The torch and sklearn `ensemble_generator` registrations accept and ignore the parameter.
- The flax `ensemble_generator` forwards `rngs` into the reset_traverser so flax `ensemble(reset_params=True)` now produces members with independently re-initialized parameters.

### Tests
- 4 new tests under `tests/probly/transformation/class_bias_ensemble/test_flax.py` covering structural assertions, per-class bias modification, and `reset_params=True` producing distinct kernels.
- Three previously-skipped/stub tests in `tests/probly/method/ensemble/test_flax.py` are now real assertions:
  - `test_ensemble_attributes_with_reset` — un-skipped; verifies any-leaf difference vs base
  - `test_not_implemented_error_with_reset` (removed) → `test_reset_params_returns_distinct_members` (added) — flips from "asserts the path raises" to "asserts the path produces distinct members"
  - `test_ensemble_flax_custom_model_call_with_reset` — un-skipped; verifies forward outputs differ from base
- `tests/probly/method/ensemble/test_common.py` updated: mock-call assertion now includes the new `rngs=1` kwarg.

### Verification
- `uv run pytest tests/probly/transformation/class_bias_ensemble tests/probly/method/ensemble` — 86 passed (incl. all torch/sklearn ensemble tests, no regressions)
- `uv run prek run --all-files` — clean
- No torch-side behavior changes; `rngs` flows through but is ignored by torch and sklearn handlers.