### PR TITLE
Add Flax implementation Bayesian

### DIFF
--- a/src/probly/layers/flax.py
+++ b/src/probly/layers/flax.py
@@ -84,7 +84,7 @@ class BayesLinear(nnx.Module):
         self.dot_general = base_layer.dot_general
         self.promote_dtype = base_layer.promote_dtype
 
-        self._init_rngs(rngs)
+        self.rngs = _init_rngs(self.rng_collection, rngs)
 
         shape = (self.in_features, self.out_features)
 
@@ -127,7 +127,7 @@ class BayesLinear(nnx.Module):
             self.bias_prior_mu = BayesianPrior(bias_prior_mu_init)
             self.bias_prior_sigma = BayesianPrior(jnp.full(bias_shape, prior_std))
 
-    def _init_rngs(
+    """def _init_rngs(
         self,
         rngs: rnglib.Rngs | rnglib.RngStream | None = None,
     ) -> None:
@@ -139,7 +139,7 @@ class BayesLinear(nnx.Module):
             self.rngs = nnx.data(None)
         else:
             msg = f"rngs must be a RNGS, RngStream or None, but got {type(rngs)}."
-            raise TypeError(msg)
+            raise TypeError(msg)"""
 
     def __call__(
         self,
@@ -217,6 +217,224 @@ class BayesLinear(nnx.Module):
                 ),
             )
         return kl
