### PR TITLE
fix active learning compatibility for tabular (openml) datasets

### DIFF
--- a/src/probly_benchmark/active_learning.py
+++ b/src/probly_benchmark/active_learning.py
@@ -81,6 +81,9 @@ def _build_estimator(
     al_train_overrides = al_block.pop("train", None) or {}
     if al_train_overrides:
         train_kwargs = {**train_kwargs, **al_train_overrides}
+    # Loading pre-trained weights from wandb is not supported in the AL loop
+    # (each iteration retrains from scratch).
+    train_kwargs.pop("load_from", None)
     rep_kwargs: dict[str, Any] = al_block
 
     needs_conformal = cfg.conformal.name != "none"

--- a/src/probly_benchmark/al_estimators.py
+++ b/src/probly_benchmark/al_estimators.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, cast
 
+from laplace.baselaplace import BaseLaplace
 import torch
 from torch import nn
 from torch.utils.data import DataLoader, TensorDataset
@@ -16,8 +17,17 @@ from probly.quantification import quantify
 from probly.representer import representer
 from probly_benchmark.builders import BuildContext, build_model
 from probly_benchmark.decision import decide
-from probly_benchmark.train import train_model
+from probly_benchmark.train import _move_to_device, train_model
 from probly_benchmark.uncertainty import select_uncertainty
+
+
+def _eval_mode(model: nn.Module | BaseLaplace) -> None:
+    """Set model to eval mode, handling Laplace which wraps an inner model."""
+    if isinstance(model, BaseLaplace):
+        model.model.eval()
+    else:
+        model.eval()
+
 
 if TYPE_CHECKING:
     from omegaconf import DictConfig
@@ -231,14 +241,18 @@ class BaseEstimator:
             in_features=self.in_features,
         )
         model = build_model(self.method_name, dict(self.method_params), ctx)
-        model.to(self.device)
-        train_model(model, train_loader, None, self.cfg, self.device, _NoOpRun(), dict(self.train_kwargs))
+        _move_to_device(model, self.device)
+        tk = dict(self.train_kwargs)
+        tk.setdefault("num_classes", self.num_classes)
+        tk.setdefault("base_model_name", self.base_model_name)
+        tk.setdefault("in_features", self.in_features)
+        train_model(model, train_loader, None, self.cfg, self.device, _NoOpRun(), tk)
         return model
 
     @torch.no_grad()
     def predict_proba(self, x: torch.Tensor) -> torch.Tensor:
         """Return class probabilities via probly's predict dispatch."""
-        self.model.eval()
+        _eval_mode(self.model)
         amp_enabled = self.cfg.get("amp", False)
         parts = []
         for i in range(0, len(x), self.cfg.batch_size):
@@ -256,7 +270,7 @@ class BaseEstimator:
     @torch.no_grad()
     def embed(self, x: torch.Tensor) -> torch.Tensor:
         """Return penultimate-layer features for BADGE."""
-        self.model.eval()
+        _eval_mode(self.model)
         base = self.model
         if isinstance(base, CalibrationPredictor):
             base = base.predictor
@@ -326,7 +340,7 @@ class UncertaintyEstimator(BaseEstimator):
     @torch.no_grad()
     def predict_proba(self, x: torch.Tensor) -> torch.Tensor:
         """Return class probabilities via the ``decide`` dispatch."""
-        self.model.eval()
+        _eval_mode(self.model)
         amp_enabled = self.cfg.get("amp", False)
         parts = []
         for i in range(0, len(x), self.cfg.batch_size):
@@ -339,7 +353,7 @@ class UncertaintyEstimator(BaseEstimator):
     @torch.no_grad()
     def uncertainty_scores(self, x: torch.Tensor) -> torch.Tensor:
         """Return per-sample uncertainty via representer -> quantify -> select_uncertainty."""
-        self.model.eval()
+        _eval_mode(self.model)
         rep = representer(self.model, **self.rep_kwargs)
         amp_enabled = self.cfg.get("amp", False)
         parts: list[torch.Tensor] = []

