### PR TITLE
Run the unit tests on Python 3.12 in CI

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -41,6 +41,21 @@ runs:
         fi
         uv sync --no-dev --group test --group "$DEPENDENCY_GROUP"
 
+    - name: Verify the interpreter under test
+      # .python-version pins the development interpreter, so a matrix entry
+      # that failed to override it would silently test the wrong version.
+      shell: bash
+      env:
+        EXPECTED: ${{ inputs.python-version }}
+      run: |
+        expected="$(printf '%s' "$EXPECTED" | cut -d. -f1,2)"
+        actual="$(uv run --no-sync python -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"
+        if [ "$actual" != "$expected" ]; then
+          echo "::error::requested Python $expected but the environment is $actual"
+          exit 1
+        fi
+        echo "testing on Python $actual"
+
     - name: Run tests with coverage
       if: inputs.coverage == 'true'
       shell: bash

--- a/.github/workflows/ci-lower-bounds.yml
+++ b/.github/workflows/ci-lower-bounds.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   lower_bounds_tests:
-    name: Test Lower Bounds (${{ matrix.dependency-group }}, ${{ matrix.os }})
+    name: Test Lower Bounds (${{ matrix.dependency-group }}, py${{ matrix.python-version }}, ${{ matrix.os }})
     # Run on manual dispatch, or on PRs that carry the "run-lower-bounds" label
     # (label name may include decorative emoji/prefix — we substring-match via join).
     if: >-
@@ -18,19 +18,34 @@ jobs:
       contains(join(github.event.pull_request.labels.*.name, ','), 'run-lower-bounds')
     strategy:
       fail-fast: false
+      # The declared lower bounds were chosen when 3.13 was the minimum (see the
+      # "first cp313 wheels" comments in pyproject.toml), so the oldest
+      # interpreter is worth pairing with the oldest dependencies on Linux.
       matrix:
         include:
           - os: ubuntu-latest
+            python-version: "3.12"
             dependency-group: torch
           - os: ubuntu-latest
+            python-version: "3.12"
+            dependency-group: jax
+          - os: ubuntu-latest
+            python-version: "3.13"
+            dependency-group: torch
+          - os: ubuntu-latest
+            python-version: "3.13"
             dependency-group: jax
           - os: macos-latest
+            python-version: "3.13"
             dependency-group: torch
           - os: macos-latest
+            python-version: "3.13"
             dependency-group: jax
           - os: windows-latest
+            python-version: "3.13"
             dependency-group: torch
           - os: windows-latest
+            python-version: "3.13"
             dependency-group: jax
     runs-on: ${{ matrix.os }}
     steps:
@@ -40,7 +55,7 @@ jobs:
       - name: Run tests with minimum dependency versions
         uses: ./.github/actions/run-tests
         with:
-          python-version: "3.13"
+          python-version: ${{ matrix.python-version }}
           dependency-group: ${{ matrix.dependency-group }}
           resolution: "lowest-direct"
           coverage: "false"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,17 @@ jobs:
     # Install and Import Check
     # ----------------------------------------------------------------------------------------------
     install_and_import:
-        name: Install and Import Check
+        name: Install and Import Check (py${{ matrix.python-version }})
         # Skip draft PRs; runs on ready-for-review, push, and dispatch.
         if: github.event.pull_request.draft == false
         runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
+            matrix:
+                # Oldest and newest supported interpreter; installs from the
+                # project metadata, so it also catches a requires-python that
+                # no longer matches what the code needs.
+                python-version: ["3.12", "3.13"]
         steps:
             -   uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
                 with:
@@ -46,40 +53,62 @@ jobs:
             -   name: Set up Python and uv
                 uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2
                 with:
-                    python-version: "3.13"
+                    python-version: ${{ matrix.python-version }}
                     enable-cache: true
             -   name: Create uv virtual environment
                 run: uv venv
             -   name: Install probly package
                 run: uv run --no-sync uv pip install .
             -   name: Test import
-                run: uv run --no-sync python -c "import probly; print('✅ probly imported successfully')"
+                run: uv run --no-sync python -c "import sys, probly; print(f'✅ probly imported successfully on Python {sys.version.split()[0]}')"
     # ----------------------------------------------------------------------------------------------
     # Unit Tests with Matrix
     # ----------------------------------------------------------------------------------------------
     run_unit_tests:
-        name: Tests (${{ matrix.os }}, ${{ matrix.dependency-group }})
+        name: Tests (${{ matrix.os }}, py${{ matrix.python-version }}, ${{ matrix.dependency-group }})
         # Skip draft PRs; runs on ready-for-review, push, and dispatch.
         if: github.event.pull_request.draft == false
         strategy:
             fail-fast: false
+            # Both ends of the supported range (see project.requires-python) are
+            # covered on Linux; the other operating systems run the newest only.
             matrix:
                 include:
                     - os: ubuntu-latest
+                      python-version: "3.12"
                       dependency-group: torch
                     - os: ubuntu-latest
+                      python-version: "3.12"
                       dependency-group: jax
                     - os: ubuntu-latest
+                      python-version: "3.12"
                       dependency-group: river
                     - os: ubuntu-latest
