### PR TITLE
Fix import ordering flagged by ruff check (prek)

### DIFF
--- a/src/probly/calibrator/_common.py
+++ b/src/probly/calibrator/_common.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 from typing import Protocol, runtime_checkable
 
-from flextype import flexdispatch
 from flextype.registry_meta import ProtocolRegistry
+
+from flextype import flexdispatch
 
 
 @runtime_checkable

--- a/src/probly/conformal_scores/absolute_error/_common.py
+++ b/src/probly/conformal_scores/absolute_error/_common.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from flextype import flexdispatch
 import numpy as np
 import numpy.typing as npt
 
+from flextype import flexdispatch
 from probly.representation.array_like import ArrayLike
 
 

--- a/src/probly/conformal_scores/aps/_common.py
+++ b/src/probly/conformal_scores/aps/_common.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
-from flextype import flexdispatch
 import numpy as np
 
+from flextype import flexdispatch
 from probly.representation.array_like import ArrayLike
 
 

--- a/src/probly/conformal_scores/cqr/_common.py
+++ b/src/probly/conformal_scores/cqr/_common.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from flextype import flexdispatch
 import numpy as np
+
+from flextype import flexdispatch
 
 if TYPE_CHECKING:
     from probly.representation.array_like import ArrayLike

--- a/src/probly/conformal_scores/cqr_r/_common.py
+++ b/src/probly/conformal_scores/cqr_r/_common.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from flextype import flexdispatch
 import numpy as np
 
+from flextype import flexdispatch
 from probly.representation.array_like import ArrayLike
 
 _EPS = 1e-6  # Small constant to prevent division by zero

--- a/src/probly/conformal_scores/dirichlet_relative_likelihood/_common.py
+++ b/src/probly/conformal_scores/dirichlet_relative_likelihood/_common.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
-from flextype import flexdispatch
 import numpy as np
 
+from flextype import flexdispatch
 from probly.conformal_scores import NonConformityScore
 from probly.representation.array_like import ArrayLike
 

--- a/src/probly/conformal_scores/inner_product/_common.py
+++ b/src/probly/conformal_scores/inner_product/_common.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
-from flextype import flexdispatch
 import numpy as np
 
+from flextype import flexdispatch
 from probly.conformal_scores import NonConformityScore
 from probly.representation.array_like import ArrayLike
 

--- a/src/probly/conformal_scores/kullback_leibler/_common.py
+++ b/src/probly/conformal_scores/kullback_leibler/_common.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
-from flextype import flexdispatch
 import numpy as np
 
+from flextype import flexdispatch
 from probly.conformal_scores import NonConformityScore
 from probly.representation.array_like import ArrayLike
 

--- a/src/probly/conformal_scores/lac/_common.py
+++ b/src/probly/conformal_scores/lac/_common.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from flextype import flexdispatch
 import numpy as np
 
+from flextype import flexdispatch
 from probly.representation.distribution import ArrayCategoricalDistribution
 from probly.representation.sample.array import ArraySample
 

--- a/src/probly/conformal_scores/raps/_common.py
+++ b/src/probly/conformal_scores/raps/_common.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
-from flextype import flexdispatch
 import numpy as np
 
+from flextype import flexdispatch
 from probly.representation.distribution import ArrayCategoricalDistribution
 from probly.representation.sample.array import ArraySample
 

--- a/src/probly/conformal_scores/saps/_common.py
+++ b/src/probly/conformal_scores/saps/_common.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
-from flextype import flexdispatch
 import numpy as np
 
+from flextype import flexdispatch
 from probly.representation.array_like import ArrayLike
 
 

--- a/src/probly/conformal_scores/total_variation/_common.py
+++ b/src/probly/conformal_scores/total_variation/_common.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
-from flextype import flexdispatch
 import numpy as np
 
+from flextype import flexdispatch
 from probly.conformal_scores import NonConformityScore
 from probly.representation.array_like import ArrayLike
 

--- a/src/probly/conformal_scores/uacqr/_common.py
+++ b/src/probly/conformal_scores/uacqr/_common.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from flextype import flexdispatch
 import numpy as np
 
