### PR TITLE
active_learning: cap unlabeled pool / test set for huge tabular datasets

### DIFF
--- a/src/probly_benchmark/active_learning.py
+++ b/src/probly_benchmark/active_learning.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 import hydra
+import numpy as np
 from omegaconf import DictConfig, OmegaConf
 import wandb
 import wandb.util
@@ -173,6 +174,32 @@ def main(cfg: DictConfig) -> float:
         len(x_test),
         num_classes,
     )
+
+    # --- Optional pool / test subsampling for huge datasets (e.g. openml_155, _156).
+    # Caps the unlabeled pool and/or test set to a maximum size when the raw
+    # split exceeds the configured threshold. Drives a separate RNG stream
+    # (seed = cfg.seed + cfg.subsample_seed_offset) so the subsample is
+    # reproducible and independent of the model / strategy / estimator seed.
+    pool_cap = cfg.get("unlabeled_pool_max_size")
+    test_cap = cfg.get("test_max_size")
+    if pool_cap is not None or test_cap is not None:
+        sub_rng = np.random.default_rng(int(cfg.seed) + int(cfg.get("subsample_seed_offset", 0)))
+        if pool_cap is not None and len(x_train) > int(pool_cap):
+            idx = sub_rng.choice(len(x_train), size=int(pool_cap), replace=False)
+            x_train, y_train = x_train[idx], y_train[idx]
+            logger.info(
+                "Subsampled train pool: %d -> %d (unlabeled_pool_max_size)",
+                len(idx),
+                int(pool_cap),
+            )
+        if test_cap is not None and len(x_test) > int(test_cap):
+            idx = sub_rng.choice(len(x_test), size=int(test_cap), replace=False)
+            x_test, y_test = x_test[idx], y_test[idx]
+            logger.info(
+                "Subsampled test set:  %d -> %d (test_max_size)",
+                len(idx),
+                int(test_cap),
+            )
 
     # --- Pool ---
     pool = from_dataset(

--- a/src/probly_benchmark/configs/active_learning.yaml
+++ b/src/probly_benchmark/configs/active_learning.yaml
@@ -12,6 +12,18 @@ initial_size: 1000
 query_size: 1000
 n_iterations: 10
 
+# Optional unlabeled-pool and test-set caps. Each AL iteration scores the
+# entire unlabeled pool (and the test set, for accuracy reporting), which
+# scales linearly with their size. For huge tabular datasets like
+# openml_155 (~660k train) and openml_156 (~800k train) these caps cut
+# inference cost dramatically while leaving the AL story intact. Set to
+# ``null`` to disable (no cap). Subsampling uses a separate RNG stream so
+# it is reproducible and independent of the model/training seed; the
+# ``subsample_seed_offset`` lets you re-roll the subsample across reruns.
+unlabeled_pool_max_size: 50000
+test_max_size: 20000
+subsample_seed_offset: 0
+
 # Training (per AL iteration)
 epochs: 50
 batch_size: 128

--- a/src/probly_benchmark/configs/al_dataset/openml_155.yaml
+++ b/src/probly_benchmark/configs/al_dataset/openml_155.yaml
@@ -9,3 +9,6 @@ epochs: 100
 initial_size: 500
 query_size: 500
 n_iterations: 10
+# Bigger batch (vs default 128) to amortize kernel-launch overhead during
+# inference over the (capped) 50k unlabeled pool / 20k test set.
+batch_size: 4096

--- a/src/probly_benchmark/configs/al_dataset/openml_156.yaml
+++ b/src/probly_benchmark/configs/al_dataset/openml_156.yaml
@@ -9,3 +9,6 @@ epochs: 100
 initial_size: 100
 query_size: 100
 n_iterations: 15
+# Bigger batch (vs default 128) to amortize kernel-launch overhead during
+# inference over the (capped) 50k unlabeled pool / 20k test set.
+batch_size: 4096


### PR DESCRIPTION
Adds two optional knobs to the AL entry point that subsample the unlabeled pool and test set when their raw size exceeds a configured threshold. Without caps every AL iteration scans the full unlabeled pool to score uncertainty (and the full test set for accuracy reporting), which makes openml_155 (~660k train) and openml_156 (~800k train) prohibitively slow on cpu.

Defaults: ``unlabeled_pool_max_size=50000`` and ``test_max_size=20000``. Smaller datasets (cifar10, openml_6 at 16k/4k) hit the strict ``>`` guard and pass through untouched, so previously-collected results stay comparable.

Subsampling uses a separate ``np.random.default_rng`` keyed by ``cfg.seed + cfg.subsample_seed_offset``, so it is reproducible and independent of the model/training seed (set earlier via ``utils.set_seed(cfg.seed)``). The ``subsample_seed_offset`` knob lets sensitivity reruns re-roll the subsample without disturbing anything else. Both caps default to ``null``-tolerant access via ``cfg.get(...)``, so configs that don't know about these keys continue to work.

Behavior matrix:

| dataset    | train     -> pool | test      -> test |
| ---------- | ----------------- | ----------------- |
| openml_6   |  16,000  unchanged |  4,000  unchanged |
| openml_155 | 663,360 ->  50,000 | 165,841 -> 20,000 |
| openml_156 | 800,000 ->  50,000 | 200,000 -> 20,000 |