### PR TITLE
Fix docs build flakiness and over-eager gallery cache invalidation

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -32,6 +32,8 @@ To set up the development environment, run the following command:
 uv sync --dev
 ```
 This will install all the required dependencies in your Python environment.
+probly itself supports Python 3.12+, but the `dev` and `docs` dependency groups require
+Python 3.13+, which is what `.python-version` pins the development environment to.
 
 ## Guidelines 🚓
 Here are some guidelines to follow when contributing to probly.

--- a/.github/workflows/_docs-build.yml
+++ b/.github/workflows/_docs-build.yml
@@ -44,6 +44,22 @@ jobs:
           enable-cache: true
       - name: Install dependencies
         run: uv sync --locked
+      - name: Hash the docs runtime environment
+        id: docs-env
+        # Cache key for the built gallery. Only packages the examples and the
+        # gallery itself import can change the output, so hash those groups
+        # rather than uv.lock: hashing the whole lock re-runs all 81 examples
+        # (~20 minutes) whenever a lint or test tool is bumped. Old release
+        # tags may not have these groups, hence the fallback.
+        run: |
+          if env_txt="$(uv export --frozen --no-header --no-hashes --no-annotate \
+                --no-default-groups --group docs --group all_ml --group benchmark 2>/dev/null)"; then
+            hash="$(printf '%s' "$env_txt" | sha256sum | cut -d' ' -f1)"
+          else
+            echo "uv export of the docs groups failed (old tag?); falling back to the uv.lock hash"
+            hash="$(sha256sum uv.lock | cut -d' ' -f1)"
+          fi
+          echo "hash=$hash" >> "$GITHUB_OUTPUT"
       - name: Restore docs build cache
         if: inputs.docs-cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
@@ -53,9 +69,9 @@ jobs:
             docs/source/gen_modules
             docs/source/api
             docs/build
-          key: sphinx-docs-${{ hashFiles('uv.lock') }}-${{ github.run_id }}
+          key: sphinx-docs-${{ steps.docs-env.outputs.hash }}-${{ github.run_id }}
           restore-keys: |
-            sphinx-docs-${{ hashFiles('uv.lock') }}-
+            sphinx-docs-${{ steps.docs-env.outputs.hash }}-
       - name: Remove cached output of deleted examples
         # orphaned gallery pages are in no toctree and fail -W builds
         if: inputs.docs-cache
@@ -106,7 +122,7 @@ jobs:
             docs/source/gen_modules
             docs/source/api
             docs/build
-          key: sphinx-docs-${{ hashFiles('uv.lock') }}-${{ github.run_id }}
+          key: sphinx-docs-${{ steps.docs-env.outputs.hash }}-${{ github.run_id }}
       - name: Upload docs artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:

--- a/docs/source/_sphinx_helpers.py
+++ b/docs/source/_sphinx_helpers.py
@@ -19,6 +19,9 @@ if TYPE_CHECKING:
 
 REPO_ROOT_HELPERS = Path(__file__).resolve().parents[2]
 
+# Seed applied to every gallery example; see seed_gallery_rngs.
+GALLERY_SEED = 0
+
 
 def _resolve_dotted(qualified_name: str) -> object | None:
     """Resolve a dotted name to a module or a module attribute, or None."""
@@ -85,8 +88,9 @@ def scrub_external_dependencies(app: Sphinx, env: BuildEnvironment) -> None:
     """Drop recorded page dependencies on installed packages.
 
     CI recreates the venv each run with fresh mtimes, which would re-read
-    every page depending on a site-packages file. Safe to drop: package
-    upgrades change ``uv.lock``, which forces a cold build via the cache key.
+    every page depending on a site-packages file. Safe to drop: upgrading a
+    package the docs import changes the docs build cache key, which forces a
+    cold build.
 
     Args:
         app: The Sphinx application (unused).
@@ -100,6 +104,33 @@ def scrub_external_dependencies(app: Sphinx, env: BuildEnvironment) -> None:
             if "site-packages" in full.parts or not full.is_relative_to(REPO_ROOT_HELPERS):
                 external.add(dep)
         deps.difference_update(external)
+
+
+def seed_gallery_rngs(gallery_conf: dict, fname: str | None) -> None:  # noqa: ARG001
+    """Seed the global random number generators before each gallery example.
+
+    Registered in ``sphinx_gallery_conf["reset_modules"]``, so it runs in the
+    worker process that executes the example. Most examples that train a model
+    never seed anything, which makes the gallery a lottery: an unlucky
+    initialization can send an optimizer to NaN and fail the whole build (the
+    heteroscedastic VBLL objective is the known offender). Examples that seed
+    themselves are unaffected, since their own call runs after this one.
+
+    Args:
+        gallery_conf: The sphinx-gallery configuration (unused).
+        fname: The example about to run, or None between directories (unused).
+    """
+    import random  # noqa: PLC0415
+
+    import numpy as np  # noqa: PLC0415
+
+    random.seed(GALLERY_SEED)
+    np.random.seed(GALLERY_SEED)  # noqa: NPY002, seeds the legacy global RNG the examples use
+    try:
+        import torch  # noqa: PLC0415
+    except ImportError:  # docs can be built without the torch dependency group
+        return
+    torch.manual_seed(GALLERY_SEED)
 
 
 def ignore_installed_template_mtimes(app: Sphinx) -> None:

--- a/docs/source/adding_a_method.rst
+++ b/docs/source/adding_a_method.rst
@@ -352,6 +352,11 @@ Keep the example small and fast; heavier variants (e.g. on MNIST) go in a separa
 ``plot_mymethod_mnist.py`` file, following the existing examples in
 ``examples/method/``.
 
+The gallery seeds ``random``, ``numpy`` and ``torch`` before every example, so an
+example that trains a model gets the same result on every build and cannot fail the
+docs build only some of the time. Call ``torch.manual_seed`` yourself only when the
+example needs a specific seed; it then takes precedence.
+
 Step 8: Quality checks
 ======================
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -142,6 +142,9 @@ sphinx_gallery_conf = {
     # available CPU; set SPHINX_GALLERY_PARALLEL to override (1 disables,
     # sphinx-gallery treats it as off).
     "parallel": int(os.environ.get("SPHINX_GALLERY_PARALLEL", os.process_cpu_count() or 1)),
+    # Seed the RNGs before every example so a build is reproducible; given by
+    # name because the gallery config is pickled to the parallel workers.
+    "reset_modules": ("matplotlib", "seaborn", "_sphinx_helpers.seed_gallery_rngs"),
     "default_thumb_file": str(REPO_ROOT / "docs" / "source" / "_static" / "logo" / "logo_light.png"),
 }
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -140,8 +140,9 @@ sphinx_gallery_conf = {
     "abort_on_example_error": False,
     # Execute examples in isolated worker processes (joblib/loky), one per
     # available CPU; set SPHINX_GALLERY_PARALLEL to override (1 disables,
-    # sphinx-gallery treats it as off).
-    "parallel": int(os.environ.get("SPHINX_GALLERY_PARALLEL", os.process_cpu_count() or 1)),
+    # sphinx-gallery treats it as off). os.process_cpu_count is 3.13+, so fall
+    # back to os.cpu_count on 3.12.
+    "parallel": int(os.environ.get("SPHINX_GALLERY_PARALLEL", getattr(os, "process_cpu_count", os.cpu_count)() or 1)),
     # Seed the RNGs before every example so a build is reproducible; given by
     # name because the gallery config is pickled to the parallel workers.
     "reset_modules": ("matplotlib", "seaborn", "_sphinx_helpers.seed_gallery_rngs"),


### PR DESCRIPTION
The deploy of the Python 3.12 PR re-ran all 81 gallery examples and then
failed in plot_vbll_heteroscedastic_mnist.py with "normal expects all
elements of std >= 0.0". Two independent causes:

Nothing seeds the examples. The MNIST variants (unlike their non-MNIST
siblings) never call torch.manual_seed, so every full build draws a new
initialization, and an unlucky one sends the heteroscedastic VBLL
objective to NaN through its exp(-log_noise) precision term. Docs CI on
the same commit passed; only the deploy lost the draw. Seed random,
numpy and torch before every example via sphinx-gallery's reset_modules
hook, so a build is reproducible and examples that seed themselves keep
precedence.

The gallery cache key hashed all of uv.lock, so bumping a lint or test
tool discarded output that those packages cannot influence and re-ran
every example for ~20 minutes. Key the cache on the exported docs, ML
and benchmark dependency groups instead: upgrades that can change
example output still force a cold build, dev-tooling bumps no longer do.

Verified with a full FORCE_CLEAN strict build (81/81 examples executed,
no warnings beyond intersphinx inventories unreachable from the sandbox)
followed by an incremental build that skipped all 81 again.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019JDTmNhCJSPbnKh2UCiuj2