+from flextype import flexdispatch
 from probly.representation.array_like import ArrayLike
 
 

--- a/src/probly/conformal_scores/wasserstein_distance/_common.py
+++ b/src/probly/conformal_scores/wasserstein_distance/_common.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
-from flextype import flexdispatch
 import numpy as np
 
+from flextype import flexdispatch
 from probly.conformal_scores import NonConformityScore
 from probly.representation.array_like import ArrayLike
 

--- a/src/probly/decider/categorical_distribution/_common.py
+++ b/src/probly/decider/categorical_distribution/_common.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from flextype import flexdispatch
-
 from probly.representation.credal_set._common import CategoricalCredalSet
 from probly.representation.distribution import (
     CategoricalDistribution,

--- a/src/probly/evaluation/active_learning/metrics.py
+++ b/src/probly/evaluation/active_learning/metrics.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from flextype import flexdispatch
 import numpy as np
+
+from flextype import flexdispatch
 
 if TYPE_CHECKING:
     from collections.abc import Sequence

--- a/src/probly/evaluation/active_learning/strategies/_scores.py
+++ b/src/probly/evaluation/active_learning/strategies/_scores.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from flextype import flexdispatch
-
 from probly.quantification.measure.distribution import entropy
 
 if TYPE_CHECKING:

--- a/src/probly/method/ddu/_common.py
+++ b/src/probly/method/ddu/_common.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Protocol, override, runtime_checkable
 
 from flextype import flexdispatch
-
 from probly.decider import categorical_from_mean
 from probly.predictor import LogitClassifier, Predictor, RepresentationPredictor
 from probly.quantification._quantification import decompose

--- a/src/probly/method/deup/_common.py
+++ b/src/probly/method/deup/_common.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Protocol, cast, override, runtime_checkable
 
 from flextype import flexdispatch
-
 from probly.decider import categorical_from_mean
 from probly.predictor import LogitClassifier, Predictor, RepresentationPredictor
 from probly.quantification._quantification import decompose

--- a/src/probly/method/duq/_common.py
+++ b/src/probly/method/duq/_common.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Protocol, override, runtime_checkable
 
 from flextype import flexdispatch
-
 from probly.decider import categorical_from_mean
 from probly.predictor import LogitClassifier, Predictor, RepresentationPredictor
 from probly.quantification._quantification import decompose

--- a/src/probly/method/efficient_credal_prediction/_common.py
+++ b/src/probly/method/efficient_credal_prediction/_common.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Protocol, override, runtime_checkable
 
 from flextype import flexdispatch
-
 from probly.predictor import LogitClassifier, predict
 from probly.representation.array_like import ArrayLike
 from probly.representation.credal_set import (

--- a/src/probly/method/graph_posterior_network/_common.py
+++ b/src/probly/method/graph_posterior_network/_common.py
@@ -6,7 +6,6 @@ from math import log, pi
 from typing import TYPE_CHECKING, Literal, Protocol, runtime_checkable
 
 from flextype import flexdispatch
-
 from probly.predictor import (
     DirichletMixtureDistributionPredictor,
     EvidentialPredictor,

--- a/src/probly/method/mahalanobis/_common.py
+++ b/src/probly/method/mahalanobis/_common.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Protocol, override, runtime_checkable
 
 from flextype import flexdispatch
-
 from probly.decider import categorical_from_mean
 from probly.predictor import LogitClassifier, Predictor, RepresentationPredictor
 from probly.quantification._quantification import decompose

--- a/src/probly/method/sngp/_common.py
+++ b/src/probly/method/sngp/_common.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Any, Protocol, override, runtime_checkable
 import warnings
 
 from flextype import flexdispatch
-
 from probly.predictor import Predictor, RandomPredictor, predict, predict_raw
 from probly.quantification._quantification import decompose
 from probly.quantification.decomposition.decomposition import CachingDecomposition, EpistemicDecomposition

--- a/src/probly/plot/credal/_binary.py
+++ b/src/probly/plot/credal/_binary.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from flextype import flexdispatch
 import numpy as np
 
+from flextype import flexdispatch
 from probly.plot.credal._data import _get_probabilities, _to_numpy
 from probly.representation.credal_set.array import (
     ArrayConvexCredalSet,

--- a/src/probly/plot/credal/_data.py
+++ b/src/probly/plot/credal/_data.py
@@ -9,9 +9,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from flextype import flexdispatch
 import numpy as np
 
+from flextype import flexdispatch
 from probly.representation.credal_set.array import (
     ArrayConvexCredalSet,
     ArrayDiscreteCredalSet,

--- a/src/probly/plot/credal/_spider.py
+++ b/src/probly/plot/credal/_spider.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, cast
 
-from flextype import flexdispatch
 import numpy as np
 
+from flextype import flexdispatch
 from probly.plot.credal._data import _get_probabilities, _to_numpy
 from probly.representation.credal_set.array import (
     ArrayConvexCredalSet,

--- a/src/probly/plot/credal/_ternary.py
+++ b/src/probly/plot/credal/_ternary.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from flextype import flexdispatch
 import numpy as np
 
+from flextype import flexdispatch
 from probly.plot.credal._data import _get_probabilities, _to_numpy
 from probly.representation.credal_set.array import (
     ArrayConvexCredalSet,

--- a/src/probly/predictor/_common.py
+++ b/src/probly/predictor/_common.py
@@ -7,7 +7,6 @@ from contextvars import ContextVar
 from typing import Any, ClassVar, Literal, Protocol, runtime_checkable
 
 from flextype import ProtocolRegistry, flexdispatch
-
 from probly.representation import Representation
 from probly.representation.credal_set import CredalSet, ProbabilityIntervalsCredalSet
 from probly.representation.distribution import (

--- a/src/probly/quantification/measure/distribution/_common.py
+++ b/src/probly/quantification/measure/distribution/_common.py
@@ -6,7 +6,6 @@ import math
 from typing import TYPE_CHECKING, Literal
 
 from flextype import flexdispatch
-
 from probly.quantification._quantification import measure
 from probly.representation.distribution import CategoricalDistribution, Distribution
 from probly.representation.sample import Sample

--- a/src/probly/quantification/measure/sample/_common.py
+++ b/src/probly/quantification/measure/sample/_common.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from flextype import flexdispatch
-
 from probly.quantification._quantification import measure_atomic
 from probly.representation.distribution._common import CategoricalDistributionSample
 from probly.representation.sample._common import Sample

--- a/src/probly/quantification/measure/spectral/_common.py
+++ b/src/probly/quantification/measure/spectral/_common.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from flextype import flexdispatch
-
 from probly.quantification._quantification import measure
 from probly.representation.embedding._common import Embedding, EmbeddingSample
 

--- a/src/probly/quantification/measure/variance/_common.py
+++ b/src/probly/quantification/measure/variance/_common.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Literal
 
 from flextype import flexdispatch
-
 from probly.representation.distribution import Distribution
 
 if TYPE_CHECKING:

--- a/src/probly/quantification/notion.py
+++ b/src/probly/quantification/notion.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from typing import Literal, Protocol, runtime_checkable
 
 from flextype import ProtocolRegistry
-
 from probly.utils.switchdispatch import switch
 
 type NotionName = Literal[

--- a/src/probly/representation/array_like.py
+++ b/src/probly/representation/array_like.py
@@ -7,8 +7,9 @@ from collections.abc import Callable, Iterator, Sequence
 from types import EllipsisType, ModuleType
 from typing import TYPE_CHECKING, Any, Literal, Protocol, Self, SupportsIndex, override, runtime_checkable
 
-from flextype import flexdispatch
 import numpy as np
+
+from flextype import flexdispatch
 
 if TYPE_CHECKING:
     from numpy.typing import ArrayLike as NpArrayLike, DTypeLike, NDArray

--- a/src/probly/representation/conformal_set/_common.py
+++ b/src/probly/representation/conformal_set/_common.py
@@ -6,7 +6,6 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Literal, Self
 
 from flextype import flexdispatch
-
 from probly.representation.representation import Representation
 
 if TYPE_CHECKING:

--- a/src/probly/representation/credal_set/_common.py
+++ b/src/probly/representation/credal_set/_common.py
@@ -6,7 +6,6 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Literal, Protocol, Self
 
 from flextype import flexdispatch
-
 from probly.representation.array_like import ArrayLike
 from probly.representation.distribution import CategoricalDistribution
 from probly.representation.representation import Representation

--- a/src/probly/representation/distribution/_common.py
+++ b/src/probly/representation/distribution/_common.py
@@ -7,7 +7,6 @@ from contextvars import ContextVar
 from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
 from flextype import flexdispatch
-
 from probly.representation.representation import Representation
 from probly.representation.sample._common import RepresentationSample, Sample
 

--- a/src/probly/representation/embedding/_common.py
+++ b/src/probly/representation/embedding/_common.py
@@ -6,7 +6,6 @@ from abc import ABC, abstractmethod
 from typing import ClassVar
 
 from flextype import flexdispatch
-
 from probly.representation.representation import Representation
 from probly.representation.sample._common import RepresentationSample
 

--- a/src/probly/representation/sample/_common.py
+++ b/src/probly/representation/sample/_common.py
@@ -7,7 +7,6 @@ from contextvars import ContextVar
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, Protocol, Self
 
 from flextype import Flexdispatch, flexdispatch
-
 from probly.representation.representation import Representation
 from probly.utils.iterable import first_element
 

--- a/src/probly/representation/sample/axis_tracking.py
+++ b/src/probly/representation/sample/axis_tracking.py
@@ -6,9 +6,9 @@ from dataclasses import dataclass
 from types import EllipsisType, NotImplementedType
 from typing import TYPE_CHECKING, cast
 
-from flextype import flexdispatch
 import numpy as np
 
+from flextype import flexdispatch
 from probly.lazy_types import JAX_ARRAY, TORCH_TENSOR
 
 if TYPE_CHECKING:

--- a/src/probly/representation/torch_like.py
+++ b/src/probly/representation/torch_like.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Protocol, Self, overload, override, runtime_checkable
 
-from flextype import flexdispatch
 import torch
 from torch.overrides import handle_torch_function, has_torch_function_unary
 
+from flextype import flexdispatch
 from probly.representation.array_like import ArrayLike
 
 if TYPE_CHECKING:

--- a/src/probly/representer/_representer.py
+++ b/src/probly/representer/_representer.py
@@ -6,7 +6,6 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, final, override
 
 from flextype import flexdispatch
-
 from probly.predictor import RepresentationPredictor, predict
 from probly.representation import Representation
 

--- a/src/probly/representer/credal_set.py
+++ b/src/probly/representer/credal_set.py
@@ -7,7 +7,6 @@ import importlib
 from typing import TYPE_CHECKING, Any, override
 
 from flextype import flexdispatch
-
 from probly.lazy_types import TORCH_TENSOR, TORCH_TENSOR_LIKE
 from probly.predictor import IterablePredictor, predict
 from probly.representation.credal_set import create_convex_credal_set, create_probability_intervals

--- a/src/probly/representer/sampler/_common.py
+++ b/src/probly/representer/sampler/_common.py
@@ -7,7 +7,6 @@ import contextlib
 from typing import Any, Literal, override
 
 from flextype import RegistrationError, copy_explicit_registry_classes
-
 from probly.predictor import IterablePredictor, Predictor, RandomPredictor, RandomRepresentationPredictor, predict
 from probly.representation.sample import Sample, SampleFactory, create_sample
 from probly.representer._representer import Representer, representer

--- a/src/probly/transformation/batchensemble/_common.py
+++ b/src/probly/transformation/batchensemble/_common.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Literal, Protocol, override, runtime_checkable
 
 from flextype import flexdispatch
-
 from probly.predictor import LogitClassifier, Predictor, predict
 from probly.representation.sample._common import Sample
 from probly.representer._representer import Representer, representer

--- a/src/probly/transformation/calibration/_common.py
+++ b/src/probly/transformation/calibration/_common.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass
 from typing import Concatenate, Literal, Protocol, Self, runtime_checkable
 
 from flextype import flexdispatch
-
 from probly.calibrator._common import Calibrator
 from probly.predictor import BinaryLogitClassifier, BinaryProbabilisticClassifier, LogitClassifier, Predictor
 from probly.transformation.transformation import predictor_transformation

--- a/src/probly/transformation/conformal/_common.py
+++ b/src/probly/transformation/conformal/_common.py
@@ -6,7 +6,6 @@ from abc import ABC
 from typing import TYPE_CHECKING, Any, Concatenate, Protocol, Self, cast, runtime_checkable
 
 from flextype import flexdispatch
-
 from probly.calibrator._common import Calibrator
 from probly.conformal_scores import (
     APSScore,

--- a/src/probly/transformation/conformal_credal_set/_common.py
+++ b/src/probly/transformation/conformal_credal_set/_common.py
@@ -6,7 +6,6 @@ from abc import ABC
 from typing import TYPE_CHECKING, Any, Protocol, Self, cast, runtime_checkable
 
 from flextype import flexdispatch
-
 from probly.conformal_scores.dirichlet_relative_likelihood._common import dirichlet_rl_score
 from probly.conformal_scores.inner_product._common import inner_product_score
 from probly.conformal_scores.kullback_leibler._common import kl_divergence_score

--- a/src/probly/transformation/dirichlet_clipped_exp_one_activation/_common.py
+++ b/src/probly/transformation/dirichlet_clipped_exp_one_activation/_common.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 from flextype import flexdispatch
-
 from probly.predictor import EvidentialPredictor, LogitClassifier, predict, predict_raw
 from probly.representation.distribution import DirichletDistribution, create_dirichlet_distribution_from_alphas
 from probly.transformation.transformation import predictor_transformation

--- a/src/probly/transformation/dirichlet_exp_activation/_common.py
+++ b/src/probly/transformation/dirichlet_exp_activation/_common.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 from flextype import flexdispatch
-
 from probly.predictor import EvidentialPredictor, LogitClassifier, predict, predict_raw
 from probly.representation.distribution import DirichletDistribution, create_dirichlet_distribution_from_alphas
 from probly.transformation.transformation import predictor_transformation

--- a/src/probly/transformation/dirichlet_softplus_activation/_common.py
+++ b/src/probly/transformation/dirichlet_softplus_activation/_common.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 from flextype import flexdispatch
-
 from probly.predictor import EvidentialPredictor, LogitClassifier, predict, predict_raw
 from probly.representation.distribution import DirichletDistribution, create_dirichlet_distribution_from_alphas
 from probly.transformation.transformation import predictor_transformation

--- a/src/probly/transformation/ensemble/_common.py
+++ b/src/probly/transformation/ensemble/_common.py
@@ -6,7 +6,6 @@ from collections.abc import Iterable
 from typing import Protocol, runtime_checkable
 
 from flextype import flexdispatch
-
 from probly.predictor import (
     CategoricalDistributionPredictor,
     DirichletDistributionPredictor,

--- a/src/probly/transformation/natural_posterior_network/_common.py
+++ b/src/probly/transformation/natural_posterior_network/_common.py
@@ -6,7 +6,6 @@ import math
 from typing import TYPE_CHECKING, Literal, Protocol, runtime_checkable
 
 from flextype import flexdispatch
-
 from probly.predictor import EvidentialPredictor, predict, predict_raw
 from probly.representation.distribution import DirichletDistribution, create_dirichlet_distribution_from_alphas
 from probly.transformation.transformation import predictor_transformation

--- a/src/probly/transformation/posterior_network/_common.py
+++ b/src/probly/transformation/posterior_network/_common.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 from flextype import flexdispatch
-
 from probly.predictor import EvidentialPredictor, predict, predict_raw
 from probly.representation.distribution import DirichletDistribution, create_dirichlet_distribution_from_alphas
 from probly.transformation.transformation import predictor_transformation

--- a/src/probly/transformation/subensemble/_common.py
+++ b/src/probly/transformation/subensemble/_common.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 from flextype import flexdispatch
-
 from probly.transformation.ensemble import EnsemblePredictor, register_ensemble_members
 from probly.transformation.transformation import predictor_transformation
 

--- a/src/probly/utils/quantile/_common.py
+++ b/src/probly/utils/quantile/_common.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-from flextype import flexdispatch
 import numpy as np
+
+from flextype import flexdispatch
 
 
 @flexdispatch

--- a/src/probly_benchmark/decision.py
+++ b/src/probly_benchmark/decision.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from flextype import flexdispatch
-
 from probly.decider import categorical_from_mean
 from probly.method.batchensemble import BatchEnsemblePredictor
 from probly.method.credal_relative_likelihood import CredalRelativeLikelihoodPredictor

--- a/src/probly_benchmark/train.py
+++ b/src/probly_benchmark/train.py
@@ -17,7 +17,6 @@ import gc
 import pathlib
 import tempfile
 
-from flextype import flexdispatch
 import hydra
 from laplace.baselaplace import BaseLaplace
 from laplace.utils.feature_extractor import FeatureExtractor
@@ -30,6 +29,7 @@ from tqdm import tqdm
 import wandb
 import wandb.util
 
+from flextype import flexdispatch
 from probly.layers.torch import BatchEnsembleConv2d, BatchEnsembleLinear
 from probly.method.batchensemble import BatchEnsemblePredictor
 from probly.method.bayesian import BayesianPredictor

--- a/src/probly_benchmark/train_funcs.py
+++ b/src/probly_benchmark/train_funcs.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, TypedDict, cast
 
-from flextype import flexdispatch
 from laplace.baselaplace import BaseLaplace
 import torch
 from torch import nn, optim
 from torch.amp import GradScaler, autocast
 import torch.nn.functional as F
 
+from flextype import flexdispatch
 from probly.layers.torch import HeteroscedasticLayer, SNGPLayer
 from probly.method.batchensemble import BatchEnsemblePredictor
 from probly.method.bayesian import BayesianPredictor

--- a/tests/probly/serialization/test_flax.py
+++ b/tests/probly/serialization/test_flax.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 from typing import Any
 
-from flextype import registry_pickle
 import pytest
 
+from flextype import registry_pickle
 from probly.method.conformal import LACConformalSetPredictor, conformal_lac
 from probly.predictor import LogitClassifier
 

--- a/tests/probly/serialization/test_sklearn.py
+++ b/tests/probly/serialization/test_sklearn.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from flextype import registry_pickle
 import numpy as np
 import pytest
 
+from flextype import registry_pickle
 from probly.calibrator import calibrate
 from probly.method.calibration import isotonic_regression, sklearn_identity_logit_estimator
 from probly.method.conformal import conformal_lac

--- a/tests/probly/serialization/test_torch.py
+++ b/tests/probly/serialization/test_torch.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import io
 
-from flextype import registry_pickle
 import pytest
 
+from flextype import registry_pickle
 from probly.calibrator import calibrate
 from probly.layers.torch import NormalInverseGammaLinear
 from probly.method.calibration import isotonic_regression, torch_identity_logit_model


### PR DESCRIPTION
## Motivation and Context

Running `uv run prek run --all-files` (the pre-commit setup documented in `CLAUDE.md`) on a clean checkout of `main` reports **63 import-ordering errors** from the `ruff check` hook:

```
ruff check...............................................................Failed
- files were modified by this hook
  Found 63 errors (63 fixed, 0 remaining).
```

The `flextype` imports have drifted out of their correct isort group across many `_common.py` modules, so the hook rewrites them and any contributor who runs the documented pre-commit command ends up with unrelated churn in their working tree.

This PR applies `ruff`'s autofix so the hook (and CI) pass on a clean checkout.

## Changes

- Import ordering only (ruff isort): `flextype` imports are regrouped/sorted into the correct block. **No behavioral changes** — no logic, signatures, or runtime imports are altered.
- 63 files touched, all `import`-block reordering.

## Public API Changes

-   [x] No Public API changes

## How Has This Been Tested?

- `uv run prek run --all-files` now passes with no modifications.
- `ty check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)