--- a/src/probly_benchmark/builders.py
+++ b/src/probly_benchmark/builders.py
@@ -208,10 +208,12 @@ def _natural_posterior_network_builder(
     ``class_counts`` -- the per-class evidence is produced by the trainable
     classifier head, not from training-set frequencies.
     """
+    extra = {"in_features": ctx.in_features} if ctx.in_features is not None else {}
     encoder = models.get_base_model(
         f"{ctx.base_model_name}_encoder",
         ctx.num_classes,
         ctx.pretrained,
+        **extra,
     )
     return method_fn(
         encoder,
@@ -260,10 +262,12 @@ def _subensemble_builder(
     pass before fitting the heads, training the (still-frozen) encoder weights
     via a temporary ``Sequential(encoder, warmup_head)`` model.
     """
+    extra = {"in_features": ctx.in_features} if ctx.in_features is not None else {}
     encoder = models.get_base_model(
         f"{ctx.base_model_name}_encoder",
         ctx.num_classes,
         ctx.pretrained,
+        **extra,
     )
     feature_dim = get_output_dim(encoder)
     method_params = dict(params)
@@ -287,7 +291,8 @@ def _laplace_builder(
     ``Laplace(...)`` is laplace-torch's factory function (not a class) and does not accept ``predictor_type``;
     we drop it and forward the remaining yaml params as keyword arguments.
     """
-    base = models.get_base_model(ctx.base_model_name, ctx.num_classes, ctx.pretrained)
+    extra = {"in_features": ctx.in_features} if ctx.in_features is not None else {}
+    base = models.get_base_model(ctx.base_model_name, ctx.num_classes, ctx.pretrained, **extra)
     return method_fn(base, **_filter_params(method_fn, params))
 
 

--- a/src/probly_benchmark/configs/method/het_net.yaml
+++ b/src/probly_benchmark/configs/method/het_net.yaml
@@ -11,3 +11,5 @@ selective_prediction:
   num_samples: 100
 ood_detection:
   num_samples: 100
+active_learning:
+  num_samples: 100

--- a/src/probly_benchmark/train.py
+++ b/src/probly_benchmark/train.py
@@ -493,12 +493,16 @@ def _(
     frozen backbone does not inflate optimizer state nor distort gradient-norm
     computations.
     """
-    if not cfg.pretrained:
-        num_classes = metadata.DATASETS[cfg.dataset].num_classes
+    if not cfg.get("pretrained", False):
+        num_classes = train_kwargs["num_classes"]
+        base_model_name = train_kwargs["base_model_name"]
+        in_features = train_kwargs.get("in_features")
+        extra = {"in_features": in_features} if in_features is not None else {}
         warmup_encoder = models.get_base_model(
-            f"{cfg.base_model}_encoder",
+            f"{base_model_name}_encoder",
             num_classes,
             pretrained=False,
+            **extra,
         ).to(device)
         feature_dim = get_output_dim(warmup_encoder)
         warmup_head = nn.Linear(feature_dim, num_classes).to(device)
@@ -521,7 +525,7 @@ def _(
         frozen_backbone.module.load_state_dict(warmup_encoder.state_dict())
 
     for i, member in enumerate(model):
-        if i > 0:
+        if i > 0 and isinstance(cfg.get("dataset"), str):
             # Long imagenet subensemble runs accumulate worker shared-memory / FD
             # state in the parent process; new workers forked between members can
             # then SIGABRT during validation. Drop the previous member's loaders
@@ -529,6 +533,7 @@ def _(
             # ``del`` lets refcounting GC the loader, which triggers the iterator's
             # ``__del__`` -> ``_shutdown_workers``; ``gc.collect`` mops up any
             # cyclic refs; ``empty_cache`` is belt-and-braces for GPU memory.
+            # Skipped in the AL flow where the estimator provides the loader directly.
             del train_loader, val_loader
             gc.collect()
             torch.cuda.empty_cache()
@@ -1378,7 +1383,6 @@ def _(
         )
     amp_enabled = cfg.get("amp", False)
     alpha = train_kwargs.get("alpha", 0.5)
-    num_classes = metadata.DATASETS[cfg.dataset].num_classes
 
     logits_train, targets_train = utils.collect_outputs_targets_raw(
         model_.predictor,
@@ -1386,6 +1390,10 @@ def _(
         device,
         amp_enabled,
     )
+    try:
+        num_classes = metadata.DATASETS[cfg.dataset].num_classes
+    except (KeyError, TypeError):
+        num_classes = logits_train.shape[-1]
     lower, upper = compute_efficient_credal_prediction_bounds(
         logits_train,
         targets_train,
@@ -1477,6 +1485,8 @@ def main(cfg: DictConfig) -> None:
 
     method_kwargs = _build_method_kwargs(cfg)
     train_kwargs = _build_train_kwargs(cfg)
+    train_kwargs.setdefault("num_classes", num_classes)
+    train_kwargs.setdefault("base_model_name", cfg.base_model)
 
     context = BuildContext(
         base_model_name=cfg.base_model,

--- a/src/probly_benchmark/utils.py
+++ b/src/probly_benchmark/utils.py
@@ -51,17 +51,20 @@ def set_seed(seed: int | None) -> None:
     torch.cuda.manual_seed_all(seed)
 
 
-def get_device(device_id: int | None = None) -> torch.device:
-    """Return the best available device, or a specific CUDA device if requested.
+def get_device(device_id: int | str | None = None) -> torch.device:
+    """Return the best available device, or a specific device if requested.
 
     Args:
-        device_id: Optional CUDA device ID to use. If None, automatically selects the least utilized CUDA device.
-            Ignored if CUDA is not available.
+        device_id: Device specification. Can be an int (CUDA device index),
+            a string like ``"cpu"``, ``"mps"``, or ``"cuda:0"``, or ``None``
+            to auto-select the best available device.
 
     Returns:
         The selected torch.device.
 
     """
+    if isinstance(device_id, str):
+        return torch.device(device_id)
     if torch.cuda.is_available():
         if device_id is not None:
             return torch.device(f"cuda:{device_id}")


### PR DESCRIPTION
- Pass in_features to get_base_model in subensemble, NPN, and laplace builders
- Handle Laplace/ensemble models in AL estimator (eval mode, device move)
- Strip load_from in AL flow (retrains from scratch each iteration)
- Fix subensemble training to get num_classes/base_model from train_kwargs
- Fix ECP training to fall back to logits shape for num_classes
- Add missing active_learning.num_samples to het_net config
- Accept string device arg in get_device (respect device=cpu override)

## Issue
Please link the corresponding GitHub issue. If an issue does not already exist,
please open one to describe the bug or feature request before creating a pull request.

This allows us to discuss the proposal and helps avoid unnecessary work.

## Motivation and Context

---

## Public API Changes

-   [ ] No Public API changes
-   [ ] Yes, Public API changes (Details below)

---

## How Has This Been Tested?

---

## Checklist

-   [ ] The changes have been tested locally.
-   [ ] Documentation has been updated (if the public API or usage changes).
-   [ ] A entry has been added to [`CHANGELOG.md`](https://github.com/pwhofman/probly/blob/main/CHANGELOG.md) (if relevant for users).
-   [ ] The code follows the project's [style guidelines](https://github.com/pwhofman/probly/blob/main/.github/CONTRIBUTING.md) and passes minimal code style checks.
-   [ ] I have considered the impact of these changes on the public API.

---