+
+
+class BayesConv(nnx.Conv):
+    """Implementation of a Bayesian convolutional layer based on :cite:`blundellWeightUncertainty2015`.
+
+    Reuses ``nnx.Conv.__call__`` for the actual convolution (padding canonicalization,
+    dimension numbers, grouped convolution, masking, ...) by sampling a fresh ``kernel``/
+    ``bias`` from the variational posterior on every call and temporarily installing them
+    before delegating to ``super().__call__``, analogous to :class:`BatchEnsembleConv`.
+
+    Attributes:
+        in_features: int, number of input channels.
+        out_features: int, number of output channels.
+        kernel_size: int or Sequence[int], size of the kernel.
+        strides: int or Sequence[int], the inter-window strides.
+        padding: flax.typing.PaddingLike, see ``nnx.Conv`` for the accepted forms.
+        input_dilation: int or Sequence[int], dilation applied to the inputs.
+        kernel_dilation: int or Sequence[int], dilation applied to the kernel ('atrous' convolution).
+        feature_group_count: int, number of groups for grouped convolution.
+        use_bias: bool, whether to add a bias term.
+        weight_mu: nnx.Param, mean of the posterior weights.
+        weight_rho: nnx.Param, transformed standard deviation of the posterior weights.
+        weight_prior_mu: BayesianPrior, mean of the prior weights.
+        weight_prior_sigma: BayesianPrior, standard deviation of the prior weights.
+        bias_mu: nnx.Param, mean of the posterior bias.
+        bias_rho: nnx.Param, transformed standard deviation of the posterior bias.
+        bias_prior_mu: BayesianPrior, mean of the prior bias.
+        bias_prior_sigma: BayesianPrior, standard deviation of the prior bias.
+    """
+
+    def __init__(
+        self,
+        base_layer: nnx.Conv,
+        use_base_weights: bool = False,
+        posterior_std: float = 0.05,
+        prior_mean: float = 0.0,
+        prior_std: float = 1.0,
+        rng_collection: str = "bayesian",
+        rngs: rnglib.Rngs | rnglib.RngStream | None = None,
+    ) -> None:
+        """Reparameterize the standard deviation of the posterior weights using the re-parameterization trick.
+
+        Args:
+            base_layer: The original conv layer to be used.
+            use_base_weights: Whether to use the weights of the base layer as prior means.
+            posterior_std: Initial standard deviation of the posterior.
+            prior_mean: Mean of the prior.
+            prior_std: Standard deviation of the prior.
+            rng_collection: str, the rng collection name to use when requesting a rng key.
+            rngs: rnglib.Rngs or rnglib.RngStream or None, rng key.
+        """
+        self.rng_collection = rng_collection
+        _copy_conv_attrs(self, base_layer)
+
+        self.rngs = _init_rngs(self.rng_collection, rngs)
+
+        shape = self.kernel_shape
+
+        rho = cast("float", _inverse_softplus(jnp.array(posterior_std)))
+
+        if use_base_weights:
+            self.weight_mu = nnx.Param(base_layer.kernel.value)
+            prior_mu_init = base_layer.kernel.value
+        else:
+            if self.rngs is None:
+                msg = "rngs must be provided when use_base_weights is False, to initialize new weights."
+                raise ValueError(msg)
+            kernel_init = jax.nn.initializers.lecun_normal()
+            self.weight_mu = nnx.Param(kernel_init(self.rngs(), shape, base_layer.param_dtype))
+            prior_mu_init = jnp.full(shape, prior_mean)
+
+        self.weight_rho = nnx.Param(jnp.full(shape, rho, self.param_dtype))
+        self.weight_prior_mu = BayesianPrior(prior_mu_init)
+        self.weight_prior_sigma = BayesianPrior(jnp.full(shape, prior_std))
+
+        # placeholder kernel Param required by nnx.Conv.__call__; resampled on every __call__
+        self.kernel = nnx.Param(self.weight_mu[...])
+
+        if not self.use_bias:
+            self.bias = nnx.data(None)
+            self.bias_mu = nnx.data(None)
+            self.bias_rho = nnx.data(None)
+            self.bias_prior_mu = nnx.data(None)
+            self.bias_prior_sigma = nnx.data(None)
+            return
+
+        bias_shape = (self.out_features,)
+
+        if use_base_weights and base_layer.bias is not None:
+            self.bias_mu = nnx.Param(base_layer.bias.value)
+            bias_prior_mu_init = base_layer.bias.value
+        else:
+            self.bias_mu = nnx.Param(jnp.zeros(bias_shape, self.param_dtype))
+            bias_prior_mu_init = jnp.full(bias_shape, prior_mean)
+
+        self.bias_rho = nnx.Param(jnp.full(bias_shape, rho, self.param_dtype))
+        self.bias_prior_mu = BayesianPrior(bias_prior_mu_init)
+        self.bias_prior_sigma = BayesianPrior(jnp.full(bias_shape, prior_std))
+
+        # placeholder bias Param required by nnx.Conv.__call__; resampled on every __call__
+        self.bias = nnx.Param(self.bias_mu[...])
+
+    def __call__(
+        self,
+        inputs: jax.Array,
+        out_sharding: Any = None,  # noqa: ANN401
+        *,
+        rngs: rnglib.Rngs | rnglib.RngStream | None = None,
+    ) -> jax.Array:
+        """Forward pass of the Bayesian conv layer.
+
+        Args:
+            inputs: jax.Array, input data
+            out_sharding: Optional sharding specification for the output array.
+            rngs: rnglib.Rngs, rnglib.RngStream or None, optional key used to sample the
+                reparameterization noise for this call. Falls back to the rng stream captured
+                at construction time.
+
+        Returns:
+            jax.Array, layer output
+        """
+        rngs = first_from(
+            rngs,
+            self.rngs,
+            error_msg="""No `rngs` argument was provided to BayesianConv
+                as either a __call__ argument or class attribute.""",
+        )
+        if isinstance(rngs, rnglib.Rngs):
+            key = rngs[self.rng_collection]()
+        elif isinstance(rngs, rnglib.RngStream):
+            key = rngs()
+        elif isinstance(rngs, jax.Array):
+            key = rngs
+        else:
+            msg = f"rngs must be Rngs, RngStream or jax.Array, but got {type(rngs)}."
+            raise TypeError(msg)
+
+        key_weight, key_bias = jax.random.split(key)
+
+        eps_weight = jax.random.normal(key_weight, self.weight_mu.shape, self.param_dtype)
+        weight = self.weight_mu[...] + jnp.log1p(jnp.exp(self.weight_rho[...])) * eps_weight
+        self.kernel = nnx.Param(weight)
+
+        if self.use_bias:
+            bias_mu = nnx.Param(self.bias_mu)
+            bias_rho = nnx.Param(self.bias_rho)
+            eps_bias = jax.random.normal(key_bias, bias_mu.shape, self.param_dtype)
+            bias = bias_mu[...] + jnp.log1p(jnp.exp(bias_rho[...])) * eps_bias
+            self.bias = nnx.Param(bias)
+
+        return super().__call__(inputs, out_sharding=out_sharding)
+
+    @property
+    def kl_divergence(self) -> jax.Array:
+        """Computes the KL-divergence between the posterior and prior."""
+        weight_mu = cast("jax.Array", self.weight_mu)
+        weight_rho = cast("jax.Array", self.weight_rho)
+        kl = jnp.sum(
+            _kl_divergence_gaussian(
+                weight_mu,
+                jnp.log1p(jnp.exp(weight_rho)) ** 2,
+                cast("jax.Array", self.weight_prior_mu),
+                cast("jax.Array", self.weight_prior_sigma) ** 2,
+            ),
+        )
+        if self.use_bias:
+            bias_mu = cast("jax.Array", self.bias_mu)
+            bias_rho = cast("jax.Array", self.bias_rho)
+            kl += jnp.sum(
+                _kl_divergence_gaussian(
+                    bias_mu,
+                    jnp.log1p(jnp.exp(bias_rho)) ** 2,
+                    cast("jax.Array", self.bias_prior_mu),
+                    cast("jax.Array", self.bias_prior_sigma) ** 2,
+                ),
+            )
+        return kl
+
+
+def _copy_conv_attrs(module: BayesConv, base_layer: nnx.Conv) -> None:
+    """Copy the structural ``nnx.Conv`` config from ``base_layer`` onto ``module``.
+
+    These attributes are read directly by ``nnx.Conv.__call__``, which :class:`BayesConv`
+    reuses via ``super().__call__`` instead of reimplementing the convolution itself.
+    """
+    module.kernel_shape = base_layer.kernel_shape
+    module.in_features = base_layer.in_features
+    module.out_features = base_layer.out_features
+    module.kernel_size = base_layer.kernel_size
+    module.strides = base_layer.strides
+    module.padding = base_layer.padding
+    module.input_dilation = base_layer.input_dilation
+    module.kernel_dilation = base_layer.kernel_dilation
+    module.feature_group_count = base_layer.feature_group_count
+    module.use_bias = base_layer.use_bias
+    module.mask = base_layer.mask
+    module.dtype = base_layer.dtype
+    module.param_dtype = base_layer.param_dtype
+    module.precision = base_layer.precision
+    module.conv_general_dilated = base_layer.conv_general_dilated
+    module.promote_dtype = base_layer.promote_dtype
+    module.preferred_element_type = base_layer.preferred_element_type
+
+
+def _init_rngs(
+    rng_collection: str,
+    rngs: rnglib.Rngs | rnglib.RngStream | None = None,
+) -> nnx.Rngs | None:
+    if isinstance(rngs, rnglib.Rngs):
+        rngs = rngs[rng_collection].fork()
+    elif isinstance(rngs, rnglib.RngStream):
+        rngs = rngs.fork()
+    elif rngs is None:
+        rngs = nnx.data(None)
+    else:
+        msg = f"rngs must be a RNGS, RngStream or None, but got {type(rngs)}."
+        raise TypeError(msg)
+    return rngs
 
 
 def _kl_divergence_gaussian(

--- a/src/probly/layers/flax.py
+++ b/src/probly/layers/flax.py
@@ -208,10 +208,9 @@ class BayesLinear(nnx.Module):
 class BayesConv(nnx.Conv):
     """Implementation of a Bayesian convolutional layer based on :cite:`blundellWeightUncertainty2015`.
 
-    Reuses ``nnx.Conv.__call__`` for the actual convolution (padding canonicalization,
-    dimension numbers, grouped convolution, masking, ...) by sampling a fresh ``kernel``/
+    Uses `nnx.Conv.__cal__` for the actual convolution attributes by sampling a fresh ``kernel``/
     ``bias`` from the variational posterior on every call and temporarily installing them
-    before delegating to ``super().__call__``, analogous to :class:`BatchEnsembleConv`.
+    before delegating to ``super().__call__``.
 
     Attributes:
         in_features: int, number of input channels.
@@ -278,7 +277,6 @@ class BayesConv(nnx.Conv):
         self.weight_prior_mu = BayesianPrior(prior_mu_init)
         self.weight_prior_sigma = BayesianPrior(jnp.full(shape, prior_std))
 
-        # placeholder kernel Param required by nnx.Conv.__call__; resampled on every __call__
         self.kernel = nnx.Param(self.weight_mu[...])
 
         if not self.use_bias:
@@ -302,7 +300,6 @@ class BayesConv(nnx.Conv):
         self.bias_prior_mu = BayesianPrior(bias_prior_mu_init)
         self.bias_prior_sigma = BayesianPrior(jnp.full(bias_shape, prior_std))
 
-        # placeholder bias Param required by nnx.Conv.__call__; resampled on every __call__
         self.bias = nnx.Param(self.bias_mu[...])
 
     def __call__(
@@ -383,10 +380,10 @@ class BayesConv(nnx.Conv):
 
 
 def _copy_conv_attrs(module: BayesConv, base_layer: nnx.Conv) -> None:
-    """Copy the structural ``nnx.Conv`` config from ``base_layer`` onto ``module``.
+    """Copy the attributes of `nnx.Conv` onto BayesConv layer.
 
-    These attributes are read directly by ``nnx.Conv.__call__``, which :class:`BayesConv`
-    reuses via ``super().__call__`` instead of reimplementing the convolution itself.
+    They are read by `nnx.Conv.__call__`, which is resued by BayesConv layer
+    via `super().__call__()` instead of reimplementing the convolution itself.
     """
     module.kernel_shape = base_layer.kernel_shape
     module.in_features = base_layer.in_features

--- a/src/probly/layers/flax.py
+++ b/src/probly/layers/flax.py
@@ -29,6 +29,18 @@ def _init_fast_weight(
     raise ValueError(msg)
 
 
+def _inverse_softplus(x: jax.Array) -> jax.Array:
+    """Compute the inverse softplus function.
+
+    Args:
+        x: Input tensor.
+
+    Returns:
+        Output tensor after applying the inverse softplus function.
+    """
+    return jnp.log(jnp.exp(x) - 1)
+
+
 class DropConnectLinear(nnx.Module):
     """Custom Linear layer with DropConnect applied to weights during training based on :cite:`aminiDeepEvidential2020`.
 

--- a/src/probly/layers/flax.py
+++ b/src/probly/layers/flax.py
@@ -88,7 +88,7 @@ class BayesLinear(nnx.Module):
 
         shape = (self.in_features, self.out_features)
 
-        rho = cast("float", _inverse_softplus(jax.Array(posterior_std)))
+        rho = cast("float", _inverse_softplus(jnp.array(posterior_std)))
         self.weight_rho = nnx.Param(jnp.full(shape, rho))
 
         if use_base_weights:

--- a/src/probly/layers/flax.py
+++ b/src/probly/layers/flax.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 from flax import nnx
 from flax.nnx import rnglib
@@ -27,6 +27,217 @@ def _init_fast_weight(
         return mean + std * jax.random.normal(key, shape, dtype=dtype)
     msg = f"Unknown init {init_method!r}; expected 'random_sign' or 'normal'."
     raise ValueError(msg)
+
+
+class BayesianPrior(nnx.Variable):
+    """Class to create variables similar to torch Buffer."""
+
+
+class BayesLinear(nnx.Module):
+    """Implement a Bayesian linear layer based on :cite:`blundellWeightUncertainty2015`.
+
+    Attributes:
+        in_features: Number of input features.
+        out_features: Number of output features.
+        bias: Whether to use a bias term.
+        use_bias: Whether to use a bias term.
+        weight_mu: Mean of the posterior weights.
+        weight_rho: Transformed standard deviation of the posterior weights.
+        weight_prior_mu: Mean of the prior weights.
+        weight_prior_sigma: Standard deviation of the prior weights.
+        bias_mu: Mean of the posterior biases.
+        bias_rho: Transformed standard deviation of the posterior biases.
+        bias_prior_mu: Mean of the prior biases.
+        bias_prior_sigma: Standard deviation of the prior biases.
+    """
+
+    def __init__(
+        self,
+        base_layer: nnx.Linear,
+        use_base_weights: bool = False,
+        posterior_std: float = 0.05,
+        prior_mean: float = 0.0,
+        prior_std: float = 1.0,
+        rng_collection: str = "bayesian",
+        rngs: rnglib.Rngs | rnglib.RngStream | None = None,
+    ) -> None:
+        """Reparameterize the standard deviation of the posterior weights using the re-parameterization trick.
+
+        Args:
+            base_layer: The original linear layer to be used.
+            use_base_weights: Whether to use the weights of the base layer as prior means.
+            posterior_std: Initial standard deviation of the posterior.
+            prior_mean: Mean of the prior.
+            prior_std: Standard deviation of the prior.
+            rng_collection: str, the rng collection name to use when requesting a rng key.
+            rngs: rnglib.Rngs or rnglib.RngStream or None, rng key.
+
+        """
+        self.precision = base_layer.precision
+        self.rng_collection = rng_collection
+        self.dtype = base_layer.dtype
+        self.param_dtype = base_layer.param_dtype
+        self.in_features = base_layer.in_features
+        self.out_features = base_layer.out_features
+        self.bias = base_layer.bias is not None
+        self.use_bias = base_layer.use_bias
+        self.dot_general = base_layer.dot_general
+        self.promote_dtype = base_layer.promote_dtype
+
+        self._init_rngs(rngs)
+
+        shape = (self.in_features, self.out_features)
+
+        rho = cast("float", _inverse_softplus(jax.Array(posterior_std)))
+        self.weight_rho = nnx.Param(jnp.full(shape, rho))
+
+        if use_base_weights:
+            self.weight_mu = nnx.Param(base_layer.kernel.value)
+            prior_mu_init = base_layer.kernel.value
+        else:
+            if self.rngs is None:
+                msg = "rngs must be provided when use_base_weights is False, to initialize new weights."
+                raise ValueError(msg)
+            kernel_init = jax.nn.initializers.lecun_normal()
+            self.weight_mu = nnx.Param(kernel_init(self.rngs(), shape, base_layer.param_dtype))
+            prior_mu_init = jnp.full(shape, prior_mean)
+
+        self.weight_rho = nnx.Param(jnp.full(shape, rho, self.param_dtype))
+        self.weight_prior_mu = BayesianPrior(prior_mu_init)
+        self.weight_prior_sigma = BayesianPrior(jnp.full(shape, prior_std))
+
+        if not self.use_bias:
+            self.bias_mu = nnx.data(None)
+            self.bias_rho = nnx.data(None)
+            self.bias_prior_mu = nnx.data(None)
+            self.bias_prior_sigma = nnx.data(None)
+            return
+
+        bias_shape = (self.out_features,)
+
+        if self.bias:
+            if use_base_weights:
+                self.bias_mu = nnx.Param(base_layer.bias)
+                bias_prior_mu_init = base_layer.bias
+            else:
+                self.bias_mu = nnx.Param(jnp.zeros(bias_shape, self.param_dtype))
+                bias_prior_mu_init = jnp.full(bias_shape, prior_mean)
+
+            self.bias_rho = nnx.Param(jnp.full(bias_shape, rho, self.param_dtype))
+            self.bias_prior_mu = BayesianPrior(bias_prior_mu_init)
+            self.bias_prior_sigma = BayesianPrior(jnp.full(bias_shape, prior_std))
+
+    def _init_rngs(
+        self,
+        rngs: rnglib.Rngs | rnglib.RngStream | None = None,
+    ) -> None:
+        if isinstance(rngs, rnglib.Rngs):
+            self.rngs = rngs[self.rng_collection].fork()
+        elif isinstance(rngs, rnglib.RngStream):
+            self.rngs = rngs.fork()
+        elif rngs is None:
+            self.rngs = nnx.data(None)
+        else:
+            msg = f"rngs must be a RNGS, RngStream or None, but got {type(rngs)}."
+            raise TypeError(msg)
+
+    def __call__(
+        self,
+        inputs: jax.Array,
+        rngs: rnglib.Rngs | rnglib.RngStream | None = None,
+    ) -> jax.Array:
+        """Forward pass of the Bayesian linear layer.
+
+        Args:
+            inputs: jax.Array, input data
+            rngs: rnglib.Rngs, rnglib.RngStream or None, optional key used to sample the
+                reparameterization noise for this call. Falls back to the rng stream captured
+                at construction time.
+
+        Returns:
+            jax.Array, layer output
+        """
+        rngs = first_from(
+            rngs,
+            self.rngs,
+            error_msg="""No `rngs` argument was provided to BayesianLinear
+                as either a __call__ argument or class attribute.""",
+        )
+        if isinstance(rngs, rnglib.Rngs):
+            key = rngs[self.rng_collection]()
+        elif isinstance(rngs, rnglib.RngStream):
+            key = rngs()
+        elif isinstance(rngs, jax.Array):
+            key = rngs
+        else:
+            msg = f"rngs must be Rngs, RngStream or jax.Array, but got {type(rngs)}."
+            raise TypeError(msg)
+
+        key_weight, key_bias = jax.random.split(key)
+
+        eps_weight = jax.random.normal(key_weight, self.weight_mu.shape, self.param_dtype)
+        weight = self.weight_mu[...] + jnp.log1p(jnp.exp(self.weight_rho[...])) * eps_weight
+
+        bias = None
+        if self.use_bias:
+            bias_mu = nnx.Param(self.bias_mu)
+            bias_rho = nnx.Param(self.bias_rho)
+            bias_weight = jax.random.normal(key_bias, bias_mu.shape, self.param_dtype)
+            bias = bias_mu[...] + jnp.log1p(jnp.exp(bias_rho[...])) * bias_weight
+
+        inputs, weight, bias = self.promote_dtype((inputs, weight, bias), dtype=self.dtype)
+        out = self.dot_general(inputs, weight, (((inputs.ndim - 1,), (0,)), ((), ())), precision=self.precision)
+
+        if bias is not None:
+            out += jnp.reshape(bias, (1,) * (out.ndim - 1) + (-1,))
+        return out
+
+    @property
+    def kl_divergence(self) -> jax.Array:
+        """Computes the KL-divergence between the posterior and prior."""
+        weight_mu = cast("jax.Array", self.weight_mu)
+        weight_rho = cast("jax.Array", self.weight_rho)
+        bias_mu = cast("jax.Array", self.bias_mu)
+        bias_rho = cast("jax.Array", self.bias_rho)
+        kl = jnp.sum(
+            _kl_divergence_gaussian(
+                weight_mu,
+                jnp.log1p(jnp.exp(weight_rho)) ** 2,
+                cast("jax.Array", self.weight_prior_mu),
+                cast("jax.Array", self.weight_prior_sigma) ** 2,
+            ),
+        )
+        if self.bias:
+            kl += jnp.sum(
+                _kl_divergence_gaussian(
+                    bias_mu,
+                    jnp.log1p(jnp.exp(bias_rho)) ** 2,
+                    cast("jax.Array", self.bias_prior_mu),
+                    cast("jax.Array", self.bias_prior_sigma) ** 2,
+                ),
+            )
+        return kl
+
+
+def _kl_divergence_gaussian(
+    mu1: jax.Array,
+    sigma21: jax.Array,
+    mu2: jax.Array,
+    sigma22: jax.Array,
+) -> jax.Array:
+    """Compute the KL-divergence between two Gaussian distributions.
+
+    https://en.wikipedia.org/wiki/Kullback-Leibler_divergence#Examples
+    Args:
+        mu1: jax.Array, mean of the first Gaussian distribution
+        sigma21: jax.Array, variance of the first Gaussian distribution
+        mu2: jax.Array, mean of the second Gaussian distribution
+        sigma22: jax.Array, variance of the second Gaussian distribution
+    Returns:
+        kl_div: float or numpy.ndarray shape (n_instances,), KL-divergence between the two Gaussian distributions
+    """
+    kl_div: jax.Array = 0.5 * jnp.log(sigma22 / sigma21) + (sigma21 + (mu1 - mu2) ** 2) / (2 * sigma22) - 0.5
+    return kl_div
 
 
 def _inverse_softplus(x: jax.Array) -> jax.Array:

--- a/src/probly/layers/flax.py
+++ b/src/probly/layers/flax.py
@@ -127,20 +127,6 @@ class BayesLinear(nnx.Module):
             self.bias_prior_mu = BayesianPrior(bias_prior_mu_init)
             self.bias_prior_sigma = BayesianPrior(jnp.full(bias_shape, prior_std))
 
-    """def _init_rngs(
-        self,
-        rngs: rnglib.Rngs | rnglib.RngStream | None = None,
-    ) -> None:
-        if isinstance(rngs, rnglib.Rngs):
-            self.rngs = rngs[self.rng_collection].fork()
-        elif isinstance(rngs, rnglib.RngStream):
-            self.rngs = rngs.fork()
-        elif rngs is None:
-            self.rngs = nnx.data(None)
-        else:
-            msg = f"rngs must be a RNGS, RngStream or None, but got {type(rngs)}."
-            raise TypeError(msg)"""
-
     def __call__(
         self,
         inputs: jax.Array,
@@ -424,7 +410,7 @@ def _copy_conv_attrs(module: BayesConv, base_layer: nnx.Conv) -> None:
 def _init_rngs(
     rng_collection: str,
     rngs: rnglib.Rngs | rnglib.RngStream | None = None,
-) -> nnx.Rngs | None:
+) -> nnx.rnglib.RngStream | None:
     if isinstance(rngs, rnglib.Rngs):
         rngs = rngs[rng_collection].fork()
     elif isinstance(rngs, rnglib.RngStream):

--- a/src/probly/layers/flax.py
+++ b/src/probly/layers/flax.py
@@ -29,10 +29,6 @@ def _init_fast_weight(
     raise ValueError(msg)
 
 
-class BayesianPrior(nnx.Variable):
-    """Class to create variables similar to torch Buffer."""
-
-
 class BayesLinear(nnx.Module):
     """Implement a Bayesian linear layer based on :cite:`blundellWeightUncertainty2015`.
 
@@ -103,8 +99,8 @@ class BayesLinear(nnx.Module):
             prior_mu_init = jnp.full(shape, prior_mean)
 
         self.weight_rho = nnx.Param(jnp.full(shape, rho, self.param_dtype))
-        self.weight_prior_mu = BayesianPrior(prior_mu_init)
-        self.weight_prior_sigma = BayesianPrior(jnp.full(shape, prior_std))
+        self.weight_prior_mu = nnx.data(prior_mu_init)
+        self.weight_prior_sigma = nnx.data(jnp.full(shape, prior_std))
 
         if not self.use_bias:
             self.bias_mu = nnx.data(None)
@@ -124,8 +120,8 @@ class BayesLinear(nnx.Module):
                 bias_prior_mu_init = jnp.full(bias_shape, prior_mean)
 
             self.bias_rho = nnx.Param(jnp.full(bias_shape, rho, self.param_dtype))
-            self.bias_prior_mu = BayesianPrior(bias_prior_mu_init)
-            self.bias_prior_sigma = BayesianPrior(jnp.full(bias_shape, prior_std))
+            self.bias_prior_mu = nnx.data(bias_prior_mu_init)
+            self.bias_prior_sigma = nnx.data(jnp.full(bias_shape, prior_std))
 
     def __call__(
         self,
@@ -190,7 +186,7 @@ class BayesLinear(nnx.Module):
                 weight_mu,
                 jnp.log1p(jnp.exp(weight_rho)) ** 2,
                 cast("jax.Array", self.weight_prior_mu),
-                cast("jax.Array", self.weight_prior_sigma) ** 2,
+                self.weight_prior_sigma**2,
             ),
         )
         if self.bias:
@@ -224,12 +220,12 @@ class BayesConv(nnx.Conv):
         use_bias: bool, whether to add a bias term.
         weight_mu: nnx.Param, mean of the posterior weights.
         weight_rho: nnx.Param, transformed standard deviation of the posterior weights.
-        weight_prior_mu: BayesianPrior, mean of the prior weights.
-        weight_prior_sigma: BayesianPrior, standard deviation of the prior weights.
+        weight_prior_mu: jax.Array, mean of the prior weights.
+        weight_prior_sigma: jax.Array, standard deviation of the prior weights.
         bias_mu: nnx.Param, mean of the posterior bias.
         bias_rho: nnx.Param, transformed standard deviation of the posterior bias.
-        bias_prior_mu: BayesianPrior, mean of the prior bias.
-        bias_prior_sigma: BayesianPrior, standard deviation of the prior bias.
+        bias_prior_mu: jax.Array, mean of the prior bias.
+        bias_prior_sigma: jax.Array, standard deviation of the prior bias.
     """
 
     def __init__(
@@ -274,8 +270,8 @@ class BayesConv(nnx.Conv):
             prior_mu_init = jnp.full(shape, prior_mean)
 
         self.weight_rho = nnx.Param(jnp.full(shape, rho, self.param_dtype))
-        self.weight_prior_mu = BayesianPrior(prior_mu_init)
-        self.weight_prior_sigma = BayesianPrior(jnp.full(shape, prior_std))
+        self.weight_prior_mu = nnx.data(prior_mu_init)
+        self.weight_prior_sigma = nnx.data(jnp.full(shape, prior_std))
 
         self.kernel = nnx.Param(self.weight_mu[...])
 
@@ -297,8 +293,8 @@ class BayesConv(nnx.Conv):
             bias_prior_mu_init = jnp.full(bias_shape, prior_mean)
 
         self.bias_rho = nnx.Param(jnp.full(bias_shape, rho, self.param_dtype))
-        self.bias_prior_mu = BayesianPrior(bias_prior_mu_init)
-        self.bias_prior_sigma = BayesianPrior(jnp.full(bias_shape, prior_std))
+        self.bias_prior_mu = nnx.data(bias_prior_mu_init)
+        self.bias_prior_sigma = nnx.data(jnp.full(bias_shape, prior_std))
 
         self.bias = nnx.Param(self.bias_mu[...])
 
@@ -362,7 +358,7 @@ class BayesConv(nnx.Conv):
                 weight_mu,
                 jnp.log1p(jnp.exp(weight_rho)) ** 2,
                 cast("jax.Array", self.weight_prior_mu),
-                cast("jax.Array", self.weight_prior_sigma) ** 2,
+                self.weight_prior_sigma**2,
             ),
         )
         if self.use_bias:

--- a/src/probly/transformation/bayesian/__init__.py
+++ b/src/probly/transformation/bayesian/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from probly.lazy_types import TORCH_MODULE
+from probly.lazy_types import FLAX_MODULE, TORCH_MODULE
 
 from ._common import BayesianPredictor, bayesian, bayesian_traverser, register
 
@@ -11,6 +11,12 @@ from ._common import BayesianPredictor, bayesian, bayesian_traverser, register
 @bayesian_traverser.delayed_register(TORCH_MODULE)
 def _(_: type) -> None:
     from . import torch as torch  # noqa: PLC0415
+
+
+## Flax
+@bayesian_traverser.delayed_register(FLAX_MODULE)
+def _(_: type) -> None:
+    from . import flax as flax  # noqa: PLC0415
 
 
 __all__ = [

--- a/src/probly/transformation/bayesian/_common.py
+++ b/src/probly/transformation/bayesian/_common.py
@@ -10,6 +10,7 @@ from probly.traverse_nn import nn_compose
 from pytraverse import CLONE, GlobalVariable, flexdispatch_traverser, traverse
 
 if TYPE_CHECKING:
+    from flax.nnx.rnglib import Rngs
     from flextype.isinstance import LazyType
 
     from probly.predictor import Predictor
@@ -24,6 +25,8 @@ USE_BASE_WEIGHTS = GlobalVariable[bool]("USE_BASE_WEIGHTS", default=False)
 POSTERIOR_STD = GlobalVariable[float]("POSTERIOR_STD", default=0.05)
 PRIOR_MEAN = GlobalVariable[float]("PRIOR_MEAN", default=0.0)
 PRIOR_STD = GlobalVariable[float]("PRIOR_STD", default=1.0)
+type RNG = Rngs | int
+RNGS = GlobalVariable[RNG]("RNGS", "rngs for flax layer initialization.", default=1)
 
 bayesian_traverser = flexdispatch_traverser[object](name="bayesian_traverser")
 
@@ -38,6 +41,7 @@ def register(cls: LazyType, traverser: RegisteredLooseTraverser) -> None:
             "posterior_std": POSTERIOR_STD,
             "prior_mean": PRIOR_MEAN,
             "prior_std": PRIOR_STD,
+            "rngs": RNGS,
         },
     )
 
@@ -50,6 +54,7 @@ def bayesian[**In, Out](
     posterior_std: float = POSTERIOR_STD.default,
     prior_mean: float = PRIOR_MEAN.default,
     prior_std: float = PRIOR_STD.default,
+    rngs: RNG = RNGS.default,
 ) -> BayesianPredictor[In, Out]:
     """Create a Bayesian predictor from a base predictor based on :cite:`blundellWeightUncertainty2015`.
 
@@ -59,6 +64,7 @@ def bayesian[**In, Out](
         posterior_std: The initial posterior standard deviation.
         prior_mean: The prior mean.
         prior_std: The prior standard deviation.
+        rngs: The rngs used for flax layer initialization (ignored for torch models).
 
     Returns:
         The Bayesian predictor.
@@ -80,6 +86,7 @@ def bayesian[**In, Out](
             POSTERIOR_STD: posterior_std,
             PRIOR_MEAN: prior_mean,
             PRIOR_STD: prior_std,
+            RNGS: rngs,
             CLONE: True,
         },
     )

--- a/src/probly/transformation/bayesian/flax.py
+++ b/src/probly/transformation/bayesian/flax.py
@@ -1,0 +1,35 @@
+"""Flax Bayesian implementation."""
+
+from __future__ import annotations
+
+from flax.nnx import Linear, Rngs, rnglib
+
+from probly.layers.flax import BayesLinear
+
+from ._common import register
+
+
+def replace_flax_bayesian_linear(
+    obj: Linear,
+    use_base_weights: bool,
+    posterior_std: float,
+    prior_mean: float,
+    prior_std: float,
+    rngs: rnglib.Rngs | rnglib.RngStream | int,
+    rng_collection: str = "bayesian",
+) -> BayesLinear:
+    """Replace a given layer by a BayesLinear layer :cite:`blundellWeightUncertainty2015`."""
+    if isinstance(rngs, int):
+        rngs = Rngs(rngs)
+    return BayesLinear(
+        base_layer=obj,
+        use_base_weights=use_base_weights,
+        posterior_std=posterior_std,
+        prior_mean=prior_mean,
+        prior_std=prior_std,
+        rng_collection=rng_collection,
+        rngs=rngs,
+    )
+
+
+register(Linear, replace_flax_bayesian_linear)

--- a/src/probly/transformation/bayesian/flax.py
+++ b/src/probly/transformation/bayesian/flax.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from flax.nnx import Linear, Rngs, rnglib
+from flax.nnx import Conv, Linear, Rngs, rnglib
 
-from probly.layers.flax import BayesLinear
+from probly.layers.flax import BayesConv, BayesLinear
 
 from ._common import register
 
@@ -32,4 +32,28 @@ def replace_flax_bayesian_linear(
     )
 
 
+def replace_flax_bayesian_conv(
+    obj: Conv,
+    use_base_weights: bool,
+    posterior_std: float,
+    prior_mean: float,
+    prior_std: float,
+    rngs: rnglib.Rngs | rnglib.RngStream | int,
+    rng_collection: str = "bayesian",
+) -> BayesConv:
+    """Replace a given layer by a BayesConv layer :cite:`blundellWeightUncertainty2015`."""
+    if isinstance(rngs, int):
+        rngs = Rngs(rngs)
+    return BayesConv(
+        base_layer=obj,
+        use_base_weights=use_base_weights,
+        posterior_std=posterior_std,
+        prior_mean=prior_mean,
+        prior_std=prior_std,
+        rng_collection=rng_collection,
+        rngs=rngs,
+    )
+
+
 register(Linear, replace_flax_bayesian_linear)
+register(Conv, replace_flax_bayesian_conv)

--- a/src/probly/transformation/bayesian/torch.py
+++ b/src/probly/transformation/bayesian/torch.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from torch import nn
 
 from probly.layers.torch import BayesConv2d, BayesLinear
@@ -15,6 +17,7 @@ def replace_torch_bayesian_linear(
     posterior_std: float,
     prior_mean: float,
     prior_std: float,
+    rngs: Any = None,  # noqa: ARG001, ANN401
 ) -> BayesLinear:
     """Replace a given layer by a BayesLinear layer based on :cite:`blundellWeightUncertainty2015`."""
     return BayesLinear(obj, use_base_weights, posterior_std, prior_mean, prior_std)
@@ -26,6 +29,7 @@ def replace_torch_bayesian_conv2d(
     posterior_std: float,
     prior_mean: float,
     prior_std: float,
+    rngs: Any = None,  # noqa: ARG001, ANN401
 ) -> BayesConv2d:
     """Replace a given layer by a BayesConv2d layer based on :cite:`blundellWeightUncertainty2015`."""
     return BayesConv2d(obj, use_base_weights, posterior_std, prior_mean, prior_std)

--- a/tests/probly/method/bayesian/test_flax.py
+++ b/tests/probly/method/bayesian/test_flax.py
@@ -6,14 +6,20 @@ from typing import cast
 
 import pytest
 
-from probly.layers.flax import BayesConv, BayesLinear, _copy_conv_attrs, _inverse_softplus, _kl_divergence_gaussian
-from probly.transformation.bayesian import bayesian
-from tests.probly.flax_utils import count_layers
-
 flax = pytest.importorskip("flax")
 from flax import nnx  # noqa: E402
 import jax  # noqa: E402
 import jax.numpy as jnp  # noqa: E402
+
+from probly.layers.flax import (  # noqa: E402
+    BayesConv,
+    BayesLinear,
+    _copy_conv_attrs,
+    _inverse_softplus,
+    _kl_divergence_gaussian,
+)
+from probly.transformation.bayesian import bayesian  # noqa: E402
+from tests.probly.flax_utils import count_layers  # noqa: E402
 
 use_base_weights = False
 posterior_std = 0.05

--- a/tests/probly/method/bayesian/test_flax.py
+++ b/tests/probly/method/bayesian/test_flax.py
@@ -1,0 +1,36 @@
+"""Test for flax bayesian models."""
+
+from __future__ import annotations
+
+from typing import cast
+
+from flax import nnx
+import pytest
+
+from probly.layers.flax import BayesLinear
+from probly.transformation.bayesian import bayesian
+from tests.probly.flax_utils import count_layers
+
+
+@pytest.fixture
+def flax_model_small_2d_2d(flax_rngs: nnx.Rngs) -> nnx.Module:
+    """Return a small linear model with 2 input and 2 output neurons."""
+    model = nnx.Sequential(
+        nnx.Linear(2, 2, rngs=flax_rngs),
+        nnx.Linear(2, 2, rngs=flax_rngs),
+        nnx.Linear(2, 2, rngs=flax_rngs),
+    )
+    return model
+
+
+class TestNetworkArchitecture:
+    def test_replace_linear_layer(self, flax_model_small_2d_2d: nnx.Module) -> None:
+        model = cast("nnx.Module", bayesian(flax_model_small_2d_2d))
+
+        count_linear_original = count_layers(flax_model_small_2d_2d, nnx.Linear)
+        count_bayes_modified = count_layers(model, BayesLinear)
+        count_linear_modified = count_layers(model, nnx.Linear)
+
+        assert isinstance(model, type(flax_model_small_2d_2d))
+        assert count_linear_modified == 0
+        assert count_bayes_modified == count_linear_original

--- a/tests/probly/method/bayesian/test_flax.py
+++ b/tests/probly/method/bayesian/test_flax.py
@@ -5,22 +5,178 @@ from __future__ import annotations
 from typing import cast
 
 from flax import nnx
+import jax
+import jax.numpy as jnp
 import pytest
 
-from probly.layers.flax import BayesLinear
+from probly.layers.flax import BayesConv, BayesLinear, _inverse_softplus, _kl_divergence_gaussian
 from probly.transformation.bayesian import bayesian
 from tests.probly.flax_utils import count_layers
 
+use_base_weights = False
+posterior_std = 0.05
+prior_mean = 0.0
+prior_std = 1.0
 
-@pytest.fixture
-def flax_model_small_2d_2d(flax_rngs: nnx.Rngs) -> nnx.Module:
-    """Return a small linear model with 2 input and 2 output neurons."""
-    model = nnx.Sequential(
-        nnx.Linear(2, 2, rngs=flax_rngs),
-        nnx.Linear(2, 2, rngs=flax_rngs),
-        nnx.Linear(2, 2, rngs=flax_rngs),
-    )
-    return model
+
+class TestBayesianAttributes:
+    def test_bayesian_linear_attributes(self) -> None:
+        rngs = nnx.Rngs(0, params=1)
+        linear_layer = nnx.Linear(2, 2, rngs=rngs)
+
+        bayes_layer = BayesLinear(
+            linear_layer,
+            use_base_weights=use_base_weights,
+            posterior_std=posterior_std,
+            prior_mean=prior_mean,
+            prior_std=prior_std,
+            rngs=rngs,
+        )
+
+        assert bayes_layer.precision == linear_layer.precision
+        assert bayes_layer.dtype == linear_layer.dtype
+        assert bayes_layer.param_dtype == linear_layer.param_dtype
+        assert bayes_layer.in_features == linear_layer.in_features
+        assert bayes_layer.out_features == linear_layer.out_features
+        assert bayes_layer.use_bias == linear_layer.use_bias
+        assert bayes_layer.dot_general == linear_layer.dot_general
+        assert bayes_layer.promote_dtype == linear_layer.promote_dtype
+        assert bayes_layer.rng_collection == "bayesian"
+
+        assert isinstance(bayes_layer.weight_rho, nnx.Param)
+
+        # `bias` is a presence flag (bool), not the Param itself like on `nnx.Linear`.
+        assert bayes_layer.bias is not None
+        assert bayes_layer.bias == (linear_layer.bias is not None)
+
+        weight_shape = (linear_layer.in_features, linear_layer.out_features)
+        rho = _inverse_softplus(jnp.array(posterior_std))
+        assert bayes_layer.weight_mu.shape == weight_shape
+        assert bayes_layer.weight_rho.shape == weight_shape
+        assert jnp.allclose(bayes_layer.weight_rho[...], jnp.full(weight_shape, rho))
+        assert jnp.allclose(bayes_layer.weight_prior_mu[...], jnp.full(weight_shape, prior_mean))
+        assert jnp.allclose(bayes_layer.weight_prior_sigma[...], jnp.full(weight_shape, prior_std))
+
+        bias_shape = (linear_layer.out_features,)
+        assert bayes_layer.bias_mu.shape == bias_shape
+        assert bayes_layer.bias_rho.shape == bias_shape
+        assert jnp.allclose(bayes_layer.bias_mu[...], jnp.zeros(bias_shape))
+        assert jnp.allclose(bayes_layer.bias_rho[...], jnp.full(bias_shape, rho))
+        assert jnp.allclose(bayes_layer.bias_prior_mu[...], jnp.full(bias_shape, prior_mean))
+        assert jnp.allclose(bayes_layer.bias_prior_sigma[...], jnp.full(bias_shape, prior_std))
+
+    def test_bayesian_linear_attributes_use_base_weights(self) -> None:
+        rngs = nnx.Rngs(0, params=1)
+        linear_layer = nnx.Linear(2, 2, rngs=rngs)
+
+        bayes_layer = BayesLinear(linear_layer, use_base_weights=True, rngs=rngs)
+
+        # With use_base_weights=True, both the posterior mean and the prior mean are
+        # copied from the base layer's parameters instead of being freshly initialized.
+        assert jnp.array_equal(bayes_layer.weight_mu[...], linear_layer.kernel[...])
+        assert jnp.array_equal(bayes_layer.weight_prior_mu[...], linear_layer.kernel[...])
+
+        assert linear_layer.bias is not None
+        assert jnp.array_equal(bayes_layer.bias_mu[...], linear_layer.bias[...])
+        assert jnp.array_equal(bayes_layer.bias_prior_mu[...], linear_layer.bias[...])
+
+    def test_bayesian_linear_attributes_no_bias(self) -> None:
+        rngs = nnx.Rngs(0, params=1)
+        linear_layer = nnx.Linear(2, 2, use_bias=False, rngs=rngs)
+
+        bayes_layer = BayesLinear(linear_layer, use_base_weights=False, rngs=rngs)
+
+        assert bayes_layer.bias is False
+        assert bayes_layer.bias_mu is None
+        assert bayes_layer.bias_rho is None
+        assert bayes_layer.bias_prior_mu is None
+        assert bayes_layer.bias_prior_sigma is None
+
+
+class TestRngs:
+    def test_init_rngs(self) -> None:
+        rngs = nnx.Rngs(0, params=1)
+        linear_layer = nnx.Linear(1, 2, rngs=rngs)
+        rng_stream = nnx.RngStream(key=1, tag="bayesian")
+
+        bayesian_layer_rng_stream = BayesLinear(linear_layer, rngs=rng_stream)
+
+        new_rng_stream = nnx.RngStream(key=1, tag="bayesian")
+        used_rngs = new_rng_stream.fork()
+        assert bayesian_layer_rng_stream.rngs.key.value == used_rngs.key.value
+        assert isinstance(bayesian_layer_rng_stream.rngs, nnx.rnglib.RngStream)
+
+        msg = f"rngs must be a RNGS, RngStream or None, but got {str}"
+        with pytest.raises(TypeError, match=msg):
+            BayesLinear(linear_layer, rngs="test")
+
+    def test_rngs_none_without_base_weights_raises(self) -> None:
+        rngs = nnx.Rngs(0, params=1)
+        linear_layer = nnx.Linear(1, 2, rngs=rngs)
+
+        msg = "rngs must be provided when use_base_weights is False, to initialize new weights."
+        with pytest.raises(ValueError, match=msg):
+            BayesLinear(linear_layer, use_base_weights=False, rngs=None)
+
+    def test_rngs_none_with_base_weights_defers_error_to_call(self) -> None:
+        rngs = nnx.Rngs(0, params=1)
+        linear_layer = nnx.Linear(1, 2, rngs=rngs)
+
+        bayesian_layer = BayesLinear(linear_layer, use_base_weights=True, rngs=None)
+        assert bayesian_layer.rngs is None
+
+        msg = """No `rngs` argument was provided to BayesianLinear
+                as either a __call__ argument or class attribute."""
+        with pytest.raises(ValueError, match=msg):
+            bayesian_layer(jnp.ones(1))
+
+    def test_init_rngs_stream(self) -> None:
+        rngs = nnx.Rngs(0, params=1, bayesian=2)
+        linear_layer = nnx.Linear(1, 2, rngs=rngs)
+        bayesian_layer = BayesLinear(linear_layer, rngs=rngs)
+
+        new_rngs = nnx.Rngs(0, params=1, bayesian=2)
+        bayesian_rngs = new_rngs["bayesian"].fork()
+        assert bayesian_layer.rngs.tag == "bayesian"
+        assert bayesian_layer.rngs.key.value == bayesian_rngs.key.value
+        assert isinstance(bayesian_layer.rngs, nnx.rnglib.RngStream)
+
+
+class TestHelperFunctions:
+    def test_inverse_softplus_return_type(self) -> None:
+        x = jnp.ones((1,))
+        inverse_softplus = _inverse_softplus(x)
+        assert isinstance(inverse_softplus, jax.Array)
+
+    def test_kl_divergence_gaussian_return_type(self) -> None:
+        mu1 = jnp.array([0.0])
+        var1 = jnp.array([1.0])
+        mu2 = jnp.array([2.0])
+        var2 = jnp.array([1.0])
+
+        kl = _kl_divergence_gaussian(mu1, var1, mu2, var2)
+
+        assert isinstance(kl, jax.Array)
+        assert kl.shape == (1,)
+
+    def test_kl_divergence_gaussian_zero_when_distributions_equal(self) -> None:
+        mu = jnp.array([0.0, 1.0])
+        var = jnp.array([1.0, 2.0])
+
+        kl = _kl_divergence_gaussian(mu, var, mu, var)
+
+        assert jnp.allclose(kl, jnp.zeros_like(kl), atol=1e-6)
+
+    def test_kl_divergence_gaussian_exact_value(self) -> None:
+        # KL(N(0, 1) || N(2, 1)) = 0.5*log(1/1) + (1 + (0-2)**2)/(2*1) - 0.5 = 2.0 (exact).
+        mu1 = jnp.array([0.0])
+        var1 = jnp.array([1.0])
+        mu2 = jnp.array([2.0])
+        var2 = jnp.array([1.0])
+
+        kl = _kl_divergence_gaussian(mu1, var1, mu2, var2)
+
+        assert jnp.allclose(kl, jnp.array([2.0]))
 
 
 class TestNetworkArchitecture:
@@ -34,3 +190,48 @@ class TestNetworkArchitecture:
         assert isinstance(model, type(flax_model_small_2d_2d))
         assert count_linear_modified == 0
         assert count_bayes_modified == count_linear_original
+
+    def test_replace_conv_layer(self, flax_conv_linear_model: nnx.Module) -> None:
+        """Tests that plain ``nnx.Conv`` layers are replaced by ``BayesConv``.
+
+        ``BayesConv`` subclasses ``nnx.Conv`` (to reuse its ``__call__``), so counting
+        ``nnx.Conv`` instances after the transform also counts the replaced ``BayesConv``
+        layers; the original layer count is used as the point of comparison instead.
+        """
+        count_conv_original = count_layers(flax_conv_linear_model, nnx.Conv)
+        count_linear_original = count_layers(flax_conv_linear_model, nnx.Linear)
+
+        model = cast("nnx.Module", bayesian(flax_conv_linear_model))
+
+        count_bayes_conv_modified = count_layers(model, BayesConv)
+        count_bayes_linear_modified = count_layers(model, BayesLinear)
+        count_linear_modified = count_layers(model, nnx.Linear)
+
+        assert isinstance(model, type(flax_conv_linear_model))
+        assert count_linear_modified == 0
+        assert count_bayes_conv_modified == count_conv_original
+        assert count_bayes_linear_modified == count_linear_original
+
+
+class TestBayesConvCall:
+    """Test class for the ``BayesConv`` forward pass."""
+
+    def test_call(self, flax_rngs: nnx.Rngs) -> None:
+        conv = nnx.Conv(3, 5, (5, 5), rngs=flax_rngs)
+        bayes_conv = BayesConv(conv, rngs=nnx.Rngs(1))
+
+        x = jnp.ones((2, 16, 16, 3))
+        y = bayes_conv(x, rngs=nnx.Rngs(2))
+
+        assert y is not None
+        assert y.shape == (2, 16, 16, 5)
+
+    def test_kl_divergence(self, flax_rngs: nnx.Rngs) -> None:
+        conv = nnx.Conv(3, 5, (5, 5), rngs=flax_rngs)
+        bayes_conv = BayesConv(conv, rngs=nnx.Rngs(1))
+
+        kl = bayes_conv.kl_divergence
+
+        assert kl is not None
+        assert kl.shape == ()
+        assert kl >= 0

--- a/tests/probly/method/bayesian/test_flax.py
+++ b/tests/probly/method/bayesian/test_flax.py
@@ -4,14 +4,16 @@ from __future__ import annotations
 
 from typing import cast
 
-from flax import nnx
-import jax
-import jax.numpy as jnp
 import pytest
 
 from probly.layers.flax import BayesConv, BayesLinear, _copy_conv_attrs, _inverse_softplus, _kl_divergence_gaussian
 from probly.transformation.bayesian import bayesian
 from tests.probly.flax_utils import count_layers
+
+flax = pytest.importorskip("flax")
+from flax import nnx  # noqa: E402
+import jax  # noqa: E402
+import jax.numpy as jnp  # noqa: E402
 
 use_base_weights = False
 posterior_std = 0.05

--- a/tests/probly/method/bayesian/test_flax.py
+++ b/tests/probly/method/bayesian/test_flax.py
@@ -9,7 +9,7 @@ import jax
 import jax.numpy as jnp
 import pytest
 
-from probly.layers.flax import BayesConv, BayesLinear, _inverse_softplus, _kl_divergence_gaussian
+from probly.layers.flax import BayesConv, BayesLinear, _copy_conv_attrs, _inverse_softplus, _kl_divergence_gaussian
 from probly.transformation.bayesian import bayesian
 from tests.probly.flax_utils import count_layers
 
@@ -20,7 +20,10 @@ prior_std = 1.0
 
 
 class TestBayesianAttributes:
+    """Test calls for Bayesian attributes."""
+
     def test_bayesian_linear_attributes(self) -> None:
+        """Tests the BayesianLinear layer attributes."""
         rngs = nnx.Rngs(0, params=1)
         linear_layer = nnx.Linear(2, 2, rngs=rngs)
 
@@ -45,7 +48,6 @@ class TestBayesianAttributes:
 
         assert isinstance(bayes_layer.weight_rho, nnx.Param)
 
-        # `bias` is a presence flag (bool), not the Param itself like on `nnx.Linear`.
         assert bayes_layer.bias is not None
         assert bayes_layer.bias == (linear_layer.bias is not None)
 
@@ -66,13 +68,13 @@ class TestBayesianAttributes:
         assert jnp.allclose(bayes_layer.bias_prior_sigma[...], jnp.full(bias_shape, prior_std))
 
     def test_bayesian_linear_attributes_use_base_weights(self) -> None:
+        """Tests BayesianLinear layer attributes for use_base_weights True."""
         rngs = nnx.Rngs(0, params=1)
         linear_layer = nnx.Linear(2, 2, rngs=rngs)
 
         bayes_layer = BayesLinear(linear_layer, use_base_weights=True, rngs=rngs)
 
-        # With use_base_weights=True, both the posterior mean and the prior mean are
-        # copied from the base layer's parameters instead of being freshly initialized.
+        # Posterior mean dna prior mean are copied from base layer's attributes
         assert jnp.array_equal(bayes_layer.weight_mu[...], linear_layer.kernel[...])
         assert jnp.array_equal(bayes_layer.weight_prior_mu[...], linear_layer.kernel[...])
 
@@ -81,6 +83,7 @@ class TestBayesianAttributes:
         assert jnp.array_equal(bayes_layer.bias_prior_mu[...], linear_layer.bias[...])
 
     def test_bayesian_linear_attributes_no_bias(self) -> None:
+        """Tests BayesianLinear layer attributes for use_bias False."""
         rngs = nnx.Rngs(0, params=1)
         linear_layer = nnx.Linear(2, 2, use_bias=False, rngs=rngs)
 
@@ -92,8 +95,110 @@ class TestBayesianAttributes:
         assert bayes_layer.bias_prior_mu is None
         assert bayes_layer.bias_prior_sigma is None
 
+    def test_bayesian_conv_attributes(self) -> None:
+        """Tests BayesianConv layer attributes."""
+        rngs = nnx.Rngs(0, params=1)
+        conv_layer = nnx.Conv(3, 4, (3,), padding="VALID", rngs=rngs)
+        bayes_layer = BayesConv(
+            conv_layer,
+            use_base_weights=False,
+            posterior_std=posterior_std,
+            prior_mean=prior_mean,
+            prior_std=prior_std,
+            rngs=rngs,
+        )
+        assert bayes_layer.rng_collection == "bayesian"
+
+        # Attributes are set by `_copy_conv_attrs`
+        assert bayes_layer.kernel_shape == conv_layer.kernel_shape
+        assert bayes_layer.in_features == conv_layer.in_features
+        assert bayes_layer.out_features == conv_layer.out_features
+        assert bayes_layer.kernel_size == conv_layer.kernel_size
+        assert bayes_layer.strides == conv_layer.strides
+        assert bayes_layer.padding == conv_layer.padding
+        assert bayes_layer.input_dilation == conv_layer.input_dilation
+        assert bayes_layer.kernel_dilation == conv_layer.kernel_dilation
+        assert bayes_layer.feature_group_count == conv_layer.feature_group_count
+        assert bayes_layer.use_bias == conv_layer.use_bias
+        assert bayes_layer.mask == conv_layer.mask
+        assert bayes_layer.dtype == conv_layer.dtype
+        assert bayes_layer.param_dtype == conv_layer.param_dtype
+        assert bayes_layer.precision == conv_layer.precision
+        assert bayes_layer.conv_general_dilated is conv_layer.conv_general_dilated
+        assert bayes_layer.promote_dtype is conv_layer.promote_dtype
+        assert bayes_layer.preferred_element_type == conv_layer.preferred_element_type
+
+        assert bayes_layer.bias is not None
+
+        assert bayes_layer.kernel_shape == conv_layer.kernel_shape
+        weight_shape = bayes_layer.kernel_shape
+
+        rho = _inverse_softplus(jnp.array(posterior_std))
+        assert bayes_layer.weight_mu.shape == weight_shape
+        assert bayes_layer.weight_rho.shape == weight_shape
+        assert jnp.allclose(bayes_layer.weight_rho[...], jnp.full(weight_shape, rho))
+        assert jnp.allclose(bayes_layer.weight_prior_mu[...], jnp.full(weight_shape, prior_mean))
+        assert jnp.allclose(bayes_layer.weight_prior_sigma[...], jnp.full(weight_shape, prior_std))
+
+        bias_shape = (conv_layer.out_features,)
+        assert bayes_layer.bias_mu.shape == bias_shape
+        assert bayes_layer.bias_rho.shape == bias_shape
+        assert jnp.allclose(bayes_layer.bias_mu[...], jnp.zeros(bias_shape))
+        assert jnp.allclose(bayes_layer.bias_rho[...], jnp.full(bias_shape, rho))
+        assert jnp.allclose(bayes_layer.bias_prior_mu[...], jnp.full(bias_shape, prior_mean))
+        assert jnp.allclose(bayes_layer.bias_prior_sigma[...], jnp.full(bias_shape, prior_std))
+
+        assert isinstance(bayes_layer.bias, nnx.Param)
+
+    def test_bayesian_conv_attributes_use_base_weights(self) -> None:
+        """Tests BayesianConv layer attributes for use_base_weights True."""
+        rngs = nnx.Rngs(0, params=1)
+        conv_layer = nnx.Conv(3, 4, (3,), padding="VALID", rngs=rngs)
+
+        bayes_layer = BayesConv(conv_layer, use_base_weights=True, rngs=rngs)
+
+        # Posterior mean dna prior mean are copied from base layer's attributes
+        assert jnp.array_equal(bayes_layer.weight_mu[...], conv_layer.kernel[...])
+        assert jnp.array_equal(bayes_layer.weight_prior_mu[...], conv_layer.kernel[...])
+
+        assert conv_layer.bias is not None
+        assert jnp.array_equal(bayes_layer.bias_mu[...], conv_layer.bias[...])
+        assert jnp.array_equal(bayes_layer.bias_prior_mu[...], conv_layer.bias[...])
+
+    def test_bayesian_conv_attributes_no_bias(self) -> None:
+        rngs = nnx.Rngs(0, params=1)
+        conv_layer = nnx.Conv(3, 4, (3,), use_bias=False, padding="VALID", rngs=rngs)
+
+        bayes_layer = BayesConv(conv_layer, use_base_weights=False, rngs=rngs)
+
+        # Takes use_bias as bool flag instead of bias
+        assert bayes_layer.use_bias is False
+        assert bayes_layer.bias is None
+        assert bayes_layer.bias_mu is None
+        assert bayes_layer.bias_rho is None
+        assert bayes_layer.bias_prior_mu is None
+        assert bayes_layer.bias_prior_sigma is None
+
+    def test_copy_conv_attrs_direct_call(self) -> None:
+        """Exercises `_copy_conv_attrs` directly, independent of `BayesConv.__init__`."""
+        rngs = nnx.Rngs(0, params=1)
+        conv_layer = nnx.Conv(3, 4, (3,), padding="VALID", rngs=rngs)
+
+        # `_copy_conv_attrs` only assigns attributes (no reliance on prior state), so an
+        # already-constructed BayesConv can be safely used as the target `module` too.
+        bayes_layer = BayesConv(conv_layer, use_base_weights=True, rngs=rngs)
+        _copy_conv_attrs(bayes_layer, conv_layer)
+
+        assert bayes_layer.kernel_shape == conv_layer.kernel_shape
+        assert bayes_layer.strides == conv_layer.strides
+        assert bayes_layer.padding == conv_layer.padding
+        assert bayes_layer.feature_group_count == conv_layer.feature_group_count
+        assert bayes_layer.conv_general_dilated is conv_layer.conv_general_dilated
+
 
 class TestRngs:
+    """Test class for rng cases."""
+
     def test_init_rngs(self) -> None:
         rngs = nnx.Rngs(0, params=1)
         linear_layer = nnx.Linear(1, 2, rngs=rngs)
@@ -143,6 +248,8 @@ class TestRngs:
 
 
 class TestHelperFunctions:
+    """Test class for helper functions."""
+
     def test_inverse_softplus_return_type(self) -> None:
         x = jnp.ones((1,))
         inverse_softplus = _inverse_softplus(x)
@@ -168,7 +275,6 @@ class TestHelperFunctions:
         assert jnp.allclose(kl, jnp.zeros_like(kl), atol=1e-6)
 
     def test_kl_divergence_gaussian_exact_value(self) -> None:
-        # KL(N(0, 1) || N(2, 1)) = 0.5*log(1/1) + (1 + (0-2)**2)/(2*1) - 0.5 = 2.0 (exact).
         mu1 = jnp.array([0.0])
         var1 = jnp.array([1.0])
         mu2 = jnp.array([2.0])
@@ -180,55 +286,138 @@ class TestHelperFunctions:
 
 
 class TestNetworkArchitecture:
-    def test_replace_linear_layer(self, flax_model_small_2d_2d: nnx.Module) -> None:
-        model = cast("nnx.Module", bayesian(flax_model_small_2d_2d))
+    """Test class for network architecture."""
 
-        count_linear_original = count_layers(flax_model_small_2d_2d, nnx.Linear)
-        count_bayes_modified = count_layers(model, BayesLinear)
-        count_linear_modified = count_layers(model, nnx.Linear)
+    @pytest.mark.parametrize(
+        "model_fixture",
+        [
+            "flax_model_small_2d_2d",
+            "flax_conv_linear_model",
+        ],
+    )
+    def test_fixtures(
+        self,
+        request: pytest.FixtureRequest,
+        model_fixture: str,
+    ) -> None:
+        """Tests if a model replaces the linear/conv layers respectively correctly with BayesLinear or BayesConv layers.
 
-        assert isinstance(model, type(flax_model_small_2d_2d))
-        assert count_linear_modified == 0
-        assert count_bayes_modified == count_linear_original
+        Parameters:
+            request: pytest.FixtureRequest, the request for a fixture.
+            model_fixture: str, the name of the model fixture.
 
-    def test_replace_conv_layer(self, flax_conv_linear_model: nnx.Module) -> None:
-        """Tests that plain ``nnx.Conv`` layers are replaced by ``BayesConv``.
-
-        ``BayesConv`` subclasses ``nnx.Conv`` (to reuse its ``__call__``), so counting
-        ``nnx.Conv`` instances after the transform also counts the replaced ``BayesConv``
-        layers; the original layer count is used as the point of comparison instead.
+        Raises:
+            AssertionError If the structure of the model differs in an unexpected manner or if the layers are not
+            replaced correctly.
         """
-        count_conv_original = count_layers(flax_conv_linear_model, nnx.Conv)
-        count_linear_original = count_layers(flax_conv_linear_model, nnx.Linear)
+        model_base = request.getfixturevalue(model_fixture)
+        model = cast("nnx.Module", model_base)
 
-        model = cast("nnx.Module", bayesian(flax_conv_linear_model))
+        modified_model = cast(
+            "nnx.Module",
+            bayesian(
+                model,
+                use_base_weights=use_base_weights,
+                posterior_std=posterior_std,
+                prior_mean=prior_mean,
+                prior_std=prior_std,
+            ),
+        )
+        # Linear Model
+        count_linear_original = count_layers(model, nnx.Linear)
+        count_linear_modified = count_layers(modified_model, nnx.Linear)
+        count_bayes_linear_modified = count_layers(modified_model, BayesLinear)
 
-        count_bayes_conv_modified = count_layers(model, BayesConv)
-        count_bayes_linear_modified = count_layers(model, BayesLinear)
-        count_linear_modified = count_layers(model, nnx.Linear)
+        # Conv Linear Model
+        count_conv_original = count_layers(model, nnx.Conv)
+        count_conv_modified = count_layers(modified_model, nnx.Conv)
+        count_bayes_conv_modified = count_layers(modified_model, BayesConv)
 
-        assert isinstance(model, type(flax_conv_linear_model))
+        assert isinstance(modified_model, type(model))
         assert count_linear_modified == 0
-        assert count_bayes_conv_modified == count_conv_original
         assert count_bayes_linear_modified == count_linear_original
 
+        # BayesConv inherits of nnx.Conv, the number of layers stays the same
+        assert count_conv_modified == count_conv_original
+        assert count_bayes_conv_modified == count_conv_original
 
-class TestBayesConvCall:
-    """Test class for the ``BayesConv`` forward pass."""
 
-    def test_call(self, flax_rngs: nnx.Rngs) -> None:
-        conv = nnx.Conv(3, 5, (5, 5), rngs=flax_rngs)
+class TestCall:
+    """Test class for Bayesian calls."""
+
+    def test_call_linear(self) -> None:
+        """Tests the call function with rngs at initialization."""
+        linear = nnx.Linear(1, 4, rngs=nnx.Rngs(0))
+        bayes_linear = BayesLinear(linear, rngs=nnx.Rngs(0))
+        x = jnp.ones(1)
+        y = bayes_linear(x)
+        assert y is not None
+        assert y.shape == (4,)
+
+    def test_calls_linear_with_rngs(self) -> None:
+        """Tests calls with rngs at call time."""
+        linear = nnx.Linear(1, 4, rngs=nnx.Rngs(0))
+        bayes_linear = BayesLinear(linear, rngs=nnx.Rngs(0))
+
+        x = jnp.ones(1)
+        y1 = bayes_linear(x, rngs=nnx.Rngs(0))
+        y2 = bayes_linear(x, rngs=nnx.Rngs(1))
+
+        assert y1.shape == y2.shape
+        assert not jnp.equal(y1, y2).all()
+
+        y_rngs_jax_array = bayes_linear(x, rngs=jax.random.key(1))
+        assert y_rngs_jax_array is not None
+        assert y_rngs_jax_array.shape == (4,)
+
+        msg = f"rngs must be Rngs, RngStream or jax.Array, but got {str}"
+        with pytest.raises(TypeError, match=msg):
+            bayes_linear(x, rngs="test")
+
+    def test_kl_divergence_linear(self) -> None:
+        linear = nnx.Linear(1, 4, rngs=nnx.Rngs(0))
+        bayes_linear = BayesLinear(linear, rngs=nnx.Rngs(0))
+
+        kl = bayes_linear.kl_divergence
+
+        assert kl is not None
+        assert kl.shape == ()
+        assert kl >= 0
+
+    def test_call_conv(self, flax_rngs: nnx.Rngs) -> None:
+        """Tests the call function with rngs at initialization."""
+        conv = nnx.Conv(3, 4, (3,), rngs=flax_rngs)
         bayes_conv = BayesConv(conv, rngs=nnx.Rngs(1))
 
-        x = jnp.ones((2, 16, 16, 3))
+        x = jnp.ones((1, 8, 3))
         y = bayes_conv(x, rngs=nnx.Rngs(2))
 
         assert y is not None
-        assert y.shape == (2, 16, 16, 5)
+        assert y.shape == (1, 8, 4)
 
-    def test_kl_divergence(self, flax_rngs: nnx.Rngs) -> None:
-        conv = nnx.Conv(3, 5, (5, 5), rngs=flax_rngs)
-        bayes_conv = BayesConv(conv, rngs=nnx.Rngs(1))
+    def test_calls_conv_with_rngs(self) -> None:
+        """Tests calls with rngs at call time."""
+        conv = nnx.Conv(3, 4, (3,), rngs=nnx.Rngs(0))
+        bayes_conv = BayesConv(conv, rngs=nnx.Rngs(0))
+
+        x = jnp.ones((1, 8, 3))
+        y1 = bayes_conv(x, rngs=nnx.Rngs(0))
+        y2 = bayes_conv(x, rngs=nnx.Rngs(1))
+
+        assert y1.shape == y2.shape
+        assert not jnp.equal(y1, y2).all()
+
+        y_rngs_jax_array = bayes_conv(x, rngs=jax.random.key(1))
+        assert y_rngs_jax_array is not None
+        assert y_rngs_jax_array.shape == (1, 8, 4)
+
+        msg = f"rngs must be Rngs, RngStream or jax.Array, but got {str}"
+        with pytest.raises(TypeError, match=msg):
+            bayes_conv(x, rngs="test")
+
+    def test_kl_divergence_conv(self) -> None:
+        conv = nnx.Conv(3, 4, (3,), rngs=nnx.Rngs(0))
+        bayes_conv = BayesConv(conv, rngs=nnx.Rngs(0))
 
         kl = bayes_conv.kl_divergence
 


### PR DESCRIPTION
## Issue
[Extended Flax NNX/Jax Support - transformations #551](https://github.com/pwhofman/probly/issues/551)
Flax Implementation Bayesian Transformation 

## Motivation and Context
Key changes: 

- **Rngs**: Explicit Ring key for re-parameterization 
rng_collection/rngs pair on both Flax layers, with shared _init_rngs helper
RNGS GlobalVariable in _common.py, added to register() 
register() is also used by Torch, so rngs is now also an accepted keyword, but ignored.

- **BayesLinear**: dot_general instead of F.linear

- **BayesConv**:  __init__ copies base layer's structural config via _copy_con_attrs and __call__ samples fresh kernel/bias from the variational posterior each call, installs them as self.kernel/self.bias and delegates to super().__call__() for the actual convolution
BayesConv is the same instance as nnx.Conv

---

## Public API Changes

-   [ ] No Public API changes
-   [ ] Yes, Public API changes (Details below)

---

## How Has This Been Tested?

Test Class for correct attributes, Rng Handling, HelperFunctions (_inverse_softplus, _kl_divergence_gaussian), Network Architecture (correct replacing of layers) and Call Function
---

## Checklist

-   [ ] The changes have been tested locally.
-   [ ] Documentation has been updated (if the public API or usage changes).
-   [ ] A entry has been added to [`CHANGELOG.md`](https://github.com/pwhofman/probly/blob/main/CHANGELOG.md) (if relevant for users).
-   [ ] The code follows the project's [style guidelines](https://github.com/pwhofman/probly/blob/main/.github/CONTRIBUTING.md) and passes minimal code style checks.
-   [ ] I have considered the impact of these changes on the public API.

---