+                      python-version: "3.12"
+                      dependency-group: transformers
+                    - os: ubuntu-latest
+                      python-version: "3.13"
+                      dependency-group: torch
+                    - os: ubuntu-latest
+                      python-version: "3.13"
+                      dependency-group: jax
+                    - os: ubuntu-latest
+                      python-version: "3.13"
+                      dependency-group: river
+                    - os: ubuntu-latest
+                      python-version: "3.13"
                       dependency-group: transformers
                     - os: macos-latest
+                      python-version: "3.13"
                       dependency-group: torch
                     - os: macos-latest
+                      python-version: "3.13"
                       dependency-group: jax
                     - os: windows-latest
+                      python-version: "3.13"
                       dependency-group: torch
                     - os: windows-latest
+                      python-version: "3.13"
                       dependency-group: jax
         runs-on: ${{ matrix.os }}
         steps:
@@ -89,10 +118,10 @@ jobs:
             -   name: Run tests
                 uses: ./.github/actions/run-tests
                 with:
-                    python-version: "3.13"
+                    python-version: ${{ matrix.python-version }}
                     dependency-group: ${{ matrix.dependency-group }}
                     coverage: "true"
-                    coverage-artifact-name: coverage-${{ matrix.os }}-${{ matrix.dependency-group }}
+                    coverage-artifact-name: coverage-${{ matrix.os }}-py${{ matrix.python-version }}-${{ matrix.dependency-group }}
     # ----------------------------------------------------------------------------------------------
     # Code Coverage
     # ----------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Issue

Closes #575

## Motivation and Context

`project.requires-python` became `>=3.12.0` in #572, but every workflow passed `python-version: "3.13"` as a literal, so no job ever ran on the lowest supported interpreter. The 3.12 support claim was untested.

Changes:

- **`ci.yml`** — the unit-test matrix gains a `python-version` axis. Both 3.12 and 3.13 run on `ubuntu-latest` across all four dependency groups (`torch`, `jax`, `river`, `transformers`); macOS and Windows stay on 3.13 only, so the matrix grows from 8 to 12 jobs rather than to 16. Coverage artifact names now include the version, which also keeps them unique for `upload-artifact`.
- **`ci.yml`** — the install-and-import check runs on both 3.12 and 3.13. It installs from the project metadata, so it also catches a `requires-python` that no longer matches what the code needs.
- **`ci-lower-bounds.yml`** — the Linux entries run on both versions. The declared lower bounds were chosen when 3.13 was the minimum (see the `# first cp313 wheels` comments in `pyproject.toml`), so oldest-interpreter × oldest-dependencies is the combination most likely to surface a bad bound. This workflow is opt-in via label or dispatch, so the extra jobs cost nothing by default.
- **`.github/actions/run-tests/action.yml`** — a new step asserts that the interpreter under test is the one the matrix requested, failing with a clear error otherwise.

That last step is worth calling out. `.python-version` pins the development interpreter to 3.13, and `uv` consults it when nothing else specifies a version. `setup-uv` does export `UV_PYTHON` from its `python-version` input, and `UV_PYTHON` does win over `.python-version` for `uv sync` and `uv venv` — I verified both against the pinned action revision and against `uv` directly. But that precedence is exactly the kind of thing that changes quietly in a dependency bump, and if it ever flipped, a job labelled 3.12 would go green while running 3.13. The assertion turns that silent failure into a loud one.

No changes to `pyproject.toml`; the `test` group is not covered by the `[tool.uv.dependency-groups]` 3.13 restriction, so `uv sync --no-dev --group test --group <group>` already resolves and installs on 3.12.

## Public API Changes

-   [x] No Public API changes
-   [ ] Yes, Public API changes (Details below)

## How Has This Been Tested?

I ran the full suite on CPython 3.12.3 locally, once per Linux dependency group, using the same command the CI action runs (`uv sync --no-dev --group test --group <group>` then `pytest tests/probly -m "not integration"`):

| Dependency group | Result |
| --- | --- |
| `torch` | 2621 passed, 65 skipped |
| `jax` + `river` | 1438 passed, 115 skipped |
| `transformers` | 2660 passed, 61 skipped |

No failures, so these jobs should land green rather than needing follow-up fixes. macOS and Windows on 3.12 are not covered by this PR and were not tested; adding them later is a matrix entry away if you want that coverage.

## Checklist

-   [x] The changes have been tested locally.
-   [x] Documentation has been updated (if the public API or usage changes). — n/a, CI only
-   [x] A entry has been added to [`CHANGELOG.md`](https://github.com/pwhofman/probly/blob/main/CHANGELOG.md) (if relevant for users). — n/a, no user-facing change; 3.12 support itself is not listed there either
-   [x] The code follows the project's [style guidelines](https://github.com/pwhofman/probly/blob/main/.github/CONTRIBUTING.md) and passes minimal code style checks. — `prek run --all-files` passes (`zizmor` cannot reach the GitHub API from my sandbox and errors on an unrelated pre-existing file)
-   [x] I have considered the impact of these changes on the public API.


---
_Generated by [Claude Code](https://claude.ai/code/session_019JDTmNhCJSPbnKh2UCiuj2